### PR TITLE
Add bundle support

### DIFF
--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.cs
@@ -658,4 +658,28 @@ public class VirusTotalClientTests
 
         await Assert.ThrowsAsync<ApiException>(() => client.GetMonitorItemAsync("mi1"));
     }
+
+    [Fact]
+    public async Task GetBundleAsync_DeserializesResponseAndUsesCorrectPath()
+    {
+        var json = "{\"id\":\"b1\",\"type\":\"bundle\",\"data\":{\"attributes\":{\"name\":\"Demo\",\"files\":[{\"id\":\"f1\",\"type\":\"file\"}]}}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var bundle = await client.GetBundleAsync("b1");
+
+        Assert.NotNull(bundle);
+        Assert.Equal("b1", bundle!.Id);
+        Assert.Equal(ResourceType.Bundle, bundle.Type);
+        Assert.Equal("Demo", bundle.Data.Attributes.Name);
+        Assert.Single(bundle.Data.Attributes.Files);
+        Assert.Equal("/api/v3/bundles/b1", handler.Request!.RequestUri!.AbsolutePath);
+    }
 }

--- a/VirusTotalAnalyzer/Models/Bundle.cs
+++ b/VirusTotalAnalyzer/Models/Bundle.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class Bundle
+{
+    public string Id { get; set; } = string.Empty;
+    public ResourceType Type { get; set; }
+    public BundleData Data { get; set; } = new();
+}
+
+public sealed class BundleData
+{
+    public BundleAttributes Attributes { get; set; } = new();
+}
+
+public sealed class BundleAttributes
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("files")]
+    public List<Relationship> Files { get; set; } = new();
+}

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -296,6 +296,18 @@ public sealed class VirusTotalClient : IDisposable
         return await JsonSerializer.DeserializeAsync<Collection>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task<Bundle?> GetBundleAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"bundles/{id}", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<Bundle>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task<LivehuntNotification?> GetLivehuntNotificationAsync(string id, CancellationToken cancellationToken = default)
     {
         using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.LivehuntNotification)}/{id}", cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- add Bundle model mirroring VirusTotal bundle schema
- support fetching bundle details via `GetBundleAsync`
- cover bundle retrieval with unit tests

## Testing
- `dotnet restore VirusTotalAnalyzer/VirusTotalAnalyzer.csproj -p:TargetFramework=net8.0`
- `dotnet restore VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj -p:TargetFramework=net8.0`
- `dotnet test VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj -f net8.0 --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_6896672accbc832e812179eb214b421d