### PR TITLE
Add usage examples for VirusTotal client methods

### DIFF
--- a/VirusTotalAnalyzer.Examples/AddCommentExample.cs
+++ b/VirusTotalAnalyzer.Examples/AddCommentExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class AddCommentExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
-            Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
+            var comment = await client.AddCommentAsync(ResourceType.File, "file-id", "Nice file");
+            Console.WriteLine(comment?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/CreateCommentExample.cs
+++ b/VirusTotalAnalyzer.Examples/CreateCommentExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class CreateCommentExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
-            Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
+            var comment = await client.CreateCommentAsync(ResourceType.File, "file-id", "Nice file");
+            Console.WriteLine(comment?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/CreateVoteExample.cs
+++ b/VirusTotalAnalyzer.Examples/CreateVoteExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class CreateVoteExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
-            Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
+            var vote = await client.CreateVoteAsync(ResourceType.File, "file-id", VoteVerdict.Malicious);
+            Console.WriteLine(vote?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/DeleteExample.cs
+++ b/VirusTotalAnalyzer.Examples/DeleteExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class DeleteExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
-            Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
+            await client.DeleteAsync(ResourceType.File, "file-id");
+            Console.WriteLine("Deleted");
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/DeleteItemExample.cs
+++ b/VirusTotalAnalyzer.Examples/DeleteItemExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class DeleteItemExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
-            Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
+            await client.DeleteItemAsync(ResourceType.File, "file-id");
+            Console.WriteLine("Deleted");
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/GetAnalysisExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetAnalysisExample.cs
@@ -12,7 +12,7 @@ public static class GetAnalysisExample
         try
         {
             var report = await client.GetAnalysisAsync("analysis-id");
-            Console.WriteLine(report?.Data?.Id);
+            Console.WriteLine(report?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/GetAnalysisExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetAnalysisExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class GetAnalysisExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
+            var report = await client.GetAnalysisAsync("analysis-id");
             Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/GetCollectionExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetCollectionExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class GetCollectionExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
-            Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
+            var collection = await client.GetCollectionAsync("collection-id");
+            Console.WriteLine(collection?.Data?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/GetCollectionExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetCollectionExample.cs
@@ -12,7 +12,7 @@ public static class GetCollectionExample
         try
         {
             var collection = await client.GetCollectionAsync("collection-id");
-            Console.WriteLine(collection?.Data?.Id);
+            Console.WriteLine(collection?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/GetCommentsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetCommentsExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class GetCommentsExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
-            Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
+            var comments = await client.GetCommentsAsync(ResourceType.File, "file-id");
+            Console.WriteLine(comments?.Count);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/GetDomainReportExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetDomainReportExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class GetDomainReportExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
+            var report = await client.GetDomainReportAsync("example.com");
             Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/GetDomainReportExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetDomainReportExample.cs
@@ -12,7 +12,7 @@ public static class GetDomainReportExample
         try
         {
             var report = await client.GetDomainReportAsync("example.com");
-            Console.WriteLine(report?.Data?.Id);
+            Console.WriteLine(report?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/GetFeedExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFeedExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class GetFeedExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
-            Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
+            var feed = await client.GetFeedAsync(ResourceType.File);
+            Console.WriteLine(feed?.Data.Count);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/GetFileReportExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileReportExample.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
@@ -7,15 +8,19 @@ public static class GetFileReportExample
 {
     public static async Task RunAsync()
     {
-        var apiKey = Environment.GetEnvironmentVariable("VT_API_KEY");
-        if (string.IsNullOrWhiteSpace(apiKey))
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
         {
-            Console.WriteLine("VT_API_KEY environment variable is not set.");
-            return;
+            var report = await client.GetFileReportAsync("44d88612fea8a8f36de82e1278abb02f");
+            Console.WriteLine(report?.Data?.Id);
         }
-
-        var client = VirusTotalClient.Create(apiKey);
-        var report = await client.GetFileReportAsync("44d88612fea8a8f36de82e1278abb02f");
-        Console.WriteLine($"Sample file md5: {report?.Data.Attributes.Md5}, size: {report?.Data.Attributes.Size}");
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
     }
 }

--- a/VirusTotalAnalyzer.Examples/GetFileReportExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileReportExample.cs
@@ -12,7 +12,7 @@ public static class GetFileReportExample
         try
         {
             var report = await client.GetFileReportAsync("44d88612fea8a8f36de82e1278abb02f");
-            Console.WriteLine(report?.Data?.Id);
+            Console.WriteLine(report?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/GetGraphExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetGraphExample.cs
@@ -12,7 +12,7 @@ public static class GetGraphExample
         try
         {
             var graph = await client.GetGraphAsync("graph-id");
-            Console.WriteLine(graph?.Data?.Id);
+            Console.WriteLine(graph?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/GetGraphExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetGraphExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class GetGraphExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
-            Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
+            var graph = await client.GetGraphAsync("graph-id");
+            Console.WriteLine(graph?.Data?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/GetIpAddressReportExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetIpAddressReportExample.cs
@@ -12,7 +12,7 @@ public static class GetIpAddressReportExample
         try
         {
             var report = await client.GetIpAddressReportAsync("8.8.8.8");
-            Console.WriteLine(report?.Data?.Id);
+            Console.WriteLine(report?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/GetIpAddressReportExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetIpAddressReportExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class GetIpAddressReportExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
+            var report = await client.GetIpAddressReportAsync("8.8.8.8");
             Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/GetRelationshipsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetRelationshipsExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class GetRelationshipsExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
-            Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
+            var response = await client.GetRelationshipsAsync(ResourceType.File, "file-id", "comments");
+            Console.WriteLine(response?.Data.Count);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/GetUploadUrlExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetUploadUrlExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class GetUploadUrlExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
-            Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
+            var url = await client.GetUploadUrlAsync();
+            Console.WriteLine(url);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/GetUrlReportExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetUrlReportExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class GetUrlReportExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
+            var report = await client.GetUrlReportAsync("url-id");
             Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/GetUrlReportExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetUrlReportExample.cs
@@ -12,7 +12,7 @@ public static class GetUrlReportExample
         try
         {
             var report = await client.GetUrlReportAsync("url-id");
-            Console.WriteLine(report?.Data?.Id);
+            Console.WriteLine(report?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/GetUserExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetUserExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class GetUserExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
-            Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
+            var user = await client.GetUserAsync("user-id");
+            Console.WriteLine(user?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/GetVotesExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetVotesExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class GetVotesExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
-            Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
+            var votes = await client.GetVotesAsync(ResourceType.File, "file-id");
+            Console.WriteLine(votes?.Count);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/Program.cs
+++ b/VirusTotalAnalyzer.Examples/Program.cs
@@ -32,3 +32,5 @@ using VirusTotalAnalyzer.Examples;
 // await AddCommentExample.RunAsync();
 // await VoteExample.RunAsync();
 // await DeleteExample.RunAsync();
+
+await Task.CompletedTask;

--- a/VirusTotalAnalyzer.Examples/Program.cs
+++ b/VirusTotalAnalyzer.Examples/Program.cs
@@ -3,5 +3,32 @@ using VirusTotalAnalyzer.Examples;
 
 // Uncomment the example you want to run.
 
-await GetFileReportExample.RunAsync();
+// await GetFileReportExample.RunAsync();
+// await GetUrlReportExample.RunAsync();
+// await GetIpAddressReportExample.RunAsync();
+// await GetDomainReportExample.RunAsync();
+// await GetAnalysisExample.RunAsync();
+// await WaitForAnalysisCompletionExample.RunAsync();
+// await GetCommentsExample.RunAsync();
+// await GetVotesExample.RunAsync();
+// await CreateCommentExample.RunAsync();
+// await CreateVoteExample.RunAsync();
+// await DeleteItemExample.RunAsync();
+// await GetUserExample.RunAsync();
+// await GetGraphExample.RunAsync();
+// await GetCollectionExample.RunAsync();
+// await GetRelationshipsExample.RunAsync();
+// await SearchExample.RunAsync();
+// await GetFeedExample.RunAsync();
+// await GetUploadUrlExample.RunAsync();
+// await SubmitFileExample.RunAsync();
+// await SubmitFileSimpleExample.RunAsync();
+// await ReanalyzeHashExample.RunAsync();
+// await ReanalyzeFileExample.RunAsync();
+// await ReanalyzeUrlExample.RunAsync();
 // await SubmitUrlExample.RunAsync();
+// await ScanFileExample.RunAsync();
+// await ScanUrlExample.RunAsync();
+// await AddCommentExample.RunAsync();
+// await VoteExample.RunAsync();
+// await DeleteExample.RunAsync();

--- a/VirusTotalAnalyzer.Examples/ReanalyzeFileExample.cs
+++ b/VirusTotalAnalyzer.Examples/ReanalyzeFileExample.cs
@@ -12,7 +12,7 @@ public static class ReanalyzeFileExample
         try
         {
             var report = await client.ReanalyzeFileAsync("44d88612fea8a8f36de82e1278abb02f");
-            Console.WriteLine(report?.Data?.Id);
+            Console.WriteLine(report?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/ReanalyzeFileExample.cs
+++ b/VirusTotalAnalyzer.Examples/ReanalyzeFileExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class ReanalyzeFileExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
+            var report = await client.ReanalyzeFileAsync("44d88612fea8a8f36de82e1278abb02f");
             Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/ReanalyzeHashExample.cs
+++ b/VirusTotalAnalyzer.Examples/ReanalyzeHashExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class ReanalyzeHashExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
+            var report = await client.ReanalyzeHashAsync("44d88612fea8a8f36de82e1278abb02f", AnalysisType.File);
             Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/ReanalyzeHashExample.cs
+++ b/VirusTotalAnalyzer.Examples/ReanalyzeHashExample.cs
@@ -12,7 +12,7 @@ public static class ReanalyzeHashExample
         try
         {
             var report = await client.ReanalyzeHashAsync("44d88612fea8a8f36de82e1278abb02f", AnalysisType.File);
-            Console.WriteLine(report?.Data?.Id);
+            Console.WriteLine(report?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/ReanalyzeUrlExample.cs
+++ b/VirusTotalAnalyzer.Examples/ReanalyzeUrlExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class ReanalyzeUrlExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
+            var report = await client.ReanalyzeUrlAsync("url-id");
             Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/ReanalyzeUrlExample.cs
+++ b/VirusTotalAnalyzer.Examples/ReanalyzeUrlExample.cs
@@ -12,7 +12,7 @@ public static class ReanalyzeUrlExample
         try
         {
             var report = await client.ReanalyzeUrlAsync("url-id");
-            Console.WriteLine(report?.Data?.Id);
+            Console.WriteLine(report?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/ScanFileExample.cs
+++ b/VirusTotalAnalyzer.Examples/ScanFileExample.cs
@@ -1,21 +1,26 @@
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class ScanFileExample
 {
     public static async Task RunAsync()
     {
+        var path = "sample.txt";
+        if (!File.Exists(path))
+        {
+            Console.WriteLine($"File not found: {path}");
+            return;
+        }
+
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
+            var report = await client.ScanFileAsync(path);
             Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/ScanFileExample.cs
+++ b/VirusTotalAnalyzer.Examples/ScanFileExample.cs
@@ -20,7 +20,7 @@ public static class ScanFileExample
         try
         {
             var report = await client.ScanFileAsync(path);
-            Console.WriteLine(report?.Data?.Id);
+            Console.WriteLine(report?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/ScanUrlExample.cs
+++ b/VirusTotalAnalyzer.Examples/ScanUrlExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class ScanUrlExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
+            var report = await client.ScanUrlAsync("https://example.com");
             Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/ScanUrlExample.cs
+++ b/VirusTotalAnalyzer.Examples/ScanUrlExample.cs
@@ -12,7 +12,7 @@ public static class ScanUrlExample
         try
         {
             var report = await client.ScanUrlAsync("https://example.com");
-            Console.WriteLine(report?.Data?.Id);
+            Console.WriteLine(report?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/SearchExample.cs
+++ b/VirusTotalAnalyzer.Examples/SearchExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class SearchExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
-            Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
+            var response = await client.SearchAsync("type:file");
+            Console.WriteLine(response?.Data.Count);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/SubmitFileExample.cs
+++ b/VirusTotalAnalyzer.Examples/SubmitFileExample.cs
@@ -1,21 +1,31 @@
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class SubmitFileExample
 {
     public static async Task RunAsync()
     {
+        var path = "sample.txt";
+        if (!File.Exists(path))
+        {
+            Console.WriteLine($"File not found: {path}");
+            return;
+        }
+
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
+#if NET472
+            using var stream = File.OpenRead(path);
+#else
+            await using var stream = File.OpenRead(path);
+#endif
+            var report = await client.SubmitFileAsync(stream, Path.GetFileName(path), AnalysisType.File);
             Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/SubmitFileExample.cs
+++ b/VirusTotalAnalyzer.Examples/SubmitFileExample.cs
@@ -25,7 +25,7 @@ public static class SubmitFileExample
             await using var stream = File.OpenRead(path);
 #endif
             var report = await client.SubmitFileAsync(stream, Path.GetFileName(path), AnalysisType.File);
-            Console.WriteLine(report?.Data?.Id);
+            Console.WriteLine(report?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/SubmitFileSimpleExample.cs
+++ b/VirusTotalAnalyzer.Examples/SubmitFileSimpleExample.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using VirusTotalAnalyzer.Models;
 
@@ -24,8 +25,8 @@ public static class SubmitFileSimpleExample
 #else
             await using var stream = File.OpenRead(path);
 #endif
-            var report = await client.SubmitFileAsync(stream, Path.GetFileName(path));
-            Console.WriteLine(report?.Data?.Id);
+            var report = await client.SubmitFileAsync(stream, Path.GetFileName(path), CancellationToken.None);
+            Console.WriteLine(report?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/SubmitFileSimpleExample.cs
+++ b/VirusTotalAnalyzer.Examples/SubmitFileSimpleExample.cs
@@ -1,21 +1,31 @@
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class SubmitFileSimpleExample
 {
     public static async Task RunAsync()
     {
+        var path = "sample.txt";
+        if (!File.Exists(path))
+        {
+            Console.WriteLine($"File not found: {path}");
+            return;
+        }
+
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
+#if NET472
+            using var stream = File.OpenRead(path);
+#else
+            await using var stream = File.OpenRead(path);
+#endif
+            var report = await client.SubmitFileAsync(stream, Path.GetFileName(path));
             Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/SubmitUrlExample.cs
+++ b/VirusTotalAnalyzer.Examples/SubmitUrlExample.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using VirusTotalAnalyzer.Models;
 
@@ -12,10 +13,10 @@ public static class SubmitUrlExample
         try
         {
             var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
-            Console.WriteLine(report?.Data?.Id);
+            Console.WriteLine(report?.Id);
 
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
+            var simple = await client.SubmitUrlAsync("https://example.org", CancellationToken.None);
+            Console.WriteLine(simple?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/VoteExample.cs
+++ b/VirusTotalAnalyzer.Examples/VoteExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class VoteExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
-            Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
+            var vote = await client.VoteAsync(ResourceType.File, "file-id", VoteVerdict.Malicious);
+            Console.WriteLine(vote?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/WaitForAnalysisCompletionExample.cs
+++ b/VirusTotalAnalyzer.Examples/WaitForAnalysisCompletionExample.cs
@@ -4,18 +4,15 @@ using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class SubmitUrlExample
+public static class WaitForAnalysisCompletionExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
+            var report = await client.WaitForAnalysisCompletionAsync("analysis-id", TimeSpan.FromSeconds(30));
             Console.WriteLine(report?.Data?.Id);
-
-            var simple = await client.SubmitUrlAsync("https://example.org");
-            Console.WriteLine(simple?.Data?.Id);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/WaitForAnalysisCompletionExample.cs
+++ b/VirusTotalAnalyzer.Examples/WaitForAnalysisCompletionExample.cs
@@ -12,7 +12,7 @@ public static class WaitForAnalysisCompletionExample
         try
         {
             var report = await client.WaitForAnalysisCompletionAsync("analysis-id", TimeSpan.FromSeconds(30));
-            Console.WriteLine(report?.Data?.Id);
+            Console.WriteLine(report?.Id);
         }
         catch (RateLimitExceededException ex)
         {


### PR DESCRIPTION
## Summary
- Expand sample coverage with example files for each VirusTotalClient and VirusTotalClientExtensions method
- Demonstrate enum-based parameters and API error handling in examples
- Reference all examples from Program.cs for easy execution

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6894dc30beb4832ea8c3070b1fc21388