### PR TITLE
Add VirusTotalClient factory and refactor examples

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetFileReportExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileReportExample.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace VirusTotalAnalyzer.Examples;
@@ -15,13 +14,7 @@ public static class GetFileReportExample
             return;
         }
 
-        using var httpClient = new HttpClient
-        {
-            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
-        };
-        httpClient.DefaultRequestHeaders.Add("x-apikey", apiKey);
-
-        var client = new VirusTotalClient(httpClient);
+        var client = VirusTotalClient.Create(apiKey);
         var report = await client.GetFileReportAsync("44d88612fea8a8f36de82e1278abb02f");
         Console.WriteLine($"Sample file md5: {report?.Data.Attributes.Md5}, size: {report?.Data.Attributes.Size}");
     }

--- a/VirusTotalAnalyzer.Examples/SubmitUrlExample.cs
+++ b/VirusTotalAnalyzer.Examples/SubmitUrlExample.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace VirusTotalAnalyzer.Examples;
@@ -15,13 +14,7 @@ public static class SubmitUrlExample
             return;
         }
 
-        using var httpClient = new HttpClient
-        {
-            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
-        };
-        httpClient.DefaultRequestHeaders.Add("x-apikey", apiKey);
-
-        var client = new VirusTotalClient(httpClient);
+        var client = VirusTotalClient.Create(apiKey);
         var analysis = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
         Console.WriteLine($"Submission status: {analysis?.Data.Attributes.Status}");
     }

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Reflection;
 using VirusTotalAnalyzer;
 using VirusTotalAnalyzer.Models;
 using Xunit;
@@ -12,6 +13,19 @@ namespace VirusTotalAnalyzer.Tests;
 
 public class VirusTotalClientTests
 {
+    [Fact]
+    public void Create_SetsBaseAddressAndHeader()
+    {
+        var client = VirusTotalClient.Create("demo-key");
+
+        var field = typeof(VirusTotalClient).GetField("_httpClient", BindingFlags.NonPublic | BindingFlags.Instance);
+        var httpClient = Assert.IsType<HttpClient>(field!.GetValue(client)!);
+
+        Assert.Equal(new Uri("https://www.virustotal.com/api/v3/"), httpClient.BaseAddress);
+        Assert.True(httpClient.DefaultRequestHeaders.TryGetValues("x-apikey", out var values));
+        Assert.Equal("demo-key", Assert.Single(values));
+    }
+
     [Fact]
     public async Task GetFileReportAsync_DeserializesResponse()
     {

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -31,6 +31,17 @@ public sealed class VirusTotalClient
         _jsonOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
     }
 
+    public static VirusTotalClient Create(string apiKey)
+    {
+        if (string.IsNullOrWhiteSpace(apiKey)) throw new ArgumentException("Value cannot be null or whitespace.", nameof(apiKey));
+        var httpClient = new HttpClient
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        httpClient.DefaultRequestHeaders.Add("x-apikey", apiKey);
+        return new VirusTotalClient(httpClient);
+    }
+
     public async Task<FileReport?> GetFileReportAsync(string id, CancellationToken cancellationToken = default)
     {
         using var response = await _httpClient.GetAsync($"files/{id}", cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- add `VirusTotalClient.Create` to configure base address and API key
- simplify examples to use new factory
- test factory behavior for base address and API key header

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6894ca5bfdec832e99c70d6c33f1b048