### PR TITLE
Add file behavior and network traffic endpoints

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetFileBehaviorExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileBehaviorExample.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetFileBehaviorExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var behavior = await client.GetFileBehaviorAsync("44d88612fea8a8f36de82e1278abb02f");
+            Console.WriteLine(behavior?.Data.Count);
+
+            var summary = await client.GetFileBehaviorSummaryAsync("44d88612fea8a8f36de82e1278abb02f");
+            Console.WriteLine(summary?.Data.Tags.Count);
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Examples/GetFileNetworkTrafficExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileNetworkTrafficExample.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetFileNetworkTrafficExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var traffic = await client.GetFileNetworkTrafficAsync("44d88612fea8a8f36de82e1278abb02f");
+            foreach (var entry in traffic?.Data.Tcp ?? [])
+            {
+                Console.WriteLine($"{entry.Destination}:{entry.Port}");
+            }
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer/Models/FileBehavior.cs
+++ b/VirusTotalAnalyzer/Models/FileBehavior.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class FileBehavior
+{
+    [JsonPropertyName("data")]
+    public List<BehaviorEntry> Data { get; set; } = new();
+}
+
+public sealed class BehaviorEntry
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
+
+    [JsonPropertyName("attributes")]
+    public BehaviorAttributes Attributes { get; set; } = new();
+}
+
+public sealed class BehaviorAttributes
+{
+    [JsonPropertyName("processes")]
+    public List<BehaviorProcess> Processes { get; set; } = new();
+}
+
+public sealed class BehaviorProcess
+{
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+}

--- a/VirusTotalAnalyzer/Models/FileBehaviorSummary.cs
+++ b/VirusTotalAnalyzer/Models/FileBehaviorSummary.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class FileBehaviorSummary
+{
+    [JsonPropertyName("data")]
+    public BehaviorSummaryData Data { get; set; } = new();
+}
+
+public sealed class BehaviorSummaryData
+{
+    [JsonPropertyName("tags")]
+    public List<string> Tags { get; set; } = new();
+}

--- a/VirusTotalAnalyzer/Models/FileNetworkTraffic.cs
+++ b/VirusTotalAnalyzer/Models/FileNetworkTraffic.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class FileNetworkTraffic
+{
+    [JsonPropertyName("data")]
+    public NetworkTrafficData Data { get; set; } = new();
+}
+
+public sealed class NetworkTrafficData
+{
+    [JsonPropertyName("tcp")]
+    public List<NetworkTcpEntry> Tcp { get; set; } = new();
+}
+
+public sealed class NetworkTcpEntry
+{
+    [JsonPropertyName("dst")]
+    public string? Destination { get; set; }
+
+    [JsonPropertyName("port")]
+    public int Port { get; set; }
+}

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -84,6 +84,45 @@ public sealed class VirusTotalClient : IDisposable
             .ConfigureAwait(false);
     }
 
+    public async Task<FileBehavior?> GetFileBehaviorAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"files/{id}/behavior", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<FileBehavior>(stream, _jsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<FileBehaviorSummary?> GetFileBehaviorSummaryAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"files/{id}/behavior_summary", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<FileBehaviorSummary>(stream, _jsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<FileNetworkTraffic?> GetFileNetworkTrafficAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"files/{id}/network-traffic", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<FileNetworkTraffic>(stream, _jsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     public async Task<Stream> DownloadFileAsync(string id, CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.GetAsync($"files/{id}/download", HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- support VirusTotal file behavior, behavior summary, and network traffic endpoints
- add models and unit tests for behavior and network traffic responses
- include example snippets for behavior and network traffic retrieval

## Testing
- `dotnet test -p:TargetFrameworks=net8.0`
- `dotnet test -f net9.0` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689704135b34832eba773a6446de11b9