### PR TITLE
Expand VirusTotal analysis models

### DIFF
--- a/VirusTotalAnalyzer.Tests/AttributeSerializationTests.cs
+++ b/VirusTotalAnalyzer.Tests/AttributeSerializationTests.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using VirusTotalAnalyzer;
+using VirusTotalAnalyzer.Models;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public class AttributeSerializationTests
+{
+    [Fact]
+    public void FileAttributes_Roundtrip()
+    {
+        var report = new FileReport
+        {
+            Id = "file1",
+            Type = ResourceType.File,
+            Data = new FileData
+            {
+                Attributes = new FileAttributes
+                {
+                    Md5 = "md5",
+                    Reputation = 1,
+                    CreationDate = 42,
+                    Tags = new List<string> { "tag" },
+                    LastAnalysisResults = new Dictionary<string, AnalysisResult>
+                    {
+                        ["engine"] = new AnalysisResult { Category = "harmless", EngineName = "engine" }
+                    }
+                }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(report);
+        var roundtrip = JsonSerializer.Deserialize<FileReport>(json);
+        Assert.Equal(42, roundtrip!.Data.Attributes.CreationDate);
+        Assert.Equal("tag", Assert.Single(roundtrip.Data.Attributes.Tags));
+        Assert.Equal("harmless", roundtrip.Data.Attributes.LastAnalysisResults["engine"].Category);
+    }
+
+    [Fact]
+    public void UrlAttributes_Roundtrip()
+    {
+        var report = new UrlReport
+        {
+            Id = "url1",
+            Type = ResourceType.Url,
+            Data = new UrlData
+            {
+                Attributes = new UrlAttributes
+                {
+                    Url = "https://example.com",
+                    Reputation = 2,
+                    CreationDate = 84,
+                    Tags = new List<string> { "tag" },
+                    LastAnalysisResults = new Dictionary<string, AnalysisResult>
+                    {
+                        ["engine"] = new AnalysisResult { Category = "malicious", EngineName = "engine" }
+                    }
+                }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(report);
+        var roundtrip = JsonSerializer.Deserialize<UrlReport>(json);
+        Assert.Equal(84, roundtrip!.Data.Attributes.CreationDate);
+        Assert.Equal("tag", Assert.Single(roundtrip.Data.Attributes.Tags));
+        Assert.Equal("malicious", roundtrip.Data.Attributes.LastAnalysisResults["engine"].Category);
+    }
+
+    [Fact]
+    public void DomainAttributes_Roundtrip()
+    {
+        var report = new DomainReport
+        {
+            Id = "domain1",
+            Type = ResourceType.Domain,
+            Data = new DomainData
+            {
+                Attributes = new DomainAttributes
+                {
+                    Domain = "example.com",
+                    Reputation = 3,
+                    CreationDate = 21,
+                    Tags = new List<string> { "tag" },
+                    LastAnalysisResults = new Dictionary<string, AnalysisResult>
+                    {
+                        ["engine"] = new AnalysisResult { Category = "suspicious", EngineName = "engine" }
+                    }
+                }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(report);
+        var roundtrip = JsonSerializer.Deserialize<DomainReport>(json);
+        Assert.Equal(21, roundtrip!.Data.Attributes.CreationDate);
+        Assert.Equal("tag", Assert.Single(roundtrip.Data.Attributes.Tags));
+        Assert.Equal("suspicious", roundtrip.Data.Attributes.LastAnalysisResults["engine"].Category);
+    }
+
+    [Fact]
+    public void IpAddressAttributes_Roundtrip()
+    {
+        var report = new IpAddressReport
+        {
+            Id = "ip1",
+            Type = ResourceType.IpAddress,
+            Data = new IpAddressData
+            {
+                Attributes = new IpAddressAttributes
+                {
+                    IpAddress = "1.2.3.4",
+                    Reputation = 4,
+                    CreationDate = 63,
+                    Tags = new List<string> { "tag" },
+                    LastAnalysisResults = new Dictionary<string, AnalysisResult>
+                    {
+                        ["engine"] = new AnalysisResult { Category = "undetected", EngineName = "engine" }
+                    }
+                }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(report);
+        var roundtrip = JsonSerializer.Deserialize<IpAddressReport>(json);
+        Assert.Equal(63, roundtrip!.Data.Attributes.CreationDate);
+        Assert.Equal("tag", Assert.Single(roundtrip.Data.Attributes.Tags));
+        Assert.Equal("undetected", roundtrip.Data.Attributes.LastAnalysisResults["engine"].Category);
+    }
+}

--- a/VirusTotalAnalyzer/AnalysisStatus.cs
+++ b/VirusTotalAnalyzer/AnalysisStatus.cs
@@ -17,5 +17,8 @@ public enum AnalysisStatus
     Completed,
 
     [EnumMember(Value = "error")]
-    Error
+    Error,
+
+    [EnumMember(Value = "timeout")]
+    Timeout
 }

--- a/VirusTotalAnalyzer/Models/AnalysisResult.cs
+++ b/VirusTotalAnalyzer/Models/AnalysisResult.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class AnalysisResult
+{
+    [JsonPropertyName("category")]
+    public string Category { get; set; } = string.Empty;
+
+    [JsonPropertyName("engine_name")]
+    public string EngineName { get; set; } = string.Empty;
+
+    [JsonPropertyName("engine_version")]
+    public string? EngineVersion { get; set; }
+
+    [JsonPropertyName("method")]
+    public string? Method { get; set; }
+
+    [JsonPropertyName("result")]
+    public string? Result { get; set; }
+}

--- a/VirusTotalAnalyzer/Models/DomainReport.cs
+++ b/VirusTotalAnalyzer/Models/DomainReport.cs
@@ -23,8 +23,17 @@ public sealed class DomainAttributes
     [JsonPropertyName("reputation")]
     public int Reputation { get; set; }
 
+    [JsonPropertyName("creation_date")]
+    public long CreationDate { get; set; }
+
+    [JsonPropertyName("tags")]
+    public List<string> Tags { get; set; } = new();
+
     [JsonPropertyName("last_analysis_stats")]
     public AnalysisStats LastAnalysisStats { get; set; } = new();
+
+    [JsonPropertyName("last_analysis_results")]
+    public Dictionary<string, AnalysisResult> LastAnalysisResults { get; set; } = new();
 
     [JsonPropertyName("total_votes")]
     public TotalVotes TotalVotes { get; set; } = new();

--- a/VirusTotalAnalyzer/Models/FileReport.cs
+++ b/VirusTotalAnalyzer/Models/FileReport.cs
@@ -26,8 +26,17 @@ public sealed class FileAttributes
     [JsonPropertyName("reputation")]
     public int Reputation { get; set; }
 
+    [JsonPropertyName("creation_date")]
+    public long CreationDate { get; set; }
+
+    [JsonPropertyName("tags")]
+    public List<string> Tags { get; set; } = new();
+
     [JsonPropertyName("last_analysis_stats")]
     public AnalysisStats LastAnalysisStats { get; set; } = new();
+
+    [JsonPropertyName("last_analysis_results")]
+    public Dictionary<string, AnalysisResult> LastAnalysisResults { get; set; } = new();
 
     [JsonPropertyName("total_votes")]
     public TotalVotes TotalVotes { get; set; } = new();

--- a/VirusTotalAnalyzer/Models/IpAddressReport.cs
+++ b/VirusTotalAnalyzer/Models/IpAddressReport.cs
@@ -23,8 +23,17 @@ public sealed class IpAddressAttributes
     [JsonPropertyName("reputation")]
     public int Reputation { get; set; }
 
+    [JsonPropertyName("creation_date")]
+    public long CreationDate { get; set; }
+
+    [JsonPropertyName("tags")]
+    public List<string> Tags { get; set; } = new();
+
     [JsonPropertyName("last_analysis_stats")]
     public AnalysisStats LastAnalysisStats { get; set; } = new();
+
+    [JsonPropertyName("last_analysis_results")]
+    public Dictionary<string, AnalysisResult> LastAnalysisResults { get; set; } = new();
 
     [JsonPropertyName("total_votes")]
     public TotalVotes TotalVotes { get; set; } = new();

--- a/VirusTotalAnalyzer/Models/UrlReport.cs
+++ b/VirusTotalAnalyzer/Models/UrlReport.cs
@@ -23,8 +23,17 @@ public sealed class UrlAttributes
     [JsonPropertyName("reputation")]
     public int Reputation { get; set; }
 
+    [JsonPropertyName("creation_date")]
+    public long CreationDate { get; set; }
+
+    [JsonPropertyName("tags")]
+    public List<string> Tags { get; set; } = new();
+
     [JsonPropertyName("last_analysis_stats")]
     public AnalysisStats LastAnalysisStats { get; set; } = new();
+
+    [JsonPropertyName("last_analysis_results")]
+    public Dictionary<string, AnalysisResult> LastAnalysisResults { get; set; } = new();
 
     [JsonPropertyName("total_votes")]
     public TotalVotes TotalVotes { get; set; } = new();

--- a/VirusTotalAnalyzer/ResourceType.cs
+++ b/VirusTotalAnalyzer/ResourceType.cs
@@ -22,6 +22,9 @@ public enum ResourceType
     [EnumMember(Value = "analysis")]
     Analysis,
 
+    [EnumMember(Value = "private_analysis")]
+    PrivateAnalysis,
+
     [EnumMember(Value = "comment")]
     Comment,
 
@@ -35,5 +38,17 @@ public enum ResourceType
     Search,
 
     [EnumMember(Value = "feed")]
-    Feed
+    Feed,
+
+    [EnumMember(Value = "graph")]
+    Graph,
+
+    [EnumMember(Value = "user")]
+    User,
+
+    [EnumMember(Value = "collection")]
+    Collection,
+
+    [EnumMember(Value = "bundle")]
+    Bundle
 }


### PR DESCRIPTION
## Summary
- extend `AnalysisStatus` and `ResourceType` enums
- add creation date, tags and last analysis results to resource attribute models
- cover new fields with serialization roundtrip unit tests

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689465062314832ea69fc37ab4fd59e1