### PR TITLE
Add listing for hunting notifications and retrohunt jobs

### DIFF
--- a/VirusTotalAnalyzer.Examples/ListLivehuntNotificationsExample.cs
+++ b/VirusTotalAnalyzer.Examples/ListLivehuntNotificationsExample.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class ListLivehuntNotificationsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var notifications = await client.ListLivehuntNotificationsAsync();
+            foreach (var notification in notifications)
+            {
+                Console.WriteLine(notification.Id);
+            }
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Examples/ListRetrohuntJobsExample.cs
+++ b/VirusTotalAnalyzer.Examples/ListRetrohuntJobsExample.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class ListRetrohuntJobsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var jobs = await client.ListRetrohuntJobsAsync();
+            foreach (var job in jobs)
+            {
+                Console.WriteLine(job.Id);
+            }
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Examples/Program.cs
+++ b/VirusTotalAnalyzer.Examples/Program.cs
@@ -34,5 +34,7 @@ using VirusTotalAnalyzer.Examples;
 // await VoteExample.RunAsync();
 // await DeleteExample.RunAsync();
 // await UsingExistingHttpClientExample.RunAsync();
+// await ListLivehuntNotificationsExample.RunAsync();
+// await ListRetrohuntJobsExample.RunAsync();
 
 await Task.CompletedTask;

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.cs
@@ -773,4 +773,64 @@ public class VirusTotalClientTests
         Assert.NotNull(handler.Request);
         Assert.Equal("/api/v3/private/files/abc/analyse", handler.Request!.RequestUri!.AbsolutePath);
     }
+
+    [Fact]
+    public async Task ListLivehuntNotificationsAsync_PagesThroughResults()
+    {
+        var first = "{\"data\":[{\"id\":\"n1\",\"type\":\"livehuntNotification\",\"data\":{\"attributes\":{\"rule_name\":\"r1\"}}}],\"meta\":{\"cursor\":\"abc\"}}";
+        var second = "{\"data\":[{\"id\":\"n2\",\"type\":\"livehuntNotification\",\"data\":{\"attributes\":{\"rule_name\":\"r2\"}}}]}";
+        var handler = new QueueHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(first, Encoding.UTF8, "application/json")
+            },
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(second, Encoding.UTF8, "application/json")
+            });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var notifications = await client.ListLivehuntNotificationsAsync(limit: 1);
+
+        Assert.Equal(2, notifications.Count);
+        Assert.Equal("n1", notifications[0].Id);
+        Assert.Equal("n2", notifications[1].Id);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Contains("limit=1", handler.Requests[0].RequestUri!.Query);
+        Assert.Contains("cursor=abc", handler.Requests[1].RequestUri!.Query);
+    }
+
+    [Fact]
+    public async Task ListRetrohuntJobsAsync_PagesThroughResults()
+    {
+        var first = "{\"data\":[{\"id\":\"j1\",\"type\":\"retrohuntJob\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}],\"meta\":{\"cursor\":\"abc\"}}";
+        var second = "{\"data\":[{\"id\":\"j2\",\"type\":\"retrohuntJob\",\"data\":{\"attributes\":{\"status\":\"done\"}}}]}";
+        var handler = new QueueHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(first, Encoding.UTF8, "application/json")
+            },
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(second, Encoding.UTF8, "application/json")
+            });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var jobs = await client.ListRetrohuntJobsAsync(limit: 1);
+
+        Assert.Equal(2, jobs.Count);
+        Assert.Equal("j1", jobs[0].Id);
+        Assert.Equal("j2", jobs[1].Id);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Contains("limit=1", handler.Requests[0].RequestUri!.Query);
+        Assert.Contains("cursor=abc", handler.Requests[1].RequestUri!.Query);
+    }
 }

--- a/VirusTotalAnalyzer/Models/LivehuntNotification.cs
+++ b/VirusTotalAnalyzer/Models/LivehuntNotification.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
@@ -18,4 +19,13 @@ public sealed class LivehuntNotificationAttributes
 {
     [JsonPropertyName("rule_name")]
     public string RuleName { get; set; } = string.Empty;
+}
+
+public sealed class LivehuntNotificationsResponse
+{
+    [JsonPropertyName("data")]
+    public List<LivehuntNotification> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public Meta? Meta { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/Meta.cs
+++ b/VirusTotalAnalyzer/Models/Meta.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class Meta
+{
+    [JsonPropertyName("cursor")]
+    public string? Cursor { get; set; }
+}
+

--- a/VirusTotalAnalyzer/Models/RetrohuntJob.cs
+++ b/VirusTotalAnalyzer/Models/RetrohuntJob.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
@@ -18,4 +19,13 @@ public sealed class RetrohuntJobAttributes
 {
     [JsonPropertyName("status")]
     public string Status { get; set; } = string.Empty;
+}
+
+public sealed class RetrohuntJobsResponse
+{
+    [JsonPropertyName("data")]
+    public List<RetrohuntJob> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public Meta? Meta { get; set; }
 }

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -344,6 +344,37 @@ public sealed class VirusTotalClient : IDisposable
         return await JsonSerializer.DeserializeAsync<LivehuntNotification>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task<IReadOnlyList<LivehuntNotification>> ListLivehuntNotificationsAsync(int limit = 10, CancellationToken cancellationToken = default)
+    {
+        var results = new List<LivehuntNotification>();
+        string? cursor = null;
+
+        do
+        {
+            var url = $"intelligence/hunting_notifications?limit={limit}";
+            if (!string.IsNullOrEmpty(cursor))
+            {
+                url += $"&cursor={Uri.EscapeDataString(cursor)}";
+            }
+            using var response = await _httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+            await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+            using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+            await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+            var page = await JsonSerializer.DeserializeAsync<LivehuntNotificationsResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+            if (page?.Data != null)
+            {
+                results.AddRange(page.Data);
+            }
+            cursor = page?.Meta?.Cursor;
+        }
+        while (!string.IsNullOrEmpty(cursor));
+
+        return results;
+    }
+
     public async Task<RetrohuntJob?> GetRetrohuntJobAsync(string id, CancellationToken cancellationToken = default)
     {
         using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.RetrohuntJob)}/{id}", cancellationToken).ConfigureAwait(false);
@@ -354,6 +385,37 @@ public sealed class VirusTotalClient : IDisposable
         await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #endif
         return await JsonSerializer.DeserializeAsync<RetrohuntJob>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<RetrohuntJob>> ListRetrohuntJobsAsync(int limit = 10, CancellationToken cancellationToken = default)
+    {
+        var results = new List<RetrohuntJob>();
+        string? cursor = null;
+
+        do
+        {
+            var url = $"intelligence/retrohunt_jobs?limit={limit}";
+            if (!string.IsNullOrEmpty(cursor))
+            {
+                url += $"&cursor={Uri.EscapeDataString(cursor)}";
+            }
+            using var response = await _httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+            await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+            using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+            await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+            var page = await JsonSerializer.DeserializeAsync<RetrohuntJobsResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+            if (page?.Data != null)
+            {
+                results.AddRange(page.Data);
+            }
+            cursor = page?.Meta?.Cursor;
+        }
+        while (!string.IsNullOrEmpty(cursor));
+
+        return results;
     }
 
     public async Task<RetrohuntNotification?> GetRetrohuntNotificationAsync(string id, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- support listing livehunt notifications with paging
- add paged listing for retrohunt jobs
- cover deserialization and paging with new tests and examples

## Testing
- `dotnet build VirusTotalAnalyzer.sln`
- `dotnet test VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6896f639afbc832e80788e4895ffba4d