### PR TITLE
Add file download API and stream tests

### DIFF
--- a/VirusTotalAnalyzer.Examples/DownloadFileExample.cs
+++ b/VirusTotalAnalyzer.Examples/DownloadFileExample.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class DownloadFileExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            await using var stream = await client.DownloadFileAsync("44d88612fea8a8f36de82e1278abb02f");
+            await using var file = File.Create("downloaded_file.bin");
+            await stream.CopyToAsync(file);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Tests/TrackingStream.cs
+++ b/VirusTotalAnalyzer.Tests/TrackingStream.cs
@@ -1,0 +1,26 @@
+using System.IO;
+using System.Threading.Tasks;
+
+namespace VirusTotalAnalyzer.Tests;
+
+internal sealed class TrackingStream : MemoryStream
+{
+    public bool Disposed { get; private set; }
+
+    public TrackingStream(byte[] buffer) : base(buffer) { }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            Disposed = true;
+        }
+        base.Dispose(disposing);
+    }
+
+    public override ValueTask DisposeAsync()
+    {
+        Disposed = true;
+        return base.DisposeAsync();
+    }
+}

--- a/VirusTotalAnalyzer.Tests/TrackingStream.cs
+++ b/VirusTotalAnalyzer.Tests/TrackingStream.cs
@@ -18,9 +18,11 @@ internal sealed class TrackingStream : MemoryStream
         base.Dispose(disposing);
     }
 
+#if !NETFRAMEWORK
     public override ValueTask DisposeAsync()
     {
         Disposed = true;
         return base.DisposeAsync();
     }
+#endif
 }

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -84,6 +84,17 @@ public sealed class VirusTotalClient : IDisposable
             .ConfigureAwait(false);
     }
 
+    public async Task<Stream> DownloadFileAsync(string id, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.GetAsync($"files/{id}/download", HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        return await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+    }
+
     public async Task<UrlReport?> GetUrlReportAsync(string id, CancellationToken cancellationToken = default)
     {
         using var response = await _httpClient.GetAsync($"urls/{id}", cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- add `DownloadFileAsync` to retrieve file streams from VirusTotal
- include example usage of file download
- test download URL and stream disposal behavior

## Testing
- `dotnet test VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj /p:TargetFrameworks=net8.0`


------
https://chatgpt.com/codex/tasks/task_e_6896eec46c50832e960b413f8cf1a94a