### PR TITLE
feat: add rate limit retry helper

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetUserWithRetryExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetUserWithRetryExample.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetUserWithRetryExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            // Retries up to 5 times, waiting the server-provided delay when available or 4 seconds otherwise
+            var user = await client.ExecuteWithRateLimitRetryAsync(
+                c => c.GetUserAsync("user-id"),
+                maxRetries: 5,
+                defaultRetryDelay: TimeSpan.FromSeconds(4));
+            Console.WriteLine(user?.Id);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientRetryTests.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientRetryTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public class VirusTotalClientRetryTests
+{
+    [Fact]
+    public async Task ExecuteWithRateLimitRetryAsync_RetriesRequest()
+    {
+        var errorJson = "{\"error\":{\"code\":\"RateLimitExceeded\",\"message\":\"too many\"}}";
+        var rateLimitResponse = new HttpResponseMessage((HttpStatusCode)429)
+        {
+            Content = new StringContent(errorJson, Encoding.UTF8, "application/json")
+        };
+        rateLimitResponse.Headers.Add("Retry-After", "0");
+
+        var successJson = "{\"id\":\"user-id\",\"type\":\"user\",\"data\":{\"attributes\":{\"username\":\"name\",\"role\":\"user\"}}}";
+        var successResponse = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(successJson, Encoding.UTF8, "application/json")
+        };
+
+        var handler = new QueueHandler(rateLimitResponse, successResponse);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var user = await client.ExecuteWithRateLimitRetryAsync(c => c.GetUserAsync("user-id"));
+
+        Assert.NotNull(user);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task ExecuteWithRateLimitRetryAsync_PrefersServerRetryAfter()
+    {
+        var errorJson = "{\"error\":{\"code\":\"RateLimitExceeded\",\"message\":\"too many\"}}";
+        var rateLimitResponse = new HttpResponseMessage((HttpStatusCode)429)
+        {
+            Content = new StringContent(errorJson, Encoding.UTF8, "application/json")
+        };
+        rateLimitResponse.Headers.Add("Retry-After", "0");
+
+        var successJson = "{\"id\":\"user-id\",\"type\":\"user\",\"data\":{\"attributes\":{\"username\":\"name\",\"role\":\"user\"}}}";
+        var successResponse = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(successJson, Encoding.UTF8, "application/json")
+        };
+
+        var handler = new QueueHandler(rateLimitResponse, successResponse);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var sw = Stopwatch.StartNew();
+        var user = await client.ExecuteWithRateLimitRetryAsync(
+            c => c.GetUserAsync("user-id"),
+            maxRetries: 1,
+            defaultRetryDelay: TimeSpan.FromMinutes(1));
+        sw.Stop();
+
+        Assert.NotNull(user);
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task ExecuteWithRateLimitRetryAsync_ThrowsAfterMaxRetries()
+    {
+        var errorJson = "{\"error\":{\"code\":\"RateLimitExceeded\",\"message\":\"too many\"}}";        
+        HttpResponseMessage CreateRateLimitResponse()
+        {
+            var response = new HttpResponseMessage((HttpStatusCode)429)
+            {
+                Content = new StringContent(errorJson, Encoding.UTF8, "application/json")
+            };
+            response.Headers.Add("Retry-After", "0");
+            return response;
+        }
+
+        var handler = new QueueHandler(
+            CreateRateLimitResponse(),
+            CreateRateLimitResponse(),
+            CreateRateLimitResponse());
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await Assert.ThrowsAsync<RateLimitExceededException>(() =>
+            client.ExecuteWithRateLimitRetryAsync(c => c.GetUserAsync("user-id"), maxRetries: 2));
+
+        Assert.Equal(3, handler.Requests.Count);
+    }
+}


### PR DESCRIPTION
## Summary
- allow configuring rate limit retry count and default delay
- demonstrate custom retry options in example
- add unit test verifying exception after max retries reached
- clarify server delay precedence and test default delay override

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6899a857149c832eb698cd5e7539a3b1