### PR TITLE
Add user privilege and quota retrieval

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetUserQuotaExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetUserQuotaExample.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetUserQuotaExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var privileges = await client.GetUserPrivilegesAsync("user-id");
+            var quota = await client.GetUserQuotaAsync("user-id");
+            Console.WriteLine($"Privileges: {privileges?.Data.Count}");
+            Console.WriteLine($"Quota items: {quota?.Data.Count}");
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Examples/Program.cs
+++ b/VirusTotalAnalyzer.Examples/Program.cs
@@ -16,6 +16,7 @@ using VirusTotalAnalyzer.Examples;
 // await CreateVoteExample.RunAsync();
 // await DeleteItemExample.RunAsync();
 // await GetUserExample.RunAsync();
+// await GetUserQuotaExample.RunAsync();
 // await GetGraphExample.RunAsync();
 // await GetCollectionExample.RunAsync();
 // await CreateGraphExample.RunAsync();

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
@@ -36,6 +36,50 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetUserPrivilegesAsync_DeserializesResponse()
+    {
+        var json = @"{""data"":{""can_download_file"":{""allowed"":true},""can_view_graph"":{""allowed"":false}}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var privileges = await client.GetUserPrivilegesAsync("user1");
+
+        Assert.NotNull(privileges);
+        Assert.True(privileges!.Data["can_download_file"].Allowed);
+        Assert.False(privileges.Data["can_view_graph"].Allowed);
+        Assert.Equal("/api/v3/users/user1/privileges", handler.Request!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task GetUserQuotaAsync_DeserializesResponse()
+    {
+        var json = @"{""data"":{""api_requests_daily"":{""allowed"":100,""used"":10}}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var quota = await client.GetUserQuotaAsync("user1");
+
+        Assert.NotNull(quota);
+        Assert.Equal(100, quota!.Data["api_requests_daily"].Allowed);
+        Assert.Equal(10, quota.Data["api_requests_daily"].Used);
+        Assert.Equal("/api/v3/users/user1/quotas", handler.Request!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
     public async Task GetUploadUrlAsync_ReturnsUri()
     {
         var json = "{\"data\":\"https://upload.example/upload\"}";

--- a/VirusTotalAnalyzer/Models/UserPrivileges.cs
+++ b/VirusTotalAnalyzer/Models/UserPrivileges.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class UserPrivileges
+{
+    [JsonPropertyName("data")]
+    public Dictionary<string, PrivilegeData> Data { get; set; } = new();
+}
+
+public sealed class PrivilegeData
+{
+    [JsonPropertyName("allowed")]
+    public bool Allowed { get; set; }
+}

--- a/VirusTotalAnalyzer/Models/UserQuota.cs
+++ b/VirusTotalAnalyzer/Models/UserQuota.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class UserQuota
+{
+    [JsonPropertyName("data")]
+    public Dictionary<string, QuotaData> Data { get; set; } = new();
+}
+
+public sealed class QuotaData
+{
+    [JsonPropertyName("allowed")]
+    public long Allowed { get; set; }
+
+    [JsonPropertyName("used")]
+    public long Used { get; set; }
+}

--- a/VirusTotalAnalyzer/VirusTotalClient.Community.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Community.cs
@@ -104,4 +104,28 @@ public sealed partial class VirusTotalClient
 #endif
         return await JsonSerializer.DeserializeAsync<User>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
     }
+
+    public async Task<UserPrivileges?> GetUserPrivilegesAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"users/{id}/privileges", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<UserPrivileges>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<UserQuota?> GetUserQuotaAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"users/{id}/quotas", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<UserQuota>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+    }
 }


### PR DESCRIPTION
## Summary
- add `GetUserPrivilegesAsync` and `GetUserQuotaAsync` endpoints
- model user privilege and quota responses
- demonstrate quota and privilege lookup with example and tests

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6899a4709330832eb5f4d25e1edc7126