### PR TITLE
Add pagination support to search and feed APIs

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetFeedExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFeedExample.cs
@@ -11,8 +11,13 @@ public static class GetFeedExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var feed = await client.GetFeedAsync(ResourceType.File);
+            var feed = await client.GetFeedAsync(ResourceType.File, limit: 10);
             Console.WriteLine(feed?.Data.Count);
+            if (!string.IsNullOrEmpty(feed?.Meta?.Cursor))
+            {
+                var next = await client.GetFeedAsync(ResourceType.File, cursor: feed.Meta.Cursor);
+                Console.WriteLine(next?.Data.Count);
+            }
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/SearchExample.cs
+++ b/VirusTotalAnalyzer.Examples/SearchExample.cs
@@ -11,8 +11,13 @@ public static class SearchExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var response = await client.SearchAsync("type:file");
+            var response = await client.SearchAsync("type:file", limit: 10);
             Console.WriteLine(response?.Data.Count);
+            if (!string.IsNullOrEmpty(response?.Meta?.Cursor))
+            {
+                var nextPage = await client.SearchAsync("type:file", cursor: response.Meta.Cursor);
+                Console.WriteLine(nextPage?.Data.Count);
+            }
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer/Models/FeedResponse.cs
+++ b/VirusTotalAnalyzer/Models/FeedResponse.cs
@@ -7,6 +7,9 @@ public sealed class FeedResponse
 {
     [JsonPropertyName("data")]
     public List<FeedItem> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public PaginationMetadata? Meta { get; set; }
 }
 
 public sealed class FeedItem

--- a/VirusTotalAnalyzer/Models/PaginationMetadata.cs
+++ b/VirusTotalAnalyzer/Models/PaginationMetadata.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class PaginationMetadata
+{
+    [JsonPropertyName("cursor")]
+    public string? Cursor { get; set; }
+}

--- a/VirusTotalAnalyzer/Models/SearchResponse.cs
+++ b/VirusTotalAnalyzer/Models/SearchResponse.cs
@@ -7,6 +7,9 @@ public sealed class SearchResponse
 {
     [JsonPropertyName("data")]
     public List<SearchResult> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public PaginationMetadata? Meta { get; set; }
 }
 
 public sealed class SearchResult


### PR DESCRIPTION
## Summary
- allow SearchAsync and GetFeedAsync to request paginated results
- expose cursor metadata on SearchResponse and FeedResponse
- add examples and tests for paginated search and feed usage

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689704208e18832ea7e6fa12a026a0b9