### PR TITLE
Add streaming multipart form data builder

### DIFF
--- a/VirusTotalAnalyzer.Examples/Program.cs
+++ b/VirusTotalAnalyzer.Examples/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -27,6 +28,11 @@ using var submitHttpClient = new HttpClient(new StubHandler(analysisJson))
 var submitClient = new VirusTotalClient(submitHttpClient);
 var analysis = await submitClient.SubmitUrlAsync("https://example.com", AnalysisType.Url);
 Console.WriteLine($"Submission status: {analysis?.Data.Attributes.Status}");
+
+using var exampleStream = new MemoryStream(Encoding.UTF8.GetBytes("example"));
+var builder = new MultipartFormDataBuilder(exampleStream, "example.txt");
+using var httpContent = builder.Build();
+Console.WriteLine($"Multipart boundary example: {builder.Boundary}");
 
 class StubHandler : HttpMessageHandler
 {

--- a/VirusTotalAnalyzer.Tests/MultipartFormDataBuilderTests.cs
+++ b/VirusTotalAnalyzer.Tests/MultipartFormDataBuilderTests.cs
@@ -1,0 +1,31 @@
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public class MultipartFormDataBuilderTests
+{
+    [Fact]
+    public async Task Build_ReturnsContentWithBoundary()
+    {
+        using var ms = new MemoryStream(Encoding.UTF8.GetBytes("hi"));
+        var builder = new MultipartFormDataBuilder(ms, "test.txt");
+        using var content = builder.Build();
+
+        var boundaryParam = content.Headers.ContentType!.Parameters.First(p => p.Name == "boundary");
+        Assert.Equal(builder.Boundary, boundaryParam.Value);
+
+        var bytes = await content.ReadAsByteArrayAsync();
+        var expected = Encoding.UTF8.GetBytes(
+            $"--{builder.Boundary}\r\n" +
+            "Content-Disposition: form-data; name=\"file\"; filename=\"test.txt\"\r\n" +
+            "Content-Type: application/octet-stream\r\n\r\n" +
+            "hi\r\n" +
+            $"--{builder.Boundary}--\r\n");
+        Assert.Equal(expected, bytes);
+    }
+}

--- a/VirusTotalAnalyzer/MultipartFormDataBuilder.cs
+++ b/VirusTotalAnalyzer/MultipartFormDataBuilder.cs
@@ -1,0 +1,89 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VirusTotalAnalyzer;
+
+/// <summary>
+/// Builds a multipart/form-data <see cref="HttpContent"/> that streams the provided file.
+/// </summary>
+public sealed class MultipartFormDataBuilder
+{
+    private readonly Stream _stream;
+    private readonly string _fileName;
+
+    public MultipartFormDataBuilder(Stream stream, string fileName)
+    {
+        _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+        _fileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
+        Boundary = "---------------------------" + Guid.NewGuid().ToString("N");
+    }
+
+    /// <summary>
+    /// Gets the boundary string used for the multipart content.
+    /// </summary>
+    public string Boundary { get; }
+
+    /// <summary>
+    /// Builds the <see cref="HttpContent"/> that streams the file with boundaries.
+    /// </summary>
+    public HttpContent Build()
+    {
+        var start = Encoding.UTF8.GetBytes($"--{Boundary}\r\n" +
+            $"Content-Disposition: form-data; name=\"file\"; filename=\"{_fileName}\"\r\n" +
+            "Content-Type: application/octet-stream\r\n\r\n");
+        var end = Encoding.UTF8.GetBytes($"\r\n--{Boundary}--\r\n");
+        return new MultipartStreamContent(_stream, start, end, Boundary);
+    }
+
+    private sealed class MultipartStreamContent : HttpContent
+    {
+        private readonly Stream _file;
+        private readonly byte[] _start;
+        private readonly byte[] _end;
+
+        public MultipartStreamContent(Stream file, byte[] start, byte[] end, string boundary)
+        {
+            _file = file;
+            _start = start;
+            _end = end;
+            Headers.ContentType = new MediaTypeHeaderValue("multipart/form-data");
+            Headers.ContentType.Parameters.Add(new NameValueHeaderValue("boundary", boundary));
+        }
+
+#if NET472
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+            => SerializeToStreamAsync(stream, CancellationToken.None);
+#else
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+            => SerializeToStreamAsync(stream, CancellationToken.None);
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
+            => SerializeToStreamAsync(stream, cancellationToken);
+#endif
+
+        private async Task SerializeToStreamAsync(Stream target, CancellationToken cancellationToken)
+        {
+            await target.WriteAsync(_start, 0, _start.Length, cancellationToken).ConfigureAwait(false);
+            await _file.CopyToAsync(target, 81920, cancellationToken).ConfigureAwait(false);
+            await target.WriteAsync(_end, 0, _end.Length, cancellationToken).ConfigureAwait(false);
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            if (_file.CanSeek)
+            {
+                length = _start.Length + (_file.Length - _file.Position) + _end.Length;
+                return true;
+            }
+            length = 0;
+            return false;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `MultipartFormDataBuilder` for streaming file uploads with custom boundaries
- demonstrate builder usage in example project
- test boundary generation and byte output

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6893c39aa904832ea12103e6e0d9546d