### PR TITLE
Add YARA ruleset support

### DIFF
--- a/VirusTotalAnalyzer.Examples/ListYaraRulesetsExample.cs
+++ b/VirusTotalAnalyzer.Examples/ListYaraRulesetsExample.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class ListYaraRulesetsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var rulesets = await client.ListYaraRulesetsAsync();
+            if (rulesets != null)
+            {
+                foreach (var rs in rulesets)
+                {
+                    Console.WriteLine($"{rs.Id}: {rs.Data.Attributes.Name}");
+                }
+            }
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}
+

--- a/VirusTotalAnalyzer.PowerShell/GetVtYaraRulesetCommand.cs
+++ b/VirusTotalAnalyzer.PowerShell/GetVtYaraRulesetCommand.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Management.Automation;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.PowerShell;
+
+[Cmdlet(VerbsCommon.Get, "VtYaraRuleset")]
+[OutputType(typeof(YaraRuleset))]
+public sealed class GetVtYaraRulesetCommand : PSCmdlet
+{
+    [Parameter(Mandatory = true)]
+    public string ApiKey { get; set; } = string.Empty;
+
+    [Parameter(Position = 0)]
+    public string? Id { get; set; }
+
+    [Parameter]
+    public int? Limit { get; set; }
+
+    [Parameter]
+    public string? Cursor { get; set; }
+
+    protected override void ProcessRecord()
+    {
+        using var client = VirusTotalClient.Create(ApiKey);
+        if (string.IsNullOrEmpty(Id))
+        {
+            var rulesets = client.ListYaraRulesetsAsync(Limit, Cursor).GetAwaiter().GetResult();
+            if (rulesets != null)
+            {
+                WriteObject(rulesets, true);
+            }
+        }
+        else
+        {
+            var ruleset = client.GetYaraRulesetAsync(Id).GetAwaiter().GetResult();
+            if (ruleset != null)
+            {
+                WriteObject(ruleset);
+            }
+        }
+    }
+}
+

--- a/VirusTotalAnalyzer.PowerShell/NewVtYaraRulesetCommand.cs
+++ b/VirusTotalAnalyzer.PowerShell/NewVtYaraRulesetCommand.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Management.Automation;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.PowerShell;
+
+[Cmdlet(VerbsCommon.New, "VtYaraRuleset")]
+[OutputType(typeof(YaraRuleset))]
+public sealed class NewVtYaraRulesetCommand : PSCmdlet
+{
+    [Parameter(Mandatory = true)]
+    public string ApiKey { get; set; } = string.Empty;
+
+    [Parameter(Mandatory = true)]
+    public string Name { get; set; } = string.Empty;
+
+    [Parameter(Mandatory = true)]
+    public string Rules { get; set; } = string.Empty;
+
+    [Parameter]
+    public string[]? WatcherId { get; set; }
+
+    protected override void ProcessRecord()
+    {
+        var request = new YaraRulesetRequest();
+        request.Data.Attributes.Name = Name;
+        request.Data.Attributes.Rules = Rules;
+        if (WatcherId != null && WatcherId.Length > 0)
+        {
+            request.Data.Attributes.Watchers = new List<YaraWatcher>();
+            foreach (var id in WatcherId)
+            {
+                request.Data.Attributes.Watchers.Add(new YaraWatcher { Id = id, Type = "user" });
+            }
+        }
+        using var client = VirusTotalClient.Create(ApiKey);
+        var result = client.CreateYaraRulesetAsync(request).GetAwaiter().GetResult();
+        if (result != null)
+        {
+            WriteObject(result);
+        }
+    }
+}
+

--- a/VirusTotalAnalyzer.PowerShell/RemoveVtYaraRulesetCommand.cs
+++ b/VirusTotalAnalyzer.PowerShell/RemoveVtYaraRulesetCommand.cs
@@ -1,0 +1,23 @@
+using System.Management.Automation;
+
+namespace VirusTotalAnalyzer.PowerShell;
+
+[Cmdlet(VerbsCommon.Remove, "VtYaraRuleset", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
+public sealed class RemoveVtYaraRulesetCommand : PSCmdlet
+{
+    [Parameter(Mandatory = true)]
+    public string ApiKey { get; set; } = string.Empty;
+
+    [Parameter(Mandatory = true, Position = 0)]
+    public string Id { get; set; } = string.Empty;
+
+    protected override void ProcessRecord()
+    {
+        if (ShouldProcess(Id))
+        {
+            using var client = VirusTotalClient.Create(ApiKey);
+            client.DeleteYaraRulesetAsync(Id).GetAwaiter().GetResult();
+        }
+    }
+}
+

--- a/VirusTotalAnalyzer.PowerShell/SetVtYaraRulesetCommand.cs
+++ b/VirusTotalAnalyzer.PowerShell/SetVtYaraRulesetCommand.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using System.Management.Automation;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.PowerShell;
+
+[Cmdlet(VerbsCommon.Set, "VtYaraRuleset")]
+[OutputType(typeof(YaraRuleset))]
+public sealed class SetVtYaraRulesetCommand : PSCmdlet
+{
+    [Parameter(Mandatory = true)]
+    public string ApiKey { get; set; } = string.Empty;
+
+    [Parameter(Mandatory = true, Position = 0)]
+    public string Id { get; set; } = string.Empty;
+
+    [Parameter]
+    public string? Name { get; set; }
+
+    [Parameter]
+    public string? Rules { get; set; }
+
+    [Parameter]
+    public string[]? WatcherId { get; set; }
+
+    protected override void ProcessRecord()
+    {
+        var request = new YaraRulesetRequest();
+        if (Name != null)
+        {
+            request.Data.Attributes.Name = Name;
+        }
+        if (Rules != null)
+        {
+            request.Data.Attributes.Rules = Rules;
+        }
+        if (WatcherId != null)
+        {
+            request.Data.Attributes.Watchers = new List<YaraWatcher>();
+            foreach (var id in WatcherId)
+            {
+                request.Data.Attributes.Watchers.Add(new YaraWatcher { Id = id, Type = "user" });
+            }
+        }
+        using var client = VirusTotalClient.Create(ApiKey);
+        var result = client.UpdateYaraRulesetAsync(Id, request).GetAwaiter().GetResult();
+        if (result != null)
+        {
+            WriteObject(result);
+        }
+    }
+}
+

--- a/VirusTotalAnalyzer.PowerShell/VirusTotalAnalyzer.PowerShell.csproj
+++ b/VirusTotalAnalyzer.PowerShell/VirusTotalAnalyzer.PowerShell.csproj
@@ -7,5 +7,6 @@
   <ItemGroup>
     <ProjectReference Include="../VirusTotalAnalyzer/VirusTotalAnalyzer.csproj" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
+    <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" />
   </ItemGroup>
 </Project>

--- a/VirusTotalAnalyzer.Tests/YaraRulesetTests.cs
+++ b/VirusTotalAnalyzer.Tests/YaraRulesetTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public class YaraRulesetTests
+{
+    private const string SingleRulesetJson = "{\"id\":\"rs1\",\"type\":\"intelligence_hunting_ruleset\",\"data\":{\"attributes\":{\"name\":\"demo\",\"rules\":\"rule\",\"watchers\":[{\"id\":\"user1\",\"type\":\"user\"}]}}}";
+
+    [Fact]
+    public async Task ListYaraRulesetsAsync_DeserializesResponse()
+    {
+        var json = $"{{\"data\":[{SingleRulesetJson}]}}";
+        var handler = new StubHandler(json);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var rulesets = await client.ListYaraRulesetsAsync();
+
+        var rs = Assert.Single(rulesets!);
+        Assert.Equal("rs1", rs.Id);
+        Assert.Equal("demo", rs.Data.Attributes.Name);
+    }
+
+    [Fact]
+    public async Task GetYaraRulesetAsync_DeserializesResponse()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(SingleRulesetJson, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var ruleset = await client.GetYaraRulesetAsync("rs1");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/intelligence/hunting_rulesets/rs1", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal("demo", ruleset!.Data.Attributes.Name);
+    }
+
+    [Fact]
+    public async Task CreateYaraRulesetAsync_SerializesRequestAndDeserializesResponse()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent($"{{\"data\":{SingleRulesetJson}}}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+        var request = new YaraRulesetRequest();
+        request.Data.Attributes.Name = "demo";
+        request.Data.Attributes.Rules = "rule";
+        request.Data.Attributes.Watchers = new() { new YaraWatcher { Id = "user1", Type = "user" } };
+
+        var ruleset = await client.CreateYaraRulesetAsync(request);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal(HttpMethod.Post, handler.Request!.Method);
+        Assert.Equal("/api/v3/intelligence/hunting_rulesets", handler.Request.RequestUri!.AbsolutePath);
+        Assert.Contains("\"name\":\"demo\"", handler.Content);
+        Assert.Equal("demo", ruleset!.Data.Attributes.Name);
+    }
+
+    [Fact]
+    public async Task UpdateYaraRulesetAsync_SendsPatch()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent($"{{\"data\":{SingleRulesetJson}}}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+        var request = new YaraRulesetRequest();
+        request.Data.Attributes.Name = "demo";
+
+        var ruleset = await client.UpdateYaraRulesetAsync("rs1", request);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("PATCH", handler.Request!.Method.Method);
+        Assert.Equal("/api/v3/intelligence/hunting_rulesets/rs1", handler.Request.RequestUri!.AbsolutePath);
+        Assert.NotNull(ruleset);
+    }
+
+    [Fact]
+    public async Task DeleteYaraRulesetAsync_UsesCorrectPath()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK);
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.DeleteYaraRulesetAsync("rs1");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal(HttpMethod.Delete, handler.Request!.Method);
+        Assert.Equal("/api/v3/intelligence/hunting_rulesets/rs1", handler.Request.RequestUri!.AbsolutePath);
+    }
+}
+

--- a/VirusTotalAnalyzer/Models/YaraRuleset.cs
+++ b/VirusTotalAnalyzer/Models/YaraRuleset.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class YaraRuleset
+{
+    public string Id { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public YaraRulesetData Data { get; set; } = new();
+}
+
+public sealed class YaraRulesetData
+{
+    public YaraRulesetAttributes Attributes { get; set; } = new();
+}
+
+public sealed class YaraRulesetAttributes
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("rules")]
+    public string Rules { get; set; } = string.Empty;
+
+    [JsonPropertyName("watchers")]
+    public List<YaraWatcher>? Watchers { get; set; }
+}
+
+public sealed class YaraRulesetResponse
+{
+    [JsonPropertyName("data")]
+    public YaraRuleset? Data { get; set; }
+}
+
+public sealed class YaraRulesetsResponse
+{
+    [JsonPropertyName("data")]
+    public List<YaraRuleset> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public Meta? Meta { get; set; }
+}
+

--- a/VirusTotalAnalyzer/Models/YaraRulesetRequest.cs
+++ b/VirusTotalAnalyzer/Models/YaraRulesetRequest.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class YaraRulesetRequest
+{
+    [JsonPropertyName("data")]
+    public YaraRulesetRequestData Data { get; set; } = new();
+}
+
+public sealed class YaraRulesetRequestData
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "intelligence_hunting_ruleset";
+
+    [JsonPropertyName("attributes")]
+    public YaraRulesetRequestAttributes Attributes { get; set; } = new();
+}
+
+public sealed class YaraRulesetRequestAttributes
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("rules")]
+    public string Rules { get; set; } = string.Empty;
+
+    [JsonPropertyName("watchers")]
+    public List<YaraWatcher>? Watchers { get; set; }
+}
+

--- a/VirusTotalAnalyzer/Models/YaraWatcher.cs
+++ b/VirusTotalAnalyzer/Models/YaraWatcher.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class YaraWatcher
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
+}
+

--- a/VirusTotalAnalyzer/ResourceType.cs
+++ b/VirusTotalAnalyzer/ResourceType.cs
@@ -62,5 +62,8 @@ public enum ResourceType
     RetrohuntNotification,
 
     [EnumMember(Value = "monitor_item")]
-    MonitorItem
+    MonitorItem,
+
+    [EnumMember(Value = "intelligence_hunting_ruleset")]
+    IntelligenceHuntingRuleset
 }


### PR DESCRIPTION
## Summary
- add YARA ruleset and watcher models
- support intelligence/hunting_rulesets in client and PowerShell cmdlets
- add example and unit tests for ruleset operations

## Testing
- `dotnet build -c Release` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet build -c Release -p:TargetFrameworks=net8.0`
- `dotnet test VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj -c Release -p:TargetFrameworks=net8.0`


------
https://chatgpt.com/codex/tasks/task_e_6898378eef70832ea8f37fea12de0c51