### PR TITLE
Add upload helpers and submission methods

### DIFF
--- a/VirusTotalAnalyzer.Examples/Program.cs
+++ b/VirusTotalAnalyzer.Examples/Program.cs
@@ -19,6 +19,15 @@ var client = new VirusTotalClient(httpClient);
 var report = await client.GetFileReportAsync("abc");
 Console.WriteLine($"Sample file md5: {report?.Data.Attributes.Md5}");
 
+var analysisJson = "{\"id\":\"analysis\",\"type\":\"analysis\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}";
+using var submitHttpClient = new HttpClient(new StubHandler(analysisJson))
+{
+    BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+};
+var submitClient = new VirusTotalClient(submitHttpClient);
+var analysis = await submitClient.SubmitUrlAsync("https://example.com", AnalysisType.Url);
+Console.WriteLine($"Submission status: {analysis?.Data.Attributes.Status}");
+
 class StubHandler : HttpMessageHandler
 {
     private readonly string _response;

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.cs
@@ -50,6 +50,104 @@ public class VirusTotalClientTests
         Assert.Equal("https://example.com", report.Data.Attributes.Url);
     }
 
+    [Fact]
+    public async Task GetUploadUrlAsync_ReturnsUri()
+    {
+        var json = "{\"data\":\"https://upload.example/upload\"}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var uri = await client.GetUploadUrlAsync();
+
+        Assert.NotNull(uri);
+        Assert.Equal("https://upload.example/upload", uri!.ToString());
+        Assert.Single(handler.Requests);
+        Assert.Equal("/api/v3/files/upload_url", handler.Requests[0].RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task SubmitFileAsync_UsesUploadUrlForLargeFiles()
+    {
+        var uploadJson = "{\"data\":\"https://upload.example/upload\"}";
+        var analysisJson = "{\"id\":\"an\",\"type\":\"analysis\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}";
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(uploadJson, Encoding.UTF8, "application/json")
+            },
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(analysisJson, Encoding.UTF8, "application/json")
+            });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        using var ms = new System.IO.MemoryStream(new byte[33554433]);
+        var report = await client.SubmitFileAsync(ms, "demo.bin", AnalysisType.File, "pass");
+
+        Assert.NotNull(report);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal("/api/v3/files/upload_url", handler.Requests[0].RequestUri!.AbsolutePath);
+        Assert.Equal("https://upload.example/upload", handler.Requests[1].RequestUri!.ToString());
+        Assert.True(handler.Requests[1].Headers.Contains("password"));
+    }
+
+    [Fact]
+    public async Task ReanalyzeHashAsync_UsesCorrectPath()
+    {
+        var json = "{\"id\":\"an\",\"type\":\"analysis\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var report = await client.ReanalyzeHashAsync("abc", AnalysisType.File);
+
+        Assert.NotNull(report);
+        Assert.Single(handler.Requests);
+        Assert.Equal("/api/v3/files/abc/analyse", handler.Requests[0].RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task SubmitUrlAsync_PostsFormEncodedContent()
+    {
+        var json = "{\"id\":\"an\",\"type\":\"analysis\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
+
+        Assert.NotNull(report);
+        Assert.Single(handler.Requests);
+        var request = handler.Requests[0];
+        Assert.Equal(HttpMethod.Post, request.Method);
+        Assert.Equal("/api/v3/urls", request.RequestUri!.AbsolutePath);
+        Assert.Equal("application/x-www-form-urlencoded", request.Content!.Headers.ContentType!.MediaType);
+        Assert.Equal("url=https%3A%2F%2Fexample.com", handler.Contents[0]);
+    }
+
     private sealed class StubHandler : HttpMessageHandler
     {
         private readonly string _response;
@@ -60,5 +158,30 @@ public class VirusTotalClientTests
             {
                 Content = new StringContent(_response, Encoding.UTF8, "application/json")
             });
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly System.Collections.Generic.Queue<HttpResponseMessage> _responses;
+        public System.Collections.Generic.List<HttpRequestMessage> Requests { get; } = new();
+        public System.Collections.Generic.List<string?> Contents { get; } = new();
+
+        public RecordingHandler(params HttpResponseMessage[] responses)
+            => _responses = new System.Collections.Generic.Queue<HttpResponseMessage>(responses);
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            if (request.Content != null)
+            {
+                var text = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                Contents.Add(text);
+            }
+            else
+            {
+                Contents.Add(null);
+            }
+            return _responses.Dequeue();
+        }
     }
 }

--- a/VirusTotalAnalyzer/AnalysisType.cs
+++ b/VirusTotalAnalyzer/AnalysisType.cs
@@ -1,0 +1,10 @@
+namespace VirusTotalAnalyzer;
+
+/// <summary>
+/// Represents analysis submission types.
+/// </summary>
+public enum AnalysisType
+{
+    File,
+    Url
+}

--- a/VirusTotalAnalyzer/Models/UploadUrlResponse.cs
+++ b/VirusTotalAnalyzer/Models/UploadUrlResponse.cs
@@ -1,0 +1,6 @@
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class UploadUrlResponse
+{
+    public string Data { get; set; } = string.Empty;
+}

--- a/VirusTotalAnalyzer/MultipartFormDataHelper.cs
+++ b/VirusTotalAnalyzer/MultipartFormDataHelper.cs
@@ -1,0 +1,18 @@
+using System;
+using System.IO;
+using System.Net.Http;
+
+namespace VirusTotalAnalyzer;
+
+internal static class MultipartFormDataHelper
+{
+    public static MultipartFormDataContent Create(Stream stream, string fileName)
+    {
+        var boundary = Guid.NewGuid().ToString("N");
+        var content = new MultipartFormDataContent(boundary);
+        var fileContent = new StreamContent(stream);
+        fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/octet-stream");
+        content.Add(fileContent, "file", fileName);
+        return content;
+    }
+}

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -90,4 +92,100 @@ public sealed class VirusTotalClient
         return await JsonSerializer.DeserializeAsync<AnalysisReport>(stream, _jsonOptions, cancellationToken)
             .ConfigureAwait(false);
     }
+
+    public async Task<Uri?> GetUploadUrlAsync(CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync("files/upload_url", cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<UploadUrlResponse>(stream, _jsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+        if (result is null || string.IsNullOrEmpty(result.Data))
+        {
+            return null;
+        }
+        return new Uri(result.Data);
+    }
+
+    public async Task<AnalysisReport?> SubmitFileAsync(Stream stream, string fileName, AnalysisType analysisType = AnalysisType.File, string? password = null, CancellationToken cancellationToken = default)
+    {
+        if (analysisType != AnalysisType.File)
+        {
+            throw new ArgumentOutOfRangeException(nameof(analysisType));
+        }
+
+        string requestUrl = "files";
+        if (stream.CanSeek && stream.Length > 33554432)
+        {
+            var uploadUrl = await GetUploadUrlAsync(cancellationToken).ConfigureAwait(false);
+            if (uploadUrl is null)
+            {
+                throw new InvalidOperationException("Upload URL was not provided by the API.");
+            }
+            requestUrl = uploadUrl.ToString();
+        }
+
+        using var content = MultipartFormDataHelper.Create(stream, fileName);
+        using var request = new HttpRequestMessage(HttpMethod.Post, requestUrl)
+        {
+            Content = content
+        };
+        if (!string.IsNullOrEmpty(password))
+        {
+            request.Headers.Add("password", password);
+        }
+        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+#if NET472
+        using var respStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var respStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<AnalysisReport>(respStream, _jsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<AnalysisReport?> ReanalyzeHashAsync(string hash, AnalysisType analysisType = AnalysisType.File, CancellationToken cancellationToken = default)
+    {
+        var path = $"{GetPath(analysisType)}/{hash}/analyse";
+        using var response = await _httpClient.PostAsync(path, content: null, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<AnalysisReport>(stream, _jsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<AnalysisReport?> SubmitUrlAsync(string url, AnalysisType analysisType = AnalysisType.Url, CancellationToken cancellationToken = default)
+    {
+        if (analysisType != AnalysisType.Url)
+        {
+            throw new ArgumentOutOfRangeException(nameof(analysisType));
+        }
+        using var content = new FormUrlEncodedContent(new[] { new KeyValuePair<string, string>("url", url) });
+        using var response = await _httpClient.PostAsync("urls", content, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<AnalysisReport>(stream, _jsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static string GetPath(AnalysisType type)
+        => type switch
+        {
+            AnalysisType.File => "files",
+            AnalysisType.Url => "urls",
+            _ => throw new ArgumentOutOfRangeException(nameof(type))
+        };
 }


### PR DESCRIPTION
## Summary
- support requesting VirusTotal upload URLs for large files
- add strongly typed submission methods for files, URLs, and hashes
- include helper for multipart bodies and example/tests

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6893bfb5c918832ea0fe962da68be6a0