### PR TITLE
Add pagination support for file name retrieval

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetFileNamesExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileNamesExample.cs
@@ -11,10 +11,14 @@ public static class GetFileNamesExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var names = await client.GetFileNamesAsync("44d88612fea8a8f36de82e1278abb02f");
-            foreach (var name in names?.Data ?? [])
+            var (names, cursor) = await client.GetFileNamesAsync("44d88612fea8a8f36de82e1278abb02f");
+            foreach (var name in names)
             {
                 Console.WriteLine($"{name.Id} (first seen: {name.Attributes.Date:u})");
+            }
+            if (cursor != null)
+            {
+                Console.WriteLine($"More names available. Next cursor: {cursor}");
             }
         }
         catch (ApiException ex)


### PR DESCRIPTION
## Summary
- extend `GetFileNamesAsync` to page through results and return a resume cursor
- update example to show accessing returned cursor
- add unit tests covering multi-page aggregation and limit handling

## Testing
- `dotnet build VirusTotalAnalyzer.sln`
- `dotnet test VirusTotalAnalyzer.sln`

------
https://chatgpt.com/codex/tasks/task_e_6899bac17284832ea18623ed6573472f