### PR TITLE
Add PCAP download support to VirusTotal client

### DIFF
--- a/VirusTotalAnalyzer.Examples/DownloadPcapExample.cs
+++ b/VirusTotalAnalyzer.Examples/DownloadPcapExample.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class DownloadPcapExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            await using var stream = await client.DownloadPcapAsync("ANALYSIS_ID");
+            await using var file = File.Create("analysis.pcap");
+            await stream.CopyToAsync(file);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Examples/Program.cs
+++ b/VirusTotalAnalyzer.Examples/Program.cs
@@ -39,6 +39,7 @@ using VirusTotalAnalyzer.Examples;
 // await UsingExistingHttpClientExample.RunAsync();
 // await ListLivehuntNotificationsExample.RunAsync();
 // await DownloadLivehuntNotificationFileExample.RunAsync();
+// await DownloadPcapExample.RunAsync();
 // await ListRetrohuntJobsExample.RunAsync();
 // await StartRetrohuntJobExample.RunAsync();
 

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Core.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Core.cs
@@ -100,6 +100,57 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task DownloadPcapAsync_UsesCorrectPathAndReturnsStream()
+    {
+        var trackingStream = new TrackingStream(new byte[] { 1, 2, 3 });
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(trackingStream)
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var stream = await client.DownloadPcapAsync("abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/analyses/abc/pcap", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.False(trackingStream.Disposed);
+#if NETFRAMEWORK
+        stream.Dispose();
+#else
+        await stream.DisposeAsync();
+#endif
+        Assert.True(trackingStream.Disposed);
+    }
+
+    [Fact]
+    public async Task DownloadPcapAsync_ThrowsApiException()
+    {
+        var errorJson = @"{""error"":{""code"":""NotFoundError"",""message"":""not found""}}";
+        var response = new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent(errorJson, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var ex = await Assert.ThrowsAsync<ApiException>(async () => await client.DownloadPcapAsync("abc"));
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/analyses/abc/pcap", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal("NotFoundError", ex.Error?.Code);
+        Assert.Equal("not found", ex.Message);
+    }
+
+    [Fact]
     public async Task DownloadRetrohuntNotificationFileAsync_UsesCorrectPathAndReturnsStream()
     {
         var trackingStream = new TrackingStream(new byte[] { 1, 2, 3 });

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -185,6 +185,17 @@ public sealed partial class VirusTotalClient : IDisposable
 #endif
     }
 
+    public async Task<Stream> DownloadPcapAsync(string analysisId, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.GetAsync($"analyses/{analysisId}/pcap", HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        return await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+    }
+
     /// <summary>
     /// Releases resources used by the client.
     /// </summary>


### PR DESCRIPTION
## Summary
- support downloading analysis PCAPs via `DownloadPcapAsync`
- show how to save PCAPs to disk in examples
- cover success and error paths with unit tests

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6898bfab969c832ea78de185a6f4241d