### PR TITLE
Add cancellation test for WaitForAnalysisCompletionAsync

### DIFF
--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Reflection;
 using VirusTotalAnalyzer;
@@ -336,6 +337,29 @@ public class VirusTotalClientTests
 
         Assert.NotNull(report);
         Assert.Equal(AnalysisStatus.Completed, report!.Data.Attributes.Status);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task WaitForAnalysisCompletionAsync_ThrowsOnCancellation()
+    {
+        var queued = "{\"id\":\"an\",\"type\":\"analysis\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}";
+        var handler = new QueueHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(queued, Encoding.UTF8, "application/json")
+            });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        using var cts = new CancellationTokenSource(100);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            client.WaitForAnalysisCompletionAsync("an", TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1), cts.Token));
+
         Assert.Single(handler.Requests);
     }
 


### PR DESCRIPTION
## Summary
- add test verifying cancellation during analysis polling

## Testing
- `~/.dotnet/dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6897c2fb4594832e927fcb91410ccd39