### PR TITLE
Expand VirusTotal schema coverage

### DIFF
--- a/VirusTotalAnalyzer.Examples/Program.cs
+++ b/VirusTotalAnalyzer.Examples/Program.cs
@@ -71,7 +71,7 @@ using var voteClientHttp = new HttpClient(new StubHandler(voteJson))
     BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
 };
 var voteClientExample = new VirusTotalClient(voteClientHttp);
-var vote = await voteClientExample.VoteAsync(ResourceType.File, "abc", Verdict.Harmless);
+var vote = await voteClientExample.VoteAsync(ResourceType.File, "abc", VoteValue.Harmless);
 Console.WriteLine($"Vote verdict: {vote?.Data.Attributes.Verdict}");
 
 var deleteHandler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.NoContent));

--- a/VirusTotalAnalyzer.Tests/AttributeSerializationTests.cs
+++ b/VirusTotalAnalyzer.Tests/AttributeSerializationTests.cs
@@ -22,7 +22,14 @@ public class AttributeSerializationTests
                     Md5 = "md5",
                     Reputation = 1,
                     CreationDate = 42,
+                    FirstSubmissionDate = 10,
+                    Size = 1234,
                     Tags = new List<string> { "tag" },
+                    Names = new List<string> { "file.exe" },
+                    CrowdSourcedVerdicts = new List<CrowdSourcedVerdict>
+                    {
+                        new CrowdSourcedVerdict { EngineName = "crowd", Verdict = Verdict.Harmless }
+                    },
                     LastAnalysisResults = new Dictionary<string, AnalysisResult>
                     {
                         ["engine"] = new AnalysisResult { Category = "harmless", EngineName = "engine" }
@@ -34,7 +41,11 @@ public class AttributeSerializationTests
         var json = JsonSerializer.Serialize(report);
         var roundtrip = JsonSerializer.Deserialize<FileReport>(json);
         Assert.Equal(42, roundtrip!.Data.Attributes.CreationDate);
+        Assert.Equal(10, roundtrip.Data.Attributes.FirstSubmissionDate);
+        Assert.Equal(1234, roundtrip.Data.Attributes.Size);
+        Assert.Equal("file.exe", Assert.Single(roundtrip.Data.Attributes.Names));
         Assert.Equal("tag", Assert.Single(roundtrip.Data.Attributes.Tags));
+        Assert.Equal("crowd", roundtrip.Data.Attributes.CrowdSourcedVerdicts[0].EngineName);
         Assert.Equal("harmless", roundtrip.Data.Attributes.LastAnalysisResults["engine"].Category);
     }
 
@@ -52,7 +63,13 @@ public class AttributeSerializationTests
                     Url = "https://example.com",
                     Reputation = 2,
                     CreationDate = 84,
+                    FirstSubmissionDate = 70,
+                    LastSubmissionDate = 80,
                     Tags = new List<string> { "tag" },
+                    CrowdSourcedVerdicts = new List<CrowdSourcedVerdict>
+                    {
+                        new CrowdSourcedVerdict { EngineName = "crowd", Verdict = Verdict.Malicious }
+                    },
                     LastAnalysisResults = new Dictionary<string, AnalysisResult>
                     {
                         ["engine"] = new AnalysisResult { Category = "malicious", EngineName = "engine" }
@@ -64,7 +81,11 @@ public class AttributeSerializationTests
         var json = JsonSerializer.Serialize(report);
         var roundtrip = JsonSerializer.Deserialize<UrlReport>(json);
         Assert.Equal(84, roundtrip!.Data.Attributes.CreationDate);
+        Assert.Equal(70, roundtrip.Data.Attributes.FirstSubmissionDate);
+        Assert.Equal(80, roundtrip.Data.Attributes.LastSubmissionDate);
         Assert.Equal("tag", Assert.Single(roundtrip.Data.Attributes.Tags));
+        Assert.Equal(1, roundtrip.Data.Attributes.CrowdSourcedVerdicts.Count);
+        Assert.Equal(Verdict.Malicious, roundtrip.Data.Attributes.CrowdSourcedVerdicts[0].Verdict);
         Assert.Equal("malicious", roundtrip.Data.Attributes.LastAnalysisResults["engine"].Category);
     }
 
@@ -126,5 +147,33 @@ public class AttributeSerializationTests
         Assert.Equal(63, roundtrip!.Data.Attributes.CreationDate);
         Assert.Equal("tag", Assert.Single(roundtrip.Data.Attributes.Tags));
         Assert.Equal("undetected", roundtrip.Data.Attributes.LastAnalysisResults["engine"].Category);
+    }
+
+    [Fact]
+    public void AnalysisAttributes_Roundtrip()
+    {
+        var report = new AnalysisReport
+        {
+            Id = "analysis1",
+            Type = ResourceType.Analysis,
+            Data = new AnalysisData
+            {
+                Attributes = new AnalysisAttributes
+                {
+                    Status = AnalysisStatus.Completed,
+                    Date = 123,
+                    Stats = new AnalysisStats { Harmless = 1 },
+                    Results = new Dictionary<string, AnalysisResult>
+                    {
+                        ["engine"] = new AnalysisResult { Category = "harmless", EngineName = "engine" }
+                    }
+                }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(report);
+        var roundtrip = JsonSerializer.Deserialize<AnalysisReport>(json);
+        Assert.Equal(123, roundtrip!.Data.Attributes.Date);
+        Assert.Equal("harmless", roundtrip.Data.Attributes.Results["engine"].Category);
     }
 }

--- a/VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj
+++ b/VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
@@ -11,5 +12,8 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 </Project>

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.cs
@@ -86,7 +86,7 @@ public class VirusTotalClientTests
         };
         var client = new VirusTotalClient(httpClient);
 
-        var vote = await client.CreateVoteAsync(ResourceType.File, "abc", Verdict.Malicious);
+        var vote = await client.CreateVoteAsync(ResourceType.File, "abc", VoteValue.Malicious);
 
         Assert.NotNull(vote);
         Assert.Single(handler.Requests);
@@ -327,7 +327,11 @@ public class VirusTotalClientTests
         var client = new VirusTotalClient(httpClient);
 
         var path = System.IO.Path.GetTempFileName();
+#if NET472
+        System.IO.File.WriteAllText(path, "demo");
+#else
         await System.IO.File.WriteAllTextAsync(path, "demo");
+#endif
         try
         {
             var report = await client.ScanFileAsync(path);
@@ -408,7 +412,11 @@ public class VirusTotalClientTests
             Requests.Add(request);
             if (request.Content != null)
             {
+#if NET472
+                var text = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+#else
                 var text = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#endif
                 Contents.Add(text);
             }
             else

--- a/VirusTotalAnalyzer/AnalysisStatus.cs
+++ b/VirusTotalAnalyzer/AnalysisStatus.cs
@@ -19,6 +19,9 @@ public enum AnalysisStatus
     [EnumMember(Value = "error")]
     Error,
 
+    [EnumMember(Value = "cancelled")]
+    Cancelled,
+
     [EnumMember(Value = "timeout")]
     Timeout
 }

--- a/VirusTotalAnalyzer/Models/AnalysisReport.cs
+++ b/VirusTotalAnalyzer/Models/AnalysisReport.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
@@ -19,8 +20,14 @@ public sealed class AnalysisAttributes
     [JsonPropertyName("status")]
     public AnalysisStatus Status { get; set; }
 
+    [JsonPropertyName("date")]
+    public long Date { get; set; }
+
     [JsonPropertyName("stats")]
     public AnalysisStats Stats { get; set; } = new();
+
+    [JsonPropertyName("results")]
+    public Dictionary<string, AnalysisResult> Results { get; set; } = new();
 
     [JsonPropertyName("error")]
     public string? Error { get; set; }

--- a/VirusTotalAnalyzer/Models/AnalysisStats.cs
+++ b/VirusTotalAnalyzer/Models/AnalysisStats.cs
@@ -11,4 +11,5 @@ public sealed class AnalysisStats
     [JsonPropertyName("timeout")] public int Timeout { get; set; }
     [JsonPropertyName("failure")] public int Failure { get; set; }
     [JsonPropertyName("type-unsupported")] public int TypeUnsupported { get; set; }
+    [JsonPropertyName("confirmed-timeout")] public int ConfirmedTimeout { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/CrowdSourcedVerdict.cs
+++ b/VirusTotalAnalyzer/Models/CrowdSourcedVerdict.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class CrowdSourcedVerdict
+{
+    [JsonPropertyName("engine_name")]
+    public string EngineName { get; set; } = string.Empty;
+
+    [JsonPropertyName("verdict")]
+    public Verdict Verdict { get; set; }
+}

--- a/VirusTotalAnalyzer/Models/FileReport.cs
+++ b/VirusTotalAnalyzer/Models/FileReport.cs
@@ -23,14 +23,59 @@ public sealed class FileAttributes
     [JsonPropertyName("sha256")]
     public string? Sha256 { get; set; }
 
+    [JsonPropertyName("sha1")]
+    public string? Sha1 { get; set; }
+
     [JsonPropertyName("reputation")]
     public int Reputation { get; set; }
 
     [JsonPropertyName("creation_date")]
     public long CreationDate { get; set; }
 
+    [JsonPropertyName("first_submission_date")]
+    public long FirstSubmissionDate { get; set; }
+
+    [JsonPropertyName("last_submission_date")]
+    public long LastSubmissionDate { get; set; }
+
+    [JsonPropertyName("times_submitted")]
+    public int TimesSubmitted { get; set; }
+
+    [JsonPropertyName("unique_sources")]
+    public int UniqueSources { get; set; }
+
+    [JsonPropertyName("size")]
+    public long Size { get; set; }
+
+    [JsonPropertyName("last_modification_date")]
+    public long LastModificationDate { get; set; }
+
+    [JsonPropertyName("meaningful_name")]
+    public string? MeaningfulName { get; set; }
+
+    [JsonPropertyName("type_description")]
+    public string? TypeDescription { get; set; }
+
+    [JsonPropertyName("type_tag")]
+    public string? TypeTag { get; set; }
+
+    [JsonPropertyName("type_extension")]
+    public string? TypeExtension { get; set; }
+
+    [JsonPropertyName("ssdeep")]
+    public string? Ssdeep { get; set; }
+
+    [JsonPropertyName("magic")]
+    public string? Magic { get; set; }
+
+    [JsonPropertyName("names")]
+    public List<string> Names { get; set; } = new();
+
     [JsonPropertyName("tags")]
     public List<string> Tags { get; set; } = new();
+
+    [JsonPropertyName("crowdsourced_verdicts")]
+    public List<CrowdSourcedVerdict> CrowdSourcedVerdicts { get; set; } = new();
 
     [JsonPropertyName("last_analysis_stats")]
     public AnalysisStats LastAnalysisStats { get; set; } = new();

--- a/VirusTotalAnalyzer/Models/UrlReport.cs
+++ b/VirusTotalAnalyzer/Models/UrlReport.cs
@@ -26,8 +26,23 @@ public sealed class UrlAttributes
     [JsonPropertyName("creation_date")]
     public long CreationDate { get; set; }
 
+    [JsonPropertyName("first_submission_date")]
+    public long FirstSubmissionDate { get; set; }
+
+    [JsonPropertyName("last_submission_date")]
+    public long LastSubmissionDate { get; set; }
+
+    [JsonPropertyName("times_submitted")]
+    public int TimesSubmitted { get; set; }
+
+    [JsonPropertyName("last_final_url")]
+    public string? LastFinalUrl { get; set; }
+
     [JsonPropertyName("tags")]
     public List<string> Tags { get; set; } = new();
+
+    [JsonPropertyName("crowdsourced_verdicts")]
+    public List<CrowdSourcedVerdict> CrowdSourcedVerdicts { get; set; } = new();
 
     [JsonPropertyName("last_analysis_stats")]
     public AnalysisStats LastAnalysisStats { get; set; } = new();

--- a/VirusTotalAnalyzer/Models/Verdict.cs
+++ b/VirusTotalAnalyzer/Models/Verdict.cs
@@ -8,6 +8,7 @@ public enum Verdict
     [EnumMember(Value = "undetected")] Undetected,
     [EnumMember(Value = "suspicious")] Suspicious,
     [EnumMember(Value = "malicious")] Malicious,
+    [EnumMember(Value = "confirmed-timeout")] ConfirmedTimeout,
     [EnumMember(Value = "timeout")] Timeout,
     [EnumMember(Value = "failure")] Failure,
     [EnumMember(Value = "type-unsupported")] TypeUnsupported

--- a/VirusTotalAnalyzer/Models/Vote.cs
+++ b/VirusTotalAnalyzer/Models/Vote.cs
@@ -21,7 +21,7 @@ public sealed class VoteAttributes
     public long Date { get; set; }
 
     [JsonPropertyName("verdict")]
-    public Verdict Verdict { get; set; }
+    public VoteValue Verdict { get; set; }
 }
 
 public sealed class VotesResponse
@@ -54,5 +54,5 @@ public sealed class CreateVoteData
 public sealed class CreateVoteAttributes
 {
     [JsonPropertyName("verdict")]
-    public Verdict Verdict { get; set; }
+    public VoteValue Verdict { get; set; }
 }

--- a/VirusTotalAnalyzer/ResourceType.cs
+++ b/VirusTotalAnalyzer/ResourceType.cs
@@ -50,5 +50,14 @@ public enum ResourceType
     Collection,
 
     [EnumMember(Value = "bundle")]
-    Bundle
+    Bundle,
+
+    [EnumMember(Value = "file_behaviour")]
+    FileBehaviour,
+
+    [EnumMember(Value = "monitor_item")]
+    MonitorItem,
+
+    [EnumMember(Value = "network_location")]
+    NetworkLocation
 }

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -177,7 +177,7 @@ public sealed class VirusTotalClient
         return result?.Data;
     }
 
-    public async Task<Vote?> CreateVoteAsync(ResourceType resourceType, string id, Verdict verdict, CancellationToken cancellationToken = default)
+    public async Task<Vote?> CreateVoteAsync(ResourceType resourceType, string id, VoteValue verdict, CancellationToken cancellationToken = default)
     {
         var request = new CreateVoteRequest
         {

--- a/VirusTotalAnalyzer/VirusTotalClientExtensions.cs
+++ b/VirusTotalAnalyzer/VirusTotalClientExtensions.cs
@@ -39,7 +39,7 @@ public static class VirusTotalClientExtensions
         return client.CreateCommentAsync(resourceType, id, text, cancellationToken);
     }
 
-    public static Task<Vote?> VoteAsync(this VirusTotalClient client, ResourceType resourceType, string id, Verdict verdict, CancellationToken cancellationToken = default)
+    public static Task<Vote?> VoteAsync(this VirusTotalClient client, ResourceType resourceType, string id, VoteValue verdict, CancellationToken cancellationToken = default)
     {
         if (client == null) throw new ArgumentNullException(nameof(client));
         return client.CreateVoteAsync(resourceType, id, verdict, cancellationToken);

--- a/VirusTotalAnalyzer/VoteValue.cs
+++ b/VirusTotalAnalyzer/VoteValue.cs
@@ -1,0 +1,11 @@
+using System.Runtime.Serialization;
+
+namespace VirusTotalAnalyzer;
+
+public enum VoteValue
+{
+    [EnumMember(Value = "harmless")] Harmless,
+    [EnumMember(Value = "malicious")] Malicious,
+    [EnumMember(Value = "suspicious")] Suspicious,
+    [EnumMember(Value = "undetected")] Undetected
+}


### PR DESCRIPTION
## Summary
- add many missing properties to file, URL, and analysis models
- introduce VoteValue and CrowdSourcedVerdict types and extend enums
- cover new fields with serialization tests

## Testing
- `dotnet test -f net8.0`
- `dotnet test -f net9.0`
- `dotnet test -f net472` *(fails: Failed to negotiate protocol, waiting for response timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6894776f46f8832e90cacbbae80ce7ba