### PR TITLE
Use DateTimeOffset for timestamps

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetFileReportExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileReportExample.cs
@@ -13,6 +13,7 @@ public static class GetFileReportExample
         {
             var report = await client.GetFileReportAsync("44d88612fea8a8f36de82e1278abb02f");
             Console.WriteLine(report?.Id);
+            Console.WriteLine(report?.Data?.Attributes.CreationDate);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Tests/AttributeSerializationTests.cs
+++ b/VirusTotalAnalyzer.Tests/AttributeSerializationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using VirusTotalAnalyzer;
@@ -11,6 +12,9 @@ public class AttributeSerializationTests
     [Fact]
     public void FileAttributes_Roundtrip()
     {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new UnixTimestampConverter());
+
         var report = new FileReport
         {
             Id = "file1",
@@ -21,13 +25,13 @@ public class AttributeSerializationTests
                 {
                     Md5 = "md5",
                     Reputation = 1,
-                    CreationDate = 42,
+                    CreationDate = DateTimeOffset.FromUnixTimeSeconds(42),
                     Tags = new List<string> { "tag" },
                     Size = 100,
-                    FirstSubmissionDate = 10,
+                    FirstSubmissionDate = DateTimeOffset.FromUnixTimeSeconds(10),
                     CrowdsourcedVerdicts =
                     {
-                        new CrowdsourcedVerdict { Source = "cs", Verdict = Verdict.Harmless, Timestamp = 1 }
+                        new CrowdsourcedVerdict { Source = "cs", Verdict = Verdict.Harmless, Timestamp = DateTimeOffset.FromUnixTimeSeconds(1) }
                     },
                     LastAnalysisResults = new Dictionary<string, AnalysisResult>
                     {
@@ -37,19 +41,22 @@ public class AttributeSerializationTests
             }
         };
 
-        var json = JsonSerializer.Serialize(report);
-        var roundtrip = JsonSerializer.Deserialize<FileReport>(json);
-        Assert.Equal(42, roundtrip!.Data.Attributes.CreationDate);
+        var json = JsonSerializer.Serialize(report, options);
+        var roundtrip = JsonSerializer.Deserialize<FileReport>(json, options);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(42), roundtrip!.Data.Attributes.CreationDate);
         Assert.Equal("tag", Assert.Single(roundtrip.Data.Attributes.Tags));
         Assert.Equal("harmless", roundtrip.Data.Attributes.LastAnalysisResults["engine"].Category);
         Assert.Equal(100, roundtrip.Data.Attributes.Size);
-        Assert.Equal(10, roundtrip.Data.Attributes.FirstSubmissionDate);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(10), roundtrip.Data.Attributes.FirstSubmissionDate);
         Assert.Equal(Verdict.Harmless, roundtrip.Data.Attributes.CrowdsourcedVerdicts[0].Verdict);
     }
 
     [Fact]
     public void UrlAttributes_Roundtrip()
     {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new UnixTimestampConverter());
+
         var report = new UrlReport
         {
             Id = "url1",
@@ -60,12 +67,12 @@ public class AttributeSerializationTests
                 {
                     Url = "https://example.com",
                     Reputation = 2,
-                    CreationDate = 84,
+                    CreationDate = DateTimeOffset.FromUnixTimeSeconds(84),
                     Tags = new List<string> { "tag" },
-                    FirstSubmissionDate = 11,
+                    FirstSubmissionDate = DateTimeOffset.FromUnixTimeSeconds(11),
                     CrowdsourcedVerdicts =
                     {
-                        new CrowdsourcedVerdict { Source = "cs", Verdict = Verdict.Malicious, Timestamp = 2 }
+                        new CrowdsourcedVerdict { Source = "cs", Verdict = Verdict.Malicious, Timestamp = DateTimeOffset.FromUnixTimeSeconds(2) }
                     },
                     LastAnalysisResults = new Dictionary<string, AnalysisResult>
                     {
@@ -75,18 +82,21 @@ public class AttributeSerializationTests
             }
         };
 
-        var json = JsonSerializer.Serialize(report);
-        var roundtrip = JsonSerializer.Deserialize<UrlReport>(json);
-        Assert.Equal(84, roundtrip!.Data.Attributes.CreationDate);
+        var json = JsonSerializer.Serialize(report, options);
+        var roundtrip = JsonSerializer.Deserialize<UrlReport>(json, options);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(84), roundtrip!.Data.Attributes.CreationDate);
         Assert.Equal("tag", Assert.Single(roundtrip.Data.Attributes.Tags));
         Assert.Equal("malicious", roundtrip.Data.Attributes.LastAnalysisResults["engine"].Category);
-        Assert.Equal(11, roundtrip.Data.Attributes.FirstSubmissionDate);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(11), roundtrip.Data.Attributes.FirstSubmissionDate);
         Assert.Equal(Verdict.Malicious, roundtrip.Data.Attributes.CrowdsourcedVerdicts[0].Verdict);
     }
 
     [Fact]
     public void AnalysisAttributes_Roundtrip()
     {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new UnixTimestampConverter());
+
         var report = new AnalysisReport
         {
             Id = "an1",
@@ -96,7 +106,7 @@ public class AttributeSerializationTests
                 Attributes = new AnalysisAttributes
                 {
                     Status = AnalysisStatus.Completed,
-                    Date = 5,
+                    Date = DateTimeOffset.FromUnixTimeSeconds(5),
                     Results = new Dictionary<string, AnalysisResult>
                     {
                         ["engine"] = new AnalysisResult { Category = "harmless", EngineName = "engine" }
@@ -105,15 +115,18 @@ public class AttributeSerializationTests
             }
         };
 
-        var json = JsonSerializer.Serialize(report);
-        var roundtrip = JsonSerializer.Deserialize<AnalysisReport>(json);
-        Assert.Equal(5, roundtrip!.Data.Attributes.Date);
+        var json = JsonSerializer.Serialize(report, options);
+        var roundtrip = JsonSerializer.Deserialize<AnalysisReport>(json, options);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(5), roundtrip!.Data.Attributes.Date);
         Assert.Equal("harmless", roundtrip.Data.Attributes.Results["engine"].Category);
     }
 
     [Fact]
     public void DomainAttributes_Roundtrip()
     {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new UnixTimestampConverter());
+
         var report = new DomainReport
         {
             Id = "domain1",
@@ -124,7 +137,7 @@ public class AttributeSerializationTests
                 {
                     Domain = "example.com",
                     Reputation = 3,
-                    CreationDate = 21,
+                    CreationDate = DateTimeOffset.FromUnixTimeSeconds(21),
                     Tags = new List<string> { "tag" },
                     LastAnalysisResults = new Dictionary<string, AnalysisResult>
                     {
@@ -134,9 +147,9 @@ public class AttributeSerializationTests
             }
         };
 
-        var json = JsonSerializer.Serialize(report);
-        var roundtrip = JsonSerializer.Deserialize<DomainReport>(json);
-        Assert.Equal(21, roundtrip!.Data.Attributes.CreationDate);
+        var json = JsonSerializer.Serialize(report, options);
+        var roundtrip = JsonSerializer.Deserialize<DomainReport>(json, options);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(21), roundtrip!.Data.Attributes.CreationDate);
         Assert.Equal("tag", Assert.Single(roundtrip.Data.Attributes.Tags));
         Assert.Equal("suspicious", roundtrip.Data.Attributes.LastAnalysisResults["engine"].Category);
     }
@@ -144,6 +157,9 @@ public class AttributeSerializationTests
     [Fact]
     public void IpAddressAttributes_Roundtrip()
     {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new UnixTimestampConverter());
+
         var report = new IpAddressReport
         {
             Id = "ip1",
@@ -154,7 +170,7 @@ public class AttributeSerializationTests
                 {
                     IpAddress = "1.2.3.4",
                     Reputation = 4,
-                    CreationDate = 63,
+                    CreationDate = DateTimeOffset.FromUnixTimeSeconds(63),
                     Tags = new List<string> { "tag" },
                     LastAnalysisResults = new Dictionary<string, AnalysisResult>
                     {
@@ -164,9 +180,9 @@ public class AttributeSerializationTests
             }
         };
 
-        var json = JsonSerializer.Serialize(report);
-        var roundtrip = JsonSerializer.Deserialize<IpAddressReport>(json);
-        Assert.Equal(63, roundtrip!.Data.Attributes.CreationDate);
+        var json = JsonSerializer.Serialize(report, options);
+        var roundtrip = JsonSerializer.Deserialize<IpAddressReport>(json, options);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(63), roundtrip!.Data.Attributes.CreationDate);
         Assert.Equal("tag", Assert.Single(roundtrip.Data.Attributes.Tags));
         Assert.Equal("undetected", roundtrip.Data.Attributes.LastAnalysisResults["engine"].Category);
     }

--- a/VirusTotalAnalyzer/Models/AnalysisReport.cs
+++ b/VirusTotalAnalyzer/Models/AnalysisReport.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
@@ -27,7 +28,7 @@ public sealed class AnalysisAttributes
     public Dictionary<string, AnalysisResult> Results { get; set; } = new();
 
     [JsonPropertyName("date")]
-    public long Date { get; set; }
+    public DateTimeOffset Date { get; set; }
 
     [JsonPropertyName("error")]
     public string? Error { get; set; }

--- a/VirusTotalAnalyzer/Models/Comment.cs
+++ b/VirusTotalAnalyzer/Models/Comment.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
@@ -18,7 +19,7 @@ public sealed class CommentData
 public sealed class CommentAttributes
 {
     [JsonPropertyName("date")]
-    public long Date { get; set; }
+    public DateTimeOffset Date { get; set; }
 
     [JsonPropertyName("text")]
     public string Text { get; set; } = string.Empty;

--- a/VirusTotalAnalyzer/Models/CrowdsourcedVerdict.cs
+++ b/VirusTotalAnalyzer/Models/CrowdsourcedVerdict.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
@@ -11,5 +12,5 @@ public sealed class CrowdsourcedVerdict
     public Verdict Verdict { get; set; }
 
     [JsonPropertyName("timestamp")]
-    public long Timestamp { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/DomainReport.cs
+++ b/VirusTotalAnalyzer/Models/DomainReport.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
@@ -24,7 +25,7 @@ public sealed class DomainAttributes
     public int Reputation { get; set; }
 
     [JsonPropertyName("creation_date")]
-    public long CreationDate { get; set; }
+    public DateTimeOffset CreationDate { get; set; }
 
     [JsonPropertyName("tags")]
     public List<string> Tags { get; set; } = new();
@@ -42,5 +43,5 @@ public sealed class DomainAttributes
     public Dictionary<string, Verdict> Categories { get; set; } = new();
 
     [JsonPropertyName("last_analysis_date")]
-    public long LastAnalysisDate { get; set; }
+    public DateTimeOffset LastAnalysisDate { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/FileReport.cs
+++ b/VirusTotalAnalyzer/Models/FileReport.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
@@ -27,7 +28,7 @@ public sealed class FileAttributes
     public int Reputation { get; set; }
 
     [JsonPropertyName("creation_date")]
-    public long CreationDate { get; set; }
+    public DateTimeOffset CreationDate { get; set; }
 
     [JsonPropertyName("tags")]
     public List<string> Tags { get; set; } = new();
@@ -36,13 +37,13 @@ public sealed class FileAttributes
     public long Size { get; set; }
 
     [JsonPropertyName("first_submission_date")]
-    public long FirstSubmissionDate { get; set; }
+    public DateTimeOffset FirstSubmissionDate { get; set; }
 
     [JsonPropertyName("last_submission_date")]
-    public long LastSubmissionDate { get; set; }
+    public DateTimeOffset LastSubmissionDate { get; set; }
 
     [JsonPropertyName("last_modification_date")]
-    public long LastModificationDate { get; set; }
+    public DateTimeOffset LastModificationDate { get; set; }
 
     [JsonPropertyName("times_submitted")]
     public int TimesSubmitted { get; set; }
@@ -66,7 +67,7 @@ public sealed class FileAttributes
     public Dictionary<string, Verdict> Categories { get; set; } = new();
 
     [JsonPropertyName("last_analysis_date")]
-    public long LastAnalysisDate { get; set; }
+    public DateTimeOffset LastAnalysisDate { get; set; }
 
     [JsonPropertyName("crowdsourced_verdicts")]
     public List<CrowdsourcedVerdict> CrowdsourcedVerdicts { get; set; } = new();

--- a/VirusTotalAnalyzer/Models/IpAddressReport.cs
+++ b/VirusTotalAnalyzer/Models/IpAddressReport.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
@@ -24,7 +25,7 @@ public sealed class IpAddressAttributes
     public int Reputation { get; set; }
 
     [JsonPropertyName("creation_date")]
-    public long CreationDate { get; set; }
+    public DateTimeOffset CreationDate { get; set; }
 
     [JsonPropertyName("tags")]
     public List<string> Tags { get; set; } = new();
@@ -42,5 +43,5 @@ public sealed class IpAddressAttributes
     public Dictionary<string, Verdict> Categories { get; set; } = new();
 
     [JsonPropertyName("last_analysis_date")]
-    public long LastAnalysisDate { get; set; }
+    public DateTimeOffset LastAnalysisDate { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/UnixTimestampConverter.cs
+++ b/VirusTotalAnalyzer/Models/UnixTimestampConverter.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+/// <summary>
+/// Converts Unix timestamp seconds to <see cref="DateTimeOffset"/> and back.
+/// </summary>
+public sealed class UnixTimestampConverter : JsonConverter<DateTimeOffset>
+{
+    public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.Number)
+        {
+            throw new JsonException();
+        }
+
+        var seconds = reader.GetInt64();
+        return DateTimeOffset.FromUnixTimeSeconds(seconds);
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options)
+    {
+        writer.WriteNumberValue(value.ToUnixTimeSeconds());
+    }
+}

--- a/VirusTotalAnalyzer/Models/UrlReport.cs
+++ b/VirusTotalAnalyzer/Models/UrlReport.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
@@ -24,19 +25,19 @@ public sealed class UrlAttributes
     public int Reputation { get; set; }
 
     [JsonPropertyName("creation_date")]
-    public long CreationDate { get; set; }
+    public DateTimeOffset CreationDate { get; set; }
 
     [JsonPropertyName("tags")]
     public List<string> Tags { get; set; } = new();
 
     [JsonPropertyName("first_submission_date")]
-    public long FirstSubmissionDate { get; set; }
+    public DateTimeOffset FirstSubmissionDate { get; set; }
 
     [JsonPropertyName("last_submission_date")]
-    public long LastSubmissionDate { get; set; }
+    public DateTimeOffset LastSubmissionDate { get; set; }
 
     [JsonPropertyName("last_modification_date")]
-    public long LastModificationDate { get; set; }
+    public DateTimeOffset LastModificationDate { get; set; }
 
     [JsonPropertyName("times_submitted")]
     public int TimesSubmitted { get; set; }
@@ -54,7 +55,7 @@ public sealed class UrlAttributes
     public Dictionary<string, Verdict> Categories { get; set; } = new();
 
     [JsonPropertyName("last_analysis_date")]
-    public long LastAnalysisDate { get; set; }
+    public DateTimeOffset LastAnalysisDate { get; set; }
 
     [JsonPropertyName("crowdsourced_verdicts")]
     public List<CrowdsourcedVerdict> CrowdsourcedVerdicts { get; set; } = new();

--- a/VirusTotalAnalyzer/Models/Vote.cs
+++ b/VirusTotalAnalyzer/Models/Vote.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
@@ -18,7 +19,7 @@ public sealed class VoteData
 public sealed class VoteAttributes
 {
     [JsonPropertyName("date")]
-    public long Date { get; set; }
+    public DateTimeOffset Date { get; set; }
 
     [JsonPropertyName("verdict")]
     public VoteVerdict Verdict { get; set; }

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -29,6 +29,7 @@ public sealed class VirusTotalClient
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };
         _jsonOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+        _jsonOptions.Converters.Add(new UnixTimestampConverter());
     }
 
     public static VirusTotalClient Create(string apiKey)


### PR DESCRIPTION
## Summary
- replace `long` timestamp fields with `DateTimeOffset`
- add reusable `UnixTimestampConverter` and register in `VirusTotalClient`
- adjust tests and examples for new timestamp type

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68962d0e47cc832ea28eb5c657d90860