### PR TITLE
Add monitor item client support

### DIFF
--- a/VirusTotalAnalyzer.Examples/CreateMonitorItemExample.cs
+++ b/VirusTotalAnalyzer.Examples/CreateMonitorItemExample.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class CreateMonitorItemExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var request = new CreateMonitorItemRequest
+            {
+                Data = { Attributes = { Path = "/path/to/file" } }
+            };
+            var item = await client.CreateMonitorItemAsync(request);
+            Console.WriteLine(item?.Id);
+
+            var items = await client.ListMonitorItemsAsync();
+            foreach (var i in items)
+            {
+                Console.WriteLine(i.Id);
+            }
+
+            if (item != null)
+            {
+                await client.DeleteMonitorItemAsync(item.Id);
+                Console.WriteLine("Monitor item deleted");
+            }
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Tests/MonitorItemTests.cs
+++ b/VirusTotalAnalyzer.Tests/MonitorItemTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public class MonitorItemTests
+{
+    [Fact]
+    public async Task ListMonitorItemsAsync_GetsItems()
+    {
+        var json = "{\"data\":[{\"id\":\"m1\",\"type\":\"monitorItem\",\"data\":{\"attributes\":{\"path\":\"/foo\"}}}]}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var items = await client.ListMonitorItemsAsync();
+
+        Assert.NotNull(items);
+        Assert.Equal(HttpMethod.Get, handler.Request!.Method);
+        Assert.Equal("/api/v3/monitor/items", handler.Request.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task CreateMonitorItemAsync_PostsItem()
+    {
+        var json = "{\"id\":\"m1\",\"type\":\"monitorItem\",\"data\":{\"attributes\":{\"path\":\"/foo\"}}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var request = new CreateMonitorItemRequest { Data = { Attributes = { Path = "/foo" } } };
+        var item = await client.CreateMonitorItemAsync(request);
+
+        Assert.NotNull(item);
+        Assert.Equal(HttpMethod.Post, handler.Request!.Method);
+        Assert.Equal("/api/v3/monitor/items", handler.Request.RequestUri!.AbsolutePath);
+        Assert.Contains("\"path\":\"/foo\"", handler.Content);
+    }
+
+    [Fact]
+    public async Task UpdateMonitorItemAsync_PatchesItem()
+    {
+        var json = "{\"id\":\"m1\",\"type\":\"monitorItem\",\"data\":{\"attributes\":{\"path\":\"/bar\"}}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var request = new UpdateMonitorItemRequest { Data = { Attributes = { Path = "/bar" } } };
+        var item = await client.UpdateMonitorItemAsync("m1", request);
+
+        Assert.NotNull(item);
+        Assert.Equal("PATCH", handler.Request!.Method.Method);
+        Assert.Equal("/api/v3/monitor/items/m1", handler.Request.RequestUri!.AbsolutePath);
+        Assert.Contains("\"path\":\"/bar\"", handler.Content);
+    }
+
+    [Fact]
+    public async Task DeleteMonitorItemAsync_UsesDelete()
+    {
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.NoContent));
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.DeleteMonitorItemAsync("m1");
+
+        Assert.Equal(HttpMethod.Delete, handler.Request!.Method);
+        Assert.Equal("/api/v3/monitor/items/m1", handler.Request.RequestUri!.AbsolutePath);
+    }
+}

--- a/VirusTotalAnalyzer/Models/MonitorItem.cs
+++ b/VirusTotalAnalyzer/Models/MonitorItem.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
@@ -18,4 +19,55 @@ public sealed class MonitorItemAttributes
 {
     [JsonPropertyName("path")]
     public string Path { get; set; } = string.Empty;
+}
+
+public sealed class MonitorItemsResponse
+{
+    [JsonPropertyName("data")]
+    public List<MonitorItem> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public Meta? Meta { get; set; }
+}
+
+public sealed class CreateMonitorItemRequest
+{
+    [JsonPropertyName("data")]
+    public CreateMonitorItemData Data { get; set; } = new();
+}
+
+public sealed class CreateMonitorItemData
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "monitor_item";
+
+    [JsonPropertyName("attributes")]
+    public CreateMonitorItemAttributes Attributes { get; set; } = new();
+}
+
+public sealed class CreateMonitorItemAttributes
+{
+    [JsonPropertyName("path")]
+    public string Path { get; set; } = string.Empty;
+}
+
+public sealed class UpdateMonitorItemRequest
+{
+    [JsonPropertyName("data")]
+    public UpdateMonitorItemData Data { get; set; } = new();
+}
+
+public sealed class UpdateMonitorItemData
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "monitor_item";
+
+    [JsonPropertyName("attributes")]
+    public UpdateMonitorItemAttributes Attributes { get; set; } = new();
+}
+
+public sealed class UpdateMonitorItemAttributes
+{
+    [JsonPropertyName("path")]
+    public string? Path { get; set; }
 }

--- a/VirusTotalAnalyzer/VirusTotalClient.Monitor.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Monitor.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer;
+
+public sealed partial class VirusTotalClient
+{
+    public async Task<IReadOnlyList<MonitorItem>?> ListMonitorItemsAsync(CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync("monitor/items", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<MonitorItemsResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+        return result?.Data;
+    }
+
+    public async Task<MonitorItem?> CreateMonitorItemAsync(CreateMonitorItemRequest request, CancellationToken cancellationToken = default)
+    {
+        var json = JsonSerializer.Serialize(request, _jsonOptions);
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var response = await _httpClient.PostAsync("monitor/items", content, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<MonitorItem>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<MonitorItem?> UpdateMonitorItemAsync(string id, UpdateMonitorItemRequest request, CancellationToken cancellationToken = default)
+    {
+        var json = JsonSerializer.Serialize(request, _jsonOptions);
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var message = new HttpRequestMessage(new HttpMethod("PATCH"), $"monitor/items/{id}") { Content = content };
+        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<MonitorItem>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task DeleteMonitorItemAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.DeleteAsync($"monitor/items/{id}", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+}


### PR DESCRIPTION
## Summary
- add models for creating and updating monitor items
- support listing, creating, updating and deleting monitor items
- add example and tests for monitor item operations

## Testing
- `dotnet test -p:TargetFrameworks=net8.0`

------
https://chatgpt.com/codex/tasks/task_e_68988c90cae0832ea549e22131d9903e