### PR TITLE
Add private file analysis support

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetPrivateAnalysisExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetPrivateAnalysisExample.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetPrivateAnalysisExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var report = await client.GetPrivateAnalysisAsync("analysis-id");
+            Console.WriteLine(report?.Id);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Examples/SubmitPrivateFileExample.cs
+++ b/VirusTotalAnalyzer.Examples/SubmitPrivateFileExample.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class SubmitPrivateFileExample
+{
+    public static async Task RunAsync()
+    {
+        var path = "sample.txt";
+        if (!File.Exists(path))
+        {
+            Console.WriteLine($"File not found: {path}");
+            return;
+        }
+
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+#if NET472
+            using var stream = File.OpenRead(path);
+#else
+            await using var stream = File.OpenRead(path);
+#endif
+            var report = await client.SubmitPrivateFileAsync(stream, Path.GetFileName(path));
+            Console.WriteLine(report?.Id);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer/AnalysisType.cs
+++ b/VirusTotalAnalyzer/AnalysisType.cs
@@ -6,5 +6,6 @@ namespace VirusTotalAnalyzer;
 public enum AnalysisType
 {
     File,
-    Url
+    Url,
+    PrivateFile
 }

--- a/VirusTotalAnalyzer/Models/PrivateAnalysis.cs
+++ b/VirusTotalAnalyzer/Models/PrivateAnalysis.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class PrivateAnalysis
+{
+    public string Id { get; set; } = string.Empty;
+    public ResourceType Type { get; set; }
+    public PrivateAnalysisData Data { get; set; } = new();
+}
+
+public sealed class PrivateAnalysisData
+{
+    public PrivateAnalysisAttributes Attributes { get; set; } = new();
+}
+
+public sealed class PrivateAnalysisAttributes
+{
+    [JsonPropertyName("status")]
+    public AnalysisStatus Status { get; set; }
+
+    [JsonPropertyName("stats")]
+    public AnalysisStats Stats { get; set; } = new();
+
+    [JsonPropertyName("results")]
+    public Dictionary<string, AnalysisResult> Results { get; set; } = new();
+
+    [JsonPropertyName("date")]
+    public DateTimeOffset Date { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+}


### PR DESCRIPTION
## Summary
- add `PrivateFile` analysis type and map to private file path
- support submitting and retrieving private analyses
- document private analysis usage with new examples

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6896ee66ee94832e87d4ef0ff00992f1