### PR TITLE
Add pagination support for comments and votes

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetCommentsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetCommentsExample.cs
@@ -11,8 +11,13 @@ public static class GetCommentsExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var comments = await client.GetCommentsAsync(ResourceType.File, "file-id");
-            Console.WriteLine(comments?.Count);
+            var first = await client.GetCommentsAsync(ResourceType.File, "file-id", limit: 10);
+            Console.WriteLine(first?.Data.Count);
+            if (!string.IsNullOrEmpty(first?.Meta?.Cursor))
+            {
+                var next = await client.GetCommentsAsync(ResourceType.File, "file-id", cursor: first.Meta.Cursor);
+                Console.WriteLine(next?.Data.Count);
+            }
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/GetVotesExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetVotesExample.cs
@@ -11,8 +11,13 @@ public static class GetVotesExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var votes = await client.GetVotesAsync(ResourceType.File, "file-id");
-            Console.WriteLine(votes?.Count);
+            var first = await client.GetVotesAsync(ResourceType.File, "file-id", limit: 10);
+            Console.WriteLine(first?.Data.Count);
+            if (!string.IsNullOrEmpty(first?.Meta?.Cursor))
+            {
+                var next = await client.GetVotesAsync(ResourceType.File, "file-id", cursor: first.Meta.Cursor);
+                Console.WriteLine(next?.Data.Count);
+            }
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer/Models/Comment.cs
+++ b/VirusTotalAnalyzer/Models/Comment.cs
@@ -29,6 +29,9 @@ public sealed class CommentsResponse
 {
     [JsonPropertyName("data")]
     public List<Comment> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public PaginationMetadata? Meta { get; set; }
 }
 
 public sealed class CommentResponse

--- a/VirusTotalAnalyzer/Models/Vote.cs
+++ b/VirusTotalAnalyzer/Models/Vote.cs
@@ -29,6 +29,9 @@ public sealed class VotesResponse
 {
     [JsonPropertyName("data")]
     public List<Vote> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public PaginationMetadata? Meta { get; set; }
 }
 
 public sealed class VoteResponse


### PR DESCRIPTION
## Summary
- support optional limit and cursor when retrieving community comments or votes
- include pagination metadata in comment and vote responses
- document and test paginated retrieval examples

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6899b58daa9c832eb9e38f74e511099e