### PR TITLE
Add fluent request builders for comments and votes

### DIFF
--- a/VirusTotalAnalyzer.Examples/CreateCommentWithBuilderExample.cs
+++ b/VirusTotalAnalyzer.Examples/CreateCommentWithBuilderExample.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class CreateCommentWithBuilderExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR-API-KEY");
+
+        var request = new CommentRequestBuilder()
+            .WithText("Nice file")
+            .Build();
+
+        var comment = await client.CreateCommentAsync(ResourceType.File, "file-id", request);
+        _ = comment;
+    }
+}
+

--- a/VirusTotalAnalyzer.Examples/Program.cs
+++ b/VirusTotalAnalyzer.Examples/Program.cs
@@ -12,6 +12,7 @@ using VirusTotalAnalyzer.Examples;
 // await GetCommentsExample.RunAsync();
 // await GetVotesExample.RunAsync();
 // await CreateCommentExample.RunAsync();
+// await CreateCommentWithBuilderExample.RunAsync();
 // await CreateVoteExample.RunAsync();
 // await DeleteItemExample.RunAsync();
 // await GetUserExample.RunAsync();

--- a/VirusTotalAnalyzer.Tests/RequestBuilderTests.cs
+++ b/VirusTotalAnalyzer.Tests/RequestBuilderTests.cs
@@ -1,0 +1,29 @@
+using VirusTotalAnalyzer;
+using VirusTotalAnalyzer.Models;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public class RequestBuilderTests
+{
+    [Fact]
+    public void CommentRequestBuilder_SetsText()
+    {
+        var request = new CommentRequestBuilder()
+            .WithText("hello")
+            .Build();
+
+        Assert.Equal("hello", request.Data.Attributes.Text);
+    }
+
+    [Fact]
+    public void VoteRequestBuilder_SetsVerdict()
+    {
+        var request = new VoteRequestBuilder()
+            .WithVerdict(VoteVerdict.Harmless)
+            .Build();
+
+        Assert.Equal(VoteVerdict.Harmless, request.Data.Attributes.Verdict);
+    }
+}
+

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientBuilderTests.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientBuilderTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer;
+using VirusTotalAnalyzer.Models;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public class VirusTotalClientBuilderTests
+{
+    [Fact]
+    public async Task CreateCommentAsync_WithRequest_PostsComment()
+    {
+        var json = @"{""data"":{""id"":""c1"",""type"":""comment"",""data"":{""attributes"":{""date"":1,""text"":""hello""}}}}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var request = new CommentRequestBuilder()
+            .WithText("hello")
+            .Build();
+        var comment = await client.CreateCommentAsync(ResourceType.File, "abc", request);
+
+        Assert.NotNull(comment);
+        Assert.Single(handler.Requests);
+        Assert.Equal("/api/v3/files/abc/comments", handler.Requests[0].RequestUri!.AbsolutePath);
+        Assert.Contains("\"text\":\"hello\"", handler.Contents[0]);
+    }
+
+    [Fact]
+    public async Task CreateVoteAsync_WithRequest_PostsVerdict()
+    {
+        var json = @"{""data"":{""id"":""v1"",""type"":""vote"",""data"":{""attributes"":{""date"":1,""verdict"":""malicious""}}}}";
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var request = new VoteRequestBuilder()
+            .WithVerdict(VoteVerdict.Malicious)
+            .Build();
+        var vote = await client.CreateVoteAsync(ResourceType.File, "abc", request);
+
+        Assert.NotNull(vote);
+        Assert.Single(handler.Requests);
+        Assert.Equal("/api/v3/files/abc/votes", handler.Requests[0].RequestUri!.AbsolutePath);
+        Assert.Contains("\"verdict\":\"malicious\"", handler.Contents[0]);
+}
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly System.Collections.Generic.Queue<HttpResponseMessage> _responses;
+        public System.Collections.Generic.List<HttpRequestMessage> Requests { get; } = new();
+        public System.Collections.Generic.List<string?> Contents { get; } = new();
+
+        public RecordingHandler(params HttpResponseMessage[] responses)
+            => _responses = new System.Collections.Generic.Queue<HttpResponseMessage>(responses);
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            if (request.Content != null)
+            {
+#if NETFRAMEWORK
+                var text = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+#else
+                var text = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#endif
+                Contents.Add(text);
+            }
+            else
+            {
+                Contents.Add(null);
+            }
+            return _responses.Dequeue();
+        }
+    }
+}
+

--- a/VirusTotalAnalyzer/CommentRequestBuilder.cs
+++ b/VirusTotalAnalyzer/CommentRequestBuilder.cs
@@ -1,0 +1,27 @@
+using System;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer;
+
+/// <summary>
+/// Builds a <see cref="CreateCommentRequest"/> using a fluent API.
+/// </summary>
+public sealed class CommentRequestBuilder
+{
+    private readonly CreateCommentRequest _request = new();
+
+    /// <summary>
+    /// Sets the comment text.
+    /// </summary>
+    public CommentRequestBuilder WithText(string text)
+    {
+        _request.Data.Attributes.Text = text ?? throw new ArgumentNullException(nameof(text));
+        return this;
+    }
+
+    /// <summary>
+    /// Builds the request.
+    /// </summary>
+    public CreateCommentRequest Build() => _request;
+}
+

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -166,15 +166,16 @@ public sealed class VirusTotalClient
         return result?.Data;
     }
 
-    public async Task<Comment?> CreateCommentAsync(ResourceType resourceType, string id, string text, CancellationToken cancellationToken = default)
+    public Task<Comment?> CreateCommentAsync(ResourceType resourceType, string id, string text, CancellationToken cancellationToken = default)
     {
-        var request = new CreateCommentRequest
-        {
-            Data = new CreateCommentData
-            {
-                Attributes = new CreateCommentAttributes { Text = text }
-            }
-        };
+        var request = new CommentRequestBuilder()
+            .WithText(text)
+            .Build();
+        return CreateCommentAsync(resourceType, id, request, cancellationToken);
+    }
+
+    public async Task<Comment?> CreateCommentAsync(ResourceType resourceType, string id, CreateCommentRequest request, CancellationToken cancellationToken = default)
+    {
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var response = await _httpClient.PostAsync($"{GetPath(resourceType)}/{id}/comments", content, cancellationToken).ConfigureAwait(false);
@@ -188,15 +189,16 @@ public sealed class VirusTotalClient
         return result?.Data;
     }
 
-    public async Task<Vote?> CreateVoteAsync(ResourceType resourceType, string id, VoteVerdict verdict, CancellationToken cancellationToken = default)
+    public Task<Vote?> CreateVoteAsync(ResourceType resourceType, string id, VoteVerdict verdict, CancellationToken cancellationToken = default)
     {
-        var request = new CreateVoteRequest
-        {
-            Data = new CreateVoteData
-            {
-                Attributes = new CreateVoteAttributes { Verdict = verdict }
-            }
-        };
+        var request = new VoteRequestBuilder()
+            .WithVerdict(verdict)
+            .Build();
+        return CreateVoteAsync(resourceType, id, request, cancellationToken);
+    }
+
+    public async Task<Vote?> CreateVoteAsync(ResourceType resourceType, string id, CreateVoteRequest request, CancellationToken cancellationToken = default)
+    {
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var response = await _httpClient.PostAsync($"{GetPath(resourceType)}/{id}/votes", content, cancellationToken).ConfigureAwait(false);

--- a/VirusTotalAnalyzer/VirusTotalClientExtensions.cs
+++ b/VirusTotalAnalyzer/VirusTotalClientExtensions.cs
@@ -44,10 +44,22 @@ public static class VirusTotalClientExtensions
         return client.CreateCommentAsync(resourceType, id, text, cancellationToken);
     }
 
+    public static Task<Comment?> AddCommentAsync(this VirusTotalClient client, ResourceType resourceType, string id, CreateCommentRequest request, CancellationToken cancellationToken = default)
+    {
+        if (client == null) throw new ArgumentNullException(nameof(client));
+        return client.CreateCommentAsync(resourceType, id, request, cancellationToken);
+    }
+
     public static Task<Vote?> VoteAsync(this VirusTotalClient client, ResourceType resourceType, string id, VoteVerdict verdict, CancellationToken cancellationToken = default)
     {
         if (client == null) throw new ArgumentNullException(nameof(client));
         return client.CreateVoteAsync(resourceType, id, verdict, cancellationToken);
+    }
+
+    public static Task<Vote?> VoteAsync(this VirusTotalClient client, ResourceType resourceType, string id, CreateVoteRequest request, CancellationToken cancellationToken = default)
+    {
+        if (client == null) throw new ArgumentNullException(nameof(client));
+        return client.CreateVoteAsync(resourceType, id, request, cancellationToken);
     }
 
     public static Task DeleteAsync(this VirusTotalClient client, ResourceType resourceType, string id, CancellationToken cancellationToken = default)

--- a/VirusTotalAnalyzer/VoteRequestBuilder.cs
+++ b/VirusTotalAnalyzer/VoteRequestBuilder.cs
@@ -1,0 +1,26 @@
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer;
+
+/// <summary>
+/// Builds a <see cref="CreateVoteRequest"/> using a fluent API.
+/// </summary>
+public sealed class VoteRequestBuilder
+{
+    private readonly CreateVoteRequest _request = new();
+
+    /// <summary>
+    /// Sets the vote verdict.
+    /// </summary>
+    public VoteRequestBuilder WithVerdict(VoteVerdict verdict)
+    {
+        _request.Data.Attributes.Verdict = verdict;
+        return this;
+    }
+
+    /// <summary>
+    /// Builds the request.
+    /// </summary>
+    public CreateVoteRequest Build() => _request;
+}
+


### PR DESCRIPTION
## Summary
- add fluent builder classes for composing comment and vote requests
- allow client methods and extensions to accept pre-built requests
- document and test builder usage

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6894ec0ad600832eb64920b49fd06e5b