### PR TITLE
Refactor tests to use dedicated fake handlers

### DIFF
--- a/VirusTotalAnalyzer.Tests/QueueHandler.cs
+++ b/VirusTotalAnalyzer.Tests/QueueHandler.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VirusTotalAnalyzer.Tests;
+
+internal sealed class QueueHandler : HttpMessageHandler
+{
+    private readonly Queue<HttpResponseMessage> _responses;
+
+    public List<HttpRequestMessage> Requests { get; } = new();
+    public List<string?> Contents { get; } = new();
+
+    public QueueHandler(params HttpResponseMessage[] responses)
+        => _responses = new Queue<HttpResponseMessage>(responses);
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        Requests.Add(request);
+        if (request.Content != null)
+        {
+#if NETFRAMEWORK
+            var text = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+#else
+            var text = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#endif
+            Contents.Add(text);
+        }
+        else
+        {
+            Contents.Add(null);
+        }
+        return _responses.Dequeue();
+    }
+}

--- a/VirusTotalAnalyzer.Tests/SingleResponseHandler.cs
+++ b/VirusTotalAnalyzer.Tests/SingleResponseHandler.cs
@@ -1,0 +1,29 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VirusTotalAnalyzer.Tests;
+
+internal sealed class SingleResponseHandler : HttpMessageHandler
+{
+    private readonly HttpResponseMessage _response;
+
+    public HttpRequestMessage? Request { get; private set; }
+    public string? Content { get; private set; }
+
+    public SingleResponseHandler(HttpResponseMessage response) => _response = response;
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        Request = request;
+        if (request.Content != null)
+        {
+#if NETFRAMEWORK
+            Content = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+#else
+            Content = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        }
+        return _response;
+    }
+}

--- a/VirusTotalAnalyzer.Tests/StubHandler.cs
+++ b/VirusTotalAnalyzer.Tests/StubHandler.cs
@@ -1,0 +1,19 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VirusTotalAnalyzer.Tests;
+
+internal sealed class StubHandler : HttpMessageHandler
+{
+    private readonly string _response;
+
+    public StubHandler(string response) => _response = response;
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(_response, System.Text.Encoding.UTF8, "application/json")
+        });
+}


### PR DESCRIPTION
## Summary
- add reusable StubHandler, SingleResponseHandler, and QueueHandler for test HTTP mocking
- refactor VirusTotalClientTests to leverage new handlers and check request details
- expand client tests to cover rate-limit and timeout scenarios

## Testing
- `dotnet build VirusTotalAnalyzer.sln`
- `dotnet test VirusTotalAnalyzer.sln`


------
https://chatgpt.com/codex/tasks/task_e_6894ec069050832eaf895295ac8fe4c8