### PR TITLE
Add support for livehunt and retrohunt resources

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetLivehuntNotificationExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetLivehuntNotificationExample.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetLivehuntNotificationExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var notification = await client.GetLivehuntNotificationAsync("notification-id");
+            Console.WriteLine(notification?.Id);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.cs
@@ -398,4 +398,172 @@ public class VirusTotalClientTests
         Assert.Equal(TimeSpan.FromSeconds(10), ex.RetryAfter);
         Assert.Equal(123, ex.RemainingQuota);
     }
+
+    [Fact]
+    public async Task GetLivehuntNotificationAsync_DeserializesResponse()
+    {
+        var json = "{\"id\":\"ln1\",\"type\":\"livehuntNotification\",\"data\":{\"attributes\":{\"rule_name\":\"r1\"}}}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var notification = await client.GetLivehuntNotificationAsync("ln1");
+
+        Assert.NotNull(notification);
+        Assert.Equal("ln1", notification!.Id);
+        Assert.Equal("r1", notification.Data.Attributes.RuleName);
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/livehunt_notifications/ln1", handler.Request!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task GetLivehuntNotificationAsync_ThrowsApiException()
+    {
+        var errorJson = @"{""error"":{""code"":""NotFoundError"",""message"":""not found""}}";
+        var response = new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent(errorJson, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/" )
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await Assert.ThrowsAsync<ApiException>(() => client.GetLivehuntNotificationAsync("ln1"));
+    }
+
+    [Fact]
+    public async Task GetRetrohuntJobAsync_DeserializesResponse()
+    {
+        var json = "{\"id\":\"rj1\",\"type\":\"retrohuntJob\",\"data\":{\"attributes\":{\"status\":\"done\"}}}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var job = await client.GetRetrohuntJobAsync("rj1");
+
+        Assert.NotNull(job);
+        Assert.Equal("rj1", job!.Id);
+        Assert.Equal("done", job.Data.Attributes.Status);
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/retrohunt_jobs/rj1", handler.Request!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task GetRetrohuntJobAsync_ThrowsApiException()
+    {
+        var errorJson = @"{""error"":{""code"":""NotFoundError"",""message"":""not found""}}";
+        var response = new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent(errorJson, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await Assert.ThrowsAsync<ApiException>(() => client.GetRetrohuntJobAsync("rj1"));
+    }
+
+    [Fact]
+    public async Task GetRetrohuntNotificationAsync_DeserializesResponse()
+    {
+        var json = "{\"id\":\"rn1\",\"type\":\"retrohuntNotification\",\"data\":{\"attributes\":{\"job_id\":\"j1\"}}}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var notification = await client.GetRetrohuntNotificationAsync("rn1");
+
+        Assert.NotNull(notification);
+        Assert.Equal("rn1", notification!.Id);
+        Assert.Equal("j1", notification.Data.Attributes.JobId);
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/retrohunt_notifications/rn1", handler.Request!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task GetRetrohuntNotificationAsync_ThrowsApiException()
+    {
+        var errorJson = @"{""error"":{""code"":""NotFoundError"",""message"":""not found""}}";
+        var response = new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent(errorJson, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await Assert.ThrowsAsync<ApiException>(() => client.GetRetrohuntNotificationAsync("rn1"));
+    }
+
+    [Fact]
+    public async Task GetMonitorItemAsync_DeserializesResponse()
+    {
+        var json = "{\"id\":\"mi1\",\"type\":\"monitorItem\",\"data\":{\"attributes\":{\"path\":\"/tmp\"}}}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var item = await client.GetMonitorItemAsync("mi1");
+
+        Assert.NotNull(item);
+        Assert.Equal("mi1", item!.Id);
+        Assert.Equal("/tmp", item.Data.Attributes.Path);
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/monitor/items/mi1", handler.Request!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task GetMonitorItemAsync_ThrowsApiException()
+    {
+        var errorJson = @"{""error"":{""code"":""NotFoundError"",""message"":""not found""}}";
+        var response = new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent(errorJson, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await Assert.ThrowsAsync<ApiException>(() => client.GetMonitorItemAsync("mi1"));
+    }
 }

--- a/VirusTotalAnalyzer/Models/LivehuntNotification.cs
+++ b/VirusTotalAnalyzer/Models/LivehuntNotification.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class LivehuntNotification
+{
+    public string Id { get; set; } = string.Empty;
+    public ResourceType Type { get; set; }
+    public LivehuntNotificationData Data { get; set; } = new();
+}
+
+public sealed class LivehuntNotificationData
+{
+    public LivehuntNotificationAttributes Attributes { get; set; } = new();
+}
+
+public sealed class LivehuntNotificationAttributes
+{
+    [JsonPropertyName("rule_name")]
+    public string RuleName { get; set; } = string.Empty;
+}

--- a/VirusTotalAnalyzer/Models/MonitorItem.cs
+++ b/VirusTotalAnalyzer/Models/MonitorItem.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class MonitorItem
+{
+    public string Id { get; set; } = string.Empty;
+    public ResourceType Type { get; set; }
+    public MonitorItemData Data { get; set; } = new();
+}
+
+public sealed class MonitorItemData
+{
+    public MonitorItemAttributes Attributes { get; set; } = new();
+}
+
+public sealed class MonitorItemAttributes
+{
+    [JsonPropertyName("path")]
+    public string Path { get; set; } = string.Empty;
+}

--- a/VirusTotalAnalyzer/Models/RetrohuntJob.cs
+++ b/VirusTotalAnalyzer/Models/RetrohuntJob.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class RetrohuntJob
+{
+    public string Id { get; set; } = string.Empty;
+    public ResourceType Type { get; set; }
+    public RetrohuntJobData Data { get; set; } = new();
+}
+
+public sealed class RetrohuntJobData
+{
+    public RetrohuntJobAttributes Attributes { get; set; } = new();
+}
+
+public sealed class RetrohuntJobAttributes
+{
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = string.Empty;
+}

--- a/VirusTotalAnalyzer/Models/RetrohuntNotification.cs
+++ b/VirusTotalAnalyzer/Models/RetrohuntNotification.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class RetrohuntNotification
+{
+    public string Id { get; set; } = string.Empty;
+    public ResourceType Type { get; set; }
+    public RetrohuntNotificationData Data { get; set; } = new();
+}
+
+public sealed class RetrohuntNotificationData
+{
+    public RetrohuntNotificationAttributes Attributes { get; set; } = new();
+}
+
+public sealed class RetrohuntNotificationAttributes
+{
+    [JsonPropertyName("job_id")]
+    public string JobId { get; set; } = string.Empty;
+}

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -254,6 +254,54 @@ public sealed class VirusTotalClient
         return await JsonSerializer.DeserializeAsync<Collection>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task<LivehuntNotification?> GetLivehuntNotificationAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.LivehuntNotification)}/{id}", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<LivehuntNotification>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<RetrohuntJob?> GetRetrohuntJobAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.RetrohuntJob)}/{id}", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<RetrohuntJob>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<RetrohuntNotification?> GetRetrohuntNotificationAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.RetrohuntNotification)}/{id}", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<RetrohuntNotification>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<MonitorItem?> GetMonitorItemAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.MonitorItem)}/{id}", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<MonitorItem>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task<RelationshipResponse?> GetRelationshipsAsync(ResourceType resourceType, string id, string relationship, CancellationToken cancellationToken = default)
     {
         using var response = await _httpClient.GetAsync($"{GetPath(resourceType)}/{id}/relationships/{relationship}", cancellationToken).ConfigureAwait(false);
@@ -408,10 +456,20 @@ public sealed class VirusTotalClient
             ResourceType.IpAddress => "ip_addresses",
             ResourceType.Domain => "domains",
             ResourceType.Analysis => "analyses",
+            ResourceType.PrivateAnalysis => "private/analyses",
+            ResourceType.Comment => "comments",
+            ResourceType.Vote => "votes",
+            ResourceType.Relationship => "relationships",
+            ResourceType.Search => "intelligence/search",
+            ResourceType.Feed => "feeds",
             ResourceType.Graph => "graphs",
             ResourceType.User => "users",
             ResourceType.Collection => "collections",
             ResourceType.Bundle => "bundles",
+            ResourceType.LivehuntNotification => "livehunt_notifications",
+            ResourceType.RetrohuntJob => "retrohunt_jobs",
+            ResourceType.RetrohuntNotification => "retrohunt_notifications",
+            ResourceType.MonitorItem => "monitor/items",
             _ => throw new ArgumentOutOfRangeException(nameof(type))
         };
 


### PR DESCRIPTION
## Summary
- map all ResourceType values to API paths
- add client APIs and models for livehunt notifications, retrohunt jobs/notifications, and monitor items
- cover new endpoints with unit tests and an example

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689616b25cc0832e8079c2800338fe28