### PR TITLE
Add models and client methods for crowdsourced YARA and IDS results

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetCrowdsourcedResultsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetCrowdsourcedResultsExample.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetCrowdsourcedResultsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var yaraResults = await client.GetCrowdsourcedYaraResultsAsync("44d88612fea8a8f36de82e1278abb02f");
+            Console.WriteLine(yaraResults?.Count);
+
+            var idsResults = await client.GetCrowdsourcedIdsResultsAsync("44d88612fea8a8f36de82e1278abb02f");
+            Console.WriteLine(idsResults?.Count);
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Crowdsourced.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Crowdsourced.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public partial class VirusTotalClientTests
+{
+    [Fact]
+    public async Task GetCrowdsourcedYaraResultsAsync_DeserializesResponse()
+    {
+        var json = "{\"data\":[{\"rule_name\":\"r1\",\"ruleset_id\":\"rs1\"}]}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var results = await client.GetCrowdsourcedYaraResultsAsync("abc");
+
+        Assert.NotNull(results);
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/files/abc/crowdsourced_yara_results", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal("r1", results![0].RuleName);
+        Assert.Equal("rs1", results[0].RulesetId);
+    }
+
+    [Fact]
+    public async Task GetCrowdsourcedYaraResultsAsync_ThrowsApiException()
+    {
+        var errorJson = "{\"error\":{\"code\":\"NotFoundError\",\"message\":\"not found\"}}";
+        var response = new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent(errorJson, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var ex = await Assert.ThrowsAsync<ApiException>(() => client.GetCrowdsourcedYaraResultsAsync("abc"));
+        Assert.Equal("NotFoundError", ex.Error?.Code);
+        Assert.Equal("not found", ex.Message);
+    }
+
+    [Fact]
+    public async Task GetCrowdsourcedIdsResultsAsync_DeserializesResponse()
+    {
+        var json = "{\"data\":[{\"rule_name\":\"r1\",\"rule_id\":\"1\",\"alert_severity\":2}]}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var results = await client.GetCrowdsourcedIdsResultsAsync("abc");
+
+        Assert.NotNull(results);
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/files/abc/crowdsourced_ids_results", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal("r1", results![0].RuleName);
+        Assert.Equal("1", results[0].RuleId);
+        Assert.Equal(2, results[0].AlertSeverity);
+    }
+
+    [Fact]
+    public async Task GetCrowdsourcedIdsResultsAsync_ThrowsApiException()
+    {
+        var errorJson = "{\"error\":{\"code\":\"NotFoundError\",\"message\":\"not found\"}}";
+        var response = new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent(errorJson, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var ex = await Assert.ThrowsAsync<ApiException>(() => client.GetCrowdsourcedIdsResultsAsync("abc"));
+        Assert.Equal("NotFoundError", ex.Error?.Code);
+        Assert.Equal("not found", ex.Message);
+    }
+}

--- a/VirusTotalAnalyzer/Models/CrowdsourcedIdsResult.cs
+++ b/VirusTotalAnalyzer/Models/CrowdsourcedIdsResult.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class CrowdsourcedIdsResult
+{
+    [JsonPropertyName("rule_name")]
+    public string? RuleName { get; set; }
+
+    [JsonPropertyName("rule_id")]
+    public string? RuleId { get; set; }
+
+    [JsonPropertyName("ruleset_id")]
+    public string? RulesetId { get; set; }
+
+    [JsonPropertyName("ruleset_name")]
+    public string? RulesetName { get; set; }
+
+    [JsonPropertyName("source")]
+    public string? Source { get; set; }
+
+    [JsonPropertyName("alert_severity")]
+    public int AlertSeverity { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+}
+
+public sealed class CrowdsourcedIdsResultsResponse
+{
+    [JsonPropertyName("data")]
+    public List<CrowdsourcedIdsResult> Data { get; set; } = new();
+}

--- a/VirusTotalAnalyzer/Models/CrowdsourcedYaraResult.cs
+++ b/VirusTotalAnalyzer/Models/CrowdsourcedYaraResult.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class CrowdsourcedYaraResult
+{
+    [JsonPropertyName("rule_name")]
+    public string? RuleName { get; set; }
+
+    [JsonPropertyName("ruleset_id")]
+    public string? RulesetId { get; set; }
+
+    [JsonPropertyName("ruleset_name")]
+    public string? RulesetName { get; set; }
+
+    [JsonPropertyName("source")]
+    public string? Source { get; set; }
+
+    [JsonPropertyName("author")]
+    public string? Author { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+}
+
+public sealed class CrowdsourcedYaraResultsResponse
+{
+    [JsonPropertyName("data")]
+    public List<CrowdsourcedYaraResult> Data { get; set; } = new();
+}

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -67,6 +67,32 @@ public sealed partial class VirusTotalClient
             .ConfigureAwait(false);
     }
 
+    public async Task<IReadOnlyList<CrowdsourcedYaraResult>?> GetCrowdsourcedYaraResultsAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"files/{id}/crowdsourced_yara_results", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<CrowdsourcedYaraResultsResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+        return result?.Data;
+    }
+
+    public async Task<IReadOnlyList<CrowdsourcedIdsResult>?> GetCrowdsourcedIdsResultsAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"files/{id}/crowdsourced_ids_results", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<CrowdsourcedIdsResultsResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+        return result?.Data;
+    }
+
     public async Task<Stream> DownloadFileAsync(string id, CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.GetAsync($"files/{id}/download", HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- add `CrowdsourcedYaraResult` and `CrowdsourcedIdsResult` models
- expose `GetCrowdsourcedYaraResultsAsync` and `GetCrowdsourcedIdsResultsAsync` in the analysis client
- demonstrate new API usage in `GetCrowdsourcedResultsExample`
- test new client methods

## Testing
- `~/.dotnet/dotnet build VirusTotalAnalyzer.sln`
- `~/.dotnet/dotnet test VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6899bac52224832e97aef48631990e47