### PR TITLE
Add helper to compute VT URL identifiers and overload for raw URL reports

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetUrlReportFromUrlExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetUrlReportFromUrlExample.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetUrlReportFromUrlExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var report = await client.GetUrlReportAsync(new Uri("https://example.com"));
+            Console.WriteLine(report?.Id);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Examples/Program.cs
+++ b/VirusTotalAnalyzer.Examples/Program.cs
@@ -5,6 +5,7 @@ using VirusTotalAnalyzer.Examples;
 
 // await GetFileReportExample.RunAsync();
 // await GetUrlReportExample.RunAsync();
+// await GetUrlReportFromUrlExample.RunAsync();
 // await GetIpAddressReportExample.RunAsync();
 // await GetDomainReportExample.RunAsync();
 // await GetAnalysisExample.RunAsync();

--- a/VirusTotalAnalyzer.Tests/UrlIdTests.cs
+++ b/VirusTotalAnalyzer.Tests/UrlIdTests.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Text;
+using VirusTotalAnalyzer;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public class UrlIdTests
+{
+    [Fact]
+    public void GetUrlId_CanonicalizesAndEncodes()
+    {
+        var id = VirusTotalClientExtensions.GetUrlId("HTTP://Virustotal.com");
+        const string canonical = "http://virustotal.com/";
+        var expected = Convert.ToBase64String(Encoding.UTF8.GetBytes(canonical))
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+        Assert.Equal(expected, id);
+    }
+}

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Core.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Core.cs
@@ -294,6 +294,30 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetUrlReportAsync_WithUrl_ComputesIdentifier()
+    {
+        var url = new Uri("https://example.com");
+        var id = VirusTotalClientExtensions.GetUrlId(url.ToString());
+        var json = $"{{\"id\":\"{id}\",\"type\":\"url\"}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var report = await client.GetUrlReportAsync(url);
+
+        Assert.NotNull(report);
+        Assert.Equal(id, report!.Id);
+        Assert.NotNull(handler.Request);
+        Assert.Equal($"/api/v3/urls/{id}", handler.Request!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
     public async Task CreateCommentAsync_PostsComment()
     {
         var json = @"{""data"":{""id"":""c1"",""type"":""comment"",""data"":{""attributes"":{""date"":1,""text"":""hello""}}}}";

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -91,6 +91,12 @@ public sealed partial class VirusTotalClient
             .ConfigureAwait(false);
     }
 
+    public Task<UrlReport?> GetUrlReportAsync(Uri url, CancellationToken cancellationToken = default)
+    {
+        if (url == null) throw new ArgumentNullException(nameof(url));
+        return GetUrlReportAsync(VirusTotalClientExtensions.GetUrlId(url.ToString()), cancellationToken);
+    }
+
     public async Task<IpAddressReport?> GetIpAddressReportAsync(string id, CancellationToken cancellationToken = default)
     {
         using var response = await _httpClient.GetAsync($"ip_addresses/{id}", cancellationToken).ConfigureAwait(false);

--- a/VirusTotalAnalyzer/VirusTotalClientExtensions.cs
+++ b/VirusTotalAnalyzer/VirusTotalClientExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using VirusTotalAnalyzer.Models;
@@ -8,6 +9,19 @@ namespace VirusTotalAnalyzer;
 
 public static class VirusTotalClientExtensions
 {
+    public static string GetUrlId(string url)
+    {
+        if (url == null) throw new ArgumentNullException(nameof(url));
+
+        var uri = new Uri(url, UriKind.Absolute);
+        var canonical = uri.GetComponents(UriComponents.AbsoluteUri, UriFormat.SafeUnescaped);
+        var bytes = Encoding.UTF8.GetBytes(canonical);
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
     public static Task<AnalysisReport?> ScanFileAsync(this VirusTotalClient client, string filePath, CancellationToken cancellationToken = default)
     {
         if (client == null) throw new ArgumentNullException(nameof(client));


### PR DESCRIPTION
## Summary
- add `GetUrlId` helper that canonicalizes a URL and encodes it as an unpadded Base64 VT identifier
- overload `GetUrlReportAsync` to accept a `Uri` and delegate to the identifier-based method
- include example and tests for URL identifier generation and raw URL lookups

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6899b5798a48832e8ee2985fd64740f8