### PR TITLE
Dispose HttpClient in VirusTotalClient when owned

### DIFF
--- a/VirusTotalAnalyzer.Examples/Program.cs
+++ b/VirusTotalAnalyzer.Examples/Program.cs
@@ -33,5 +33,6 @@ using VirusTotalAnalyzer.Examples;
 // await AddCommentExample.RunAsync();
 // await VoteExample.RunAsync();
 // await DeleteExample.RunAsync();
+// await UsingExistingHttpClientExample.RunAsync();
 
 await Task.CompletedTask;

--- a/VirusTotalAnalyzer.Examples/UsingExistingHttpClientExample.cs
+++ b/VirusTotalAnalyzer.Examples/UsingExistingHttpClientExample.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class UsingExistingHttpClientExample
+{
+    public static async Task RunAsync()
+    {
+        var httpClient = new HttpClient
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        httpClient.DefaultRequestHeaders.Add("x-apikey", "YOUR_API_KEY");
+
+        using var client = new VirusTotalClient(httpClient, disposeClient: true);
+
+        // Use the client here.
+        await Task.CompletedTask;
+    }
+}

--- a/VirusTotalAnalyzer.Tests/TrackingHandler.cs
+++ b/VirusTotalAnalyzer.Tests/TrackingHandler.cs
@@ -1,0 +1,20 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VirusTotalAnalyzer.Tests;
+
+internal sealed class TrackingHandler : HttpMessageHandler
+{
+    public bool Disposed { get; private set; }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        Disposed = true;
+    }
+}

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientDisposeTests.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientDisposeTests.cs
@@ -1,0 +1,32 @@
+using System.Net.Http;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public class VirusTotalClientDisposeTests
+{
+    [Fact]
+    public void Dispose_DisposesHttpClient_WhenOwned()
+    {
+        var handler = new TrackingHandler();
+        var httpClient = new HttpClient(handler);
+        var client = new VirusTotalClient(httpClient, disposeClient: true);
+
+        client.Dispose();
+
+        Assert.True(handler.Disposed);
+    }
+
+    [Fact]
+    public void Dispose_DoesNotDisposeHttpClient_WhenNotOwned()
+    {
+        var handler = new TrackingHandler();
+        var httpClient = new HttpClient(handler);
+        var client = new VirusTotalClient(httpClient);
+
+        client.Dispose();
+
+        Assert.False(handler.Disposed);
+        httpClient.Dispose();
+    }
+}

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.cs
@@ -17,12 +17,15 @@ public class VirusTotalClientTests
     {
         var client = VirusTotalClient.Create("demo-key");
 
-        var field = typeof(VirusTotalClient).GetField("_httpClient", BindingFlags.NonPublic | BindingFlags.Instance);
-        var httpClient = Assert.IsType<HttpClient>(field!.GetValue(client)!);
+        var httpField = typeof(VirusTotalClient).GetField("_httpClient", BindingFlags.NonPublic | BindingFlags.Instance);
+        var httpClient = Assert.IsType<HttpClient>(httpField!.GetValue(client)!);
+        var disposeField = typeof(VirusTotalClient).GetField("_disposeClient", BindingFlags.NonPublic | BindingFlags.Instance);
+        var disposeClient = Assert.IsType<bool>(disposeField!.GetValue(client)!);
 
         Assert.Equal(new Uri("https://www.virustotal.com/api/v3/"), httpClient.BaseAddress);
         Assert.True(httpClient.DefaultRequestHeaders.TryGetValues("x-apikey", out var values));
         Assert.Equal("demo-key", Assert.Single(values));
+        Assert.True(disposeClient);
     }
 
     [Fact]

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -16,14 +16,37 @@ namespace VirusTotalAnalyzer;
 /// <summary>
 /// Client for the VirusTotal v3 API.
 /// </summary>
-public sealed class VirusTotalClient
+/// <remarks>
+/// <para>Use <see cref="Create(string)"/> for a self-contained client:</para>
+/// <code>using var client = VirusTotalClient.Create("YOUR_API_KEY");</code>
+/// <para>
+/// When providing an existing <see cref="HttpClient"/>, specify whether the client should
+/// dispose it by setting the <c>disposeClient</c> parameter in the constructor.
+/// </para>
+/// </remarks>
+public sealed class VirusTotalClient : IDisposable
 {
     private readonly HttpClient _httpClient;
     private readonly JsonSerializerOptions _jsonOptions;
-
-    public VirusTotalClient(HttpClient httpClient)
+    private readonly bool _disposeClient;
+    private bool _disposed;
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VirusTotalClient"/> class using an existing
+    /// <see cref="HttpClient"/>.
+    /// </summary>
+    /// <param name="httpClient">The <see cref="HttpClient"/> to use for requests.</param>
+    /// <param name="disposeClient">
+    /// Set to <see langword="true"/> to dispose <paramref name="httpClient"/> when this instance
+    /// is disposed.
+    /// </param>
+    /// <remarks>
+    /// Pass <paramref name="disposeClient"/> as <see langword="false"/> when the lifetime of the
+    /// provided <paramref name="httpClient"/> is managed externally.
+    /// </remarks>
+    public VirusTotalClient(HttpClient httpClient, bool disposeClient = false)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _disposeClient = disposeClient;
         _jsonOptions = new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
@@ -32,6 +55,11 @@ public sealed class VirusTotalClient
         _jsonOptions.Converters.Add(new UnixTimestampConverter());
     }
 
+    /// <summary>
+    /// Creates a new <see cref="VirusTotalClient"/> configured with the specified API key.
+    /// </summary>
+    /// <param name="apiKey">The API key used for authenticated requests.</param>
+    /// <returns>A <see cref="VirusTotalClient"/> that owns its underlying <see cref="HttpClient"/>.</returns>
     public static VirusTotalClient Create(string apiKey)
     {
         if (string.IsNullOrWhiteSpace(apiKey)) throw new ArgumentException("Value cannot be null or whitespace.", nameof(apiKey));
@@ -40,7 +68,7 @@ public sealed class VirusTotalClient
             BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
         };
         httpClient.DefaultRequestHeaders.Add("x-apikey", apiKey);
-        return new VirusTotalClient(httpClient);
+        return new VirusTotalClient(httpClient, disposeClient: true);
     }
 
     public async Task<FileReport?> GetFileReportAsync(string id, CancellationToken cancellationToken = default)
@@ -541,5 +569,24 @@ public sealed class VirusTotalClient
         }
 
         throw new ApiException(error);
+    }
+
+    /// <summary>
+    /// Releases resources used by the client.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (_disposeClient)
+        {
+            _httpClient.Dispose();
+        }
+
+        _disposed = true;
+        GC.SuppressFinalize(this);
     }
 }


### PR DESCRIPTION
## Summary
- implement IDisposable and ownership tracking for VirusTotalClient
- add example and tests around disposing injected HttpClient

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689636762238832ea9de8616dd1c9fcb