### PR TITLE
Expand VirusTotal schema models and enums

### DIFF
--- a/VirusTotalAnalyzer.Examples/Program.cs
+++ b/VirusTotalAnalyzer.Examples/Program.cs
@@ -10,7 +10,7 @@ using VirusTotalAnalyzer.Models;
 
 Console.WriteLine("VirusTotalAnalyzer example running.");
 
-var sampleJson = "{\"id\":\"abc\",\"type\":\"file\",\"data\":{\"attributes\":{\"md5\":\"demo-md5\",\"sha256\":\"demo-sha\"}}}";
+var sampleJson = "{\"id\":\"abc\",\"type\":\"file\",\"data\":{\"attributes\":{\"md5\":\"demo-md5\",\"sha256\":\"demo-sha\",\"size\":123}}}";
 
 using var httpClient = new HttpClient(new StubHandler(sampleJson))
 {
@@ -19,7 +19,7 @@ using var httpClient = new HttpClient(new StubHandler(sampleJson))
 var client = new VirusTotalClient(httpClient);
 
 var report = await client.GetFileReportAsync("abc");
-Console.WriteLine($"Sample file md5: {report?.Data.Attributes.Md5}");
+Console.WriteLine($"Sample file md5: {report?.Data.Attributes.Md5}, size: {report?.Data.Attributes.Size}");
 
 var analysisJson = "{\"id\":\"analysis\",\"type\":\"analysis\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}";
 using var submitHttpClient = new HttpClient(new StubHandler(analysisJson))
@@ -71,7 +71,7 @@ using var voteClientHttp = new HttpClient(new StubHandler(voteJson))
     BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
 };
 var voteClientExample = new VirusTotalClient(voteClientHttp);
-var vote = await voteClientExample.VoteAsync(ResourceType.File, "abc", Verdict.Harmless);
+var vote = await voteClientExample.VoteAsync(ResourceType.File, "abc", VoteVerdict.Harmless);
 Console.WriteLine($"Vote verdict: {vote?.Data.Attributes.Verdict}");
 
 var deleteHandler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.NoContent));

--- a/VirusTotalAnalyzer.Tests/AttributeSerializationTests.cs
+++ b/VirusTotalAnalyzer.Tests/AttributeSerializationTests.cs
@@ -23,6 +23,12 @@ public class AttributeSerializationTests
                     Reputation = 1,
                     CreationDate = 42,
                     Tags = new List<string> { "tag" },
+                    Size = 100,
+                    FirstSubmissionDate = 10,
+                    CrowdsourcedVerdicts =
+                    {
+                        new CrowdsourcedVerdict { Source = "cs", Verdict = Verdict.Harmless, Timestamp = 1 }
+                    },
                     LastAnalysisResults = new Dictionary<string, AnalysisResult>
                     {
                         ["engine"] = new AnalysisResult { Category = "harmless", EngineName = "engine" }
@@ -36,6 +42,9 @@ public class AttributeSerializationTests
         Assert.Equal(42, roundtrip!.Data.Attributes.CreationDate);
         Assert.Equal("tag", Assert.Single(roundtrip.Data.Attributes.Tags));
         Assert.Equal("harmless", roundtrip.Data.Attributes.LastAnalysisResults["engine"].Category);
+        Assert.Equal(100, roundtrip.Data.Attributes.Size);
+        Assert.Equal(10, roundtrip.Data.Attributes.FirstSubmissionDate);
+        Assert.Equal(Verdict.Harmless, roundtrip.Data.Attributes.CrowdsourcedVerdicts[0].Verdict);
     }
 
     [Fact]
@@ -53,6 +62,11 @@ public class AttributeSerializationTests
                     Reputation = 2,
                     CreationDate = 84,
                     Tags = new List<string> { "tag" },
+                    FirstSubmissionDate = 11,
+                    CrowdsourcedVerdicts =
+                    {
+                        new CrowdsourcedVerdict { Source = "cs", Verdict = Verdict.Malicious, Timestamp = 2 }
+                    },
                     LastAnalysisResults = new Dictionary<string, AnalysisResult>
                     {
                         ["engine"] = new AnalysisResult { Category = "malicious", EngineName = "engine" }
@@ -66,6 +80,35 @@ public class AttributeSerializationTests
         Assert.Equal(84, roundtrip!.Data.Attributes.CreationDate);
         Assert.Equal("tag", Assert.Single(roundtrip.Data.Attributes.Tags));
         Assert.Equal("malicious", roundtrip.Data.Attributes.LastAnalysisResults["engine"].Category);
+        Assert.Equal(11, roundtrip.Data.Attributes.FirstSubmissionDate);
+        Assert.Equal(Verdict.Malicious, roundtrip.Data.Attributes.CrowdsourcedVerdicts[0].Verdict);
+    }
+
+    [Fact]
+    public void AnalysisAttributes_Roundtrip()
+    {
+        var report = new AnalysisReport
+        {
+            Id = "an1",
+            Type = ResourceType.Analysis,
+            Data = new AnalysisData
+            {
+                Attributes = new AnalysisAttributes
+                {
+                    Status = AnalysisStatus.Completed,
+                    Date = 5,
+                    Results = new Dictionary<string, AnalysisResult>
+                    {
+                        ["engine"] = new AnalysisResult { Category = "harmless", EngineName = "engine" }
+                    }
+                }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(report);
+        var roundtrip = JsonSerializer.Deserialize<AnalysisReport>(json);
+        Assert.Equal(5, roundtrip!.Data.Attributes.Date);
+        Assert.Equal("harmless", roundtrip.Data.Attributes.Results["engine"].Category);
     }
 
     [Fact]

--- a/VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj
+++ b/VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net472;net8.0;net9.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>

--- a/VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj
+++ b/VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../VirusTotalAnalyzer/VirusTotalAnalyzer.csproj" />
@@ -11,5 +12,8 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 </Project>

--- a/VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj
+++ b/VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.cs
@@ -86,7 +86,7 @@ public class VirusTotalClientTests
         };
         var client = new VirusTotalClient(httpClient);
 
-        var vote = await client.CreateVoteAsync(ResourceType.File, "abc", Verdict.Malicious);
+        var vote = await client.CreateVoteAsync(ResourceType.File, "abc", VoteVerdict.Malicious);
 
         Assert.NotNull(vote);
         Assert.Single(handler.Requests);

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.cs
@@ -327,7 +327,11 @@ public class VirusTotalClientTests
         var client = new VirusTotalClient(httpClient);
 
         var path = System.IO.Path.GetTempFileName();
+#if NETFRAMEWORK
+        System.IO.File.WriteAllText(path, "demo");
+#else
         await System.IO.File.WriteAllTextAsync(path, "demo");
+#endif
         try
         {
             var report = await client.ScanFileAsync(path);
@@ -408,7 +412,11 @@ public class VirusTotalClientTests
             Requests.Add(request);
             if (request.Content != null)
             {
+#if NETFRAMEWORK
+                var text = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+#else
                 var text = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#endif
                 Contents.Add(text);
             }
             else

--- a/VirusTotalAnalyzer/AnalysisStatus.cs
+++ b/VirusTotalAnalyzer/AnalysisStatus.cs
@@ -20,5 +20,8 @@ public enum AnalysisStatus
     Error,
 
     [EnumMember(Value = "timeout")]
-    Timeout
+    Timeout,
+
+    [EnumMember(Value = "cancelled")]
+    Cancelled
 }

--- a/VirusTotalAnalyzer/Models/AnalysisReport.cs
+++ b/VirusTotalAnalyzer/Models/AnalysisReport.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
@@ -21,6 +22,12 @@ public sealed class AnalysisAttributes
 
     [JsonPropertyName("stats")]
     public AnalysisStats Stats { get; set; } = new();
+
+    [JsonPropertyName("results")]
+    public Dictionary<string, AnalysisResult> Results { get; set; } = new();
+
+    [JsonPropertyName("date")]
+    public long Date { get; set; }
 
     [JsonPropertyName("error")]
     public string? Error { get; set; }

--- a/VirusTotalAnalyzer/Models/CrowdsourcedVerdict.cs
+++ b/VirusTotalAnalyzer/Models/CrowdsourcedVerdict.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class CrowdsourcedVerdict
+{
+    [JsonPropertyName("source")]
+    public string Source { get; set; } = string.Empty;
+
+    [JsonPropertyName("verdict")]
+    public Verdict Verdict { get; set; }
+
+    [JsonPropertyName("timestamp")]
+    public long Timestamp { get; set; }
+}

--- a/VirusTotalAnalyzer/Models/FileReport.cs
+++ b/VirusTotalAnalyzer/Models/FileReport.cs
@@ -32,6 +32,27 @@ public sealed class FileAttributes
     [JsonPropertyName("tags")]
     public List<string> Tags { get; set; } = new();
 
+    [JsonPropertyName("size")]
+    public long Size { get; set; }
+
+    [JsonPropertyName("first_submission_date")]
+    public long FirstSubmissionDate { get; set; }
+
+    [JsonPropertyName("last_submission_date")]
+    public long LastSubmissionDate { get; set; }
+
+    [JsonPropertyName("last_modification_date")]
+    public long LastModificationDate { get; set; }
+
+    [JsonPropertyName("times_submitted")]
+    public int TimesSubmitted { get; set; }
+
+    [JsonPropertyName("meaningful_name")]
+    public string? MeaningfulName { get; set; }
+
+    [JsonPropertyName("names")]
+    public List<string> Names { get; set; } = new();
+
     [JsonPropertyName("last_analysis_stats")]
     public AnalysisStats LastAnalysisStats { get; set; } = new();
 
@@ -46,4 +67,7 @@ public sealed class FileAttributes
 
     [JsonPropertyName("last_analysis_date")]
     public long LastAnalysisDate { get; set; }
+
+    [JsonPropertyName("crowdsourced_verdicts")]
+    public List<CrowdsourcedVerdict> CrowdsourcedVerdicts { get; set; } = new();
 }

--- a/VirusTotalAnalyzer/Models/UrlReport.cs
+++ b/VirusTotalAnalyzer/Models/UrlReport.cs
@@ -29,6 +29,18 @@ public sealed class UrlAttributes
     [JsonPropertyName("tags")]
     public List<string> Tags { get; set; } = new();
 
+    [JsonPropertyName("first_submission_date")]
+    public long FirstSubmissionDate { get; set; }
+
+    [JsonPropertyName("last_submission_date")]
+    public long LastSubmissionDate { get; set; }
+
+    [JsonPropertyName("last_modification_date")]
+    public long LastModificationDate { get; set; }
+
+    [JsonPropertyName("times_submitted")]
+    public int TimesSubmitted { get; set; }
+
     [JsonPropertyName("last_analysis_stats")]
     public AnalysisStats LastAnalysisStats { get; set; } = new();
 
@@ -43,4 +55,7 @@ public sealed class UrlAttributes
 
     [JsonPropertyName("last_analysis_date")]
     public long LastAnalysisDate { get; set; }
+
+    [JsonPropertyName("crowdsourced_verdicts")]
+    public List<CrowdsourcedVerdict> CrowdsourcedVerdicts { get; set; } = new();
 }

--- a/VirusTotalAnalyzer/Models/Verdict.cs
+++ b/VirusTotalAnalyzer/Models/Verdict.cs
@@ -10,5 +10,8 @@ public enum Verdict
     [EnumMember(Value = "malicious")] Malicious,
     [EnumMember(Value = "timeout")] Timeout,
     [EnumMember(Value = "failure")] Failure,
-    [EnumMember(Value = "type-unsupported")] TypeUnsupported
+    [EnumMember(Value = "type-unsupported")] TypeUnsupported,
+    [EnumMember(Value = "confirmed-timeout")] ConfirmedTimeout,
+    [EnumMember(Value = "unknown")] Unknown,
+    [EnumMember(Value = "unrated")] Unrated
 }

--- a/VirusTotalAnalyzer/Models/Vote.cs
+++ b/VirusTotalAnalyzer/Models/Vote.cs
@@ -21,7 +21,7 @@ public sealed class VoteAttributes
     public long Date { get; set; }
 
     [JsonPropertyName("verdict")]
-    public Verdict Verdict { get; set; }
+    public VoteVerdict Verdict { get; set; }
 }
 
 public sealed class VotesResponse
@@ -54,5 +54,5 @@ public sealed class CreateVoteData
 public sealed class CreateVoteAttributes
 {
     [JsonPropertyName("verdict")]
-    public Verdict Verdict { get; set; }
+    public VoteVerdict Verdict { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/VoteVerdict.cs
+++ b/VirusTotalAnalyzer/Models/VoteVerdict.cs
@@ -1,0 +1,11 @@
+using System.Runtime.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public enum VoteVerdict
+{
+    [EnumMember(Value = "harmless")]
+    Harmless,
+    [EnumMember(Value = "malicious")]
+    Malicious
+}

--- a/VirusTotalAnalyzer/ResourceType.cs
+++ b/VirusTotalAnalyzer/ResourceType.cs
@@ -50,5 +50,17 @@ public enum ResourceType
     Collection,
 
     [EnumMember(Value = "bundle")]
-    Bundle
+    Bundle,
+
+    [EnumMember(Value = "livehunt_notification")]
+    LivehuntNotification,
+
+    [EnumMember(Value = "retrohunt_job")]
+    RetrohuntJob,
+
+    [EnumMember(Value = "retrohunt_notification")]
+    RetrohuntNotification,
+
+    [EnumMember(Value = "monitor_item")]
+    MonitorItem
 }

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -177,7 +177,7 @@ public sealed class VirusTotalClient
         return result?.Data;
     }
 
-    public async Task<Vote?> CreateVoteAsync(ResourceType resourceType, string id, Verdict verdict, CancellationToken cancellationToken = default)
+    public async Task<Vote?> CreateVoteAsync(ResourceType resourceType, string id, VoteVerdict verdict, CancellationToken cancellationToken = default)
     {
         var request = new CreateVoteRequest
         {

--- a/VirusTotalAnalyzer/VirusTotalClientExtensions.cs
+++ b/VirusTotalAnalyzer/VirusTotalClientExtensions.cs
@@ -12,14 +12,19 @@ public static class VirusTotalClientExtensions
     {
         if (client == null) throw new ArgumentNullException(nameof(client));
 #if NET472
-        using var stream = File.OpenRead(filePath);
-        return client.SubmitFileAsync(stream, Path.GetFileName(filePath), cancellationToken);
+        return ScanFileFrameworkAsync(client, filePath, cancellationToken);
 #else
         return ScanFileInternalAsync(client, filePath, cancellationToken);
 #endif
     }
 
-#if !NET472
+#if NET472
+    private static async Task<AnalysisReport?> ScanFileFrameworkAsync(VirusTotalClient client, string filePath, CancellationToken cancellationToken)
+    {
+        using var stream = File.OpenRead(filePath);
+        return await client.SubmitFileAsync(stream, Path.GetFileName(filePath), cancellationToken).ConfigureAwait(false);
+    }
+#else
     private static async Task<AnalysisReport?> ScanFileInternalAsync(VirusTotalClient client, string filePath, CancellationToken cancellationToken)
     {
         await using var stream = File.OpenRead(filePath);

--- a/VirusTotalAnalyzer/VirusTotalClientExtensions.cs
+++ b/VirusTotalAnalyzer/VirusTotalClientExtensions.cs
@@ -39,7 +39,7 @@ public static class VirusTotalClientExtensions
         return client.CreateCommentAsync(resourceType, id, text, cancellationToken);
     }
 
-    public static Task<Vote?> VoteAsync(this VirusTotalClient client, ResourceType resourceType, string id, Verdict verdict, CancellationToken cancellationToken = default)
+    public static Task<Vote?> VoteAsync(this VirusTotalClient client, ResourceType resourceType, string id, VoteVerdict verdict, CancellationToken cancellationToken = default)
     {
         if (client == null) throw new ArgumentNullException(nameof(client));
         return client.CreateVoteAsync(resourceType, id, verdict, cancellationToken);


### PR DESCRIPTION
## Summary
- support additional file attributes like size, submission dates, and crowdsourced verdicts
- extend URL and analysis models to handle full VirusTotal schema
- add vote verdict enum and update client methods accordingly
- cover new enum members for resource types, analysis statuses, and verdicts
- broaden test coverage across target frameworks including net472

## Testing
- `dotnet build` *(fails: .NET SDK does not support net9.0)*
- `dotnet test VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj -p:TargetFramework=net8.0` *(fails: .NET SDK does not support net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68948e9faa60832eb62b3fc940525b7c