### PR TITLE
Validate GetFeedAsync resource types

### DIFF
--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
@@ -538,4 +538,17 @@ public partial class VirusTotalClientTests
         Assert.Equal("next", feed?.Meta?.Cursor);
     }
 
+    [Fact]
+    public async Task GetFeedAsync_ThrowsForUnsupportedResourceType()
+    {
+        var handler = new StubHandler("{\"data\":[]}");
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => client.GetFeedAsync(ResourceType.Analysis));
+    }
+
 }

--- a/VirusTotalAnalyzer/VirusTotalClient.Intelligence.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Intelligence.cs
@@ -288,6 +288,14 @@ public sealed partial class VirusTotalClient
 
     public async Task<FeedResponse?> GetFeedAsync(ResourceType resourceType, int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
     {
+        if (resourceType != ResourceType.File &&
+            resourceType != ResourceType.Url &&
+            resourceType != ResourceType.Domain &&
+            resourceType != ResourceType.IpAddress)
+        {
+            throw new ArgumentOutOfRangeException(nameof(resourceType));
+        }
+
         var path = new StringBuilder($"feeds/{GetPath(resourceType)}");
         var hasQuery = false;
         if (limit.HasValue)


### PR DESCRIPTION
## Summary
- validate `GetFeedAsync` resource types to only allow files, URLs, domains, or IPs
- throw `ArgumentOutOfRangeException` when unsupported feed resource type is requested
- test that invalid resource types are rejected

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6899d211e620832ea80ef6880f359346