### PR TITLE
Add file relationship helpers and summaries

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetFileContactedDomainsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileContactedDomainsExample.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetFileContactedDomainsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var domains = await client.GetFileContactedDomainsAsync("44d88612fea8a8f36de82e1278abb02f");
+            foreach (var domain in domains ?? [])
+            {
+                Console.WriteLine(domain.Attributes.Domain);
+            }
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Examples/GetFileContactedIpsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileContactedIpsExample.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetFileContactedIpsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var ips = await client.GetFileContactedIpsAsync("44d88612fea8a8f36de82e1278abb02f");
+            foreach (var ip in ips ?? [])
+            {
+                Console.WriteLine(ip.Attributes.IpAddress);
+            }
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Examples/GetFileContactedUrlsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileContactedUrlsExample.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetFileContactedUrlsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var urls = await client.GetFileContactedUrlsAsync("44d88612fea8a8f36de82e1278abb02f");
+            foreach (var url in urls ?? [])
+            {
+                Console.WriteLine(url.Attributes.Url);
+            }
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Examples/GetFileReferrerFilesExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileReferrerFilesExample.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetFileReferrerFilesExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var files = await client.GetFileReferrerFilesAsync("44d88612fea8a8f36de82e1278abb02f");
+            foreach (var file in files ?? [])
+            {
+                Console.WriteLine(file.Id);
+            }
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Relationships.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Relationships.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public partial class VirusTotalClientTests
+{
+    [Fact]
+    public async Task GetFileContactedUrlsAsync_DeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"1\",\"type\":\"url\",\"attributes\":{\"url\":\"http://example.com\"}}]}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var urls = await client.GetFileContactedUrlsAsync("abc");
+
+        Assert.NotNull(urls);
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/files/abc/contacted_urls", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal("http://example.com", urls![0].Attributes.Url);
+    }
+
+    [Fact]
+    public async Task GetFileContactedUrlsAsync_ThrowsApiException()
+    {
+        var errorJson = "{\"error\":{\"code\":\"NotFoundError\",\"message\":\"not found\"}}";
+        var response = new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent(errorJson, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var ex = await Assert.ThrowsAsync<ApiException>(() => client.GetFileContactedUrlsAsync("abc"));
+        Assert.Equal("NotFoundError", ex.Error?.Code);
+        Assert.Equal("not found", ex.Message);
+    }
+
+    [Fact]
+    public async Task GetFileContactedDomainsAsync_DeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"1\",\"type\":\"domain\",\"attributes\":{\"domain\":\"example.com\"}}]}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var domains = await client.GetFileContactedDomainsAsync("abc");
+
+        Assert.NotNull(domains);
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/files/abc/contacted_domains", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal("example.com", domains![0].Attributes.Domain);
+    }
+
+    [Fact]
+    public async Task GetFileContactedDomainsAsync_ThrowsApiException()
+    {
+        var errorJson = "{\"error\":{\"code\":\"NotFoundError\",\"message\":\"not found\"}}";
+        var response = new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent(errorJson, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var ex = await Assert.ThrowsAsync<ApiException>(() => client.GetFileContactedDomainsAsync("abc"));
+        Assert.Equal("NotFoundError", ex.Error?.Code);
+        Assert.Equal("not found", ex.Message);
+    }
+
+    [Fact]
+    public async Task GetFileContactedIpsAsync_DeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"1\",\"type\":\"ipAddress\",\"attributes\":{\"ip_address\":\"1.2.3.4\"}}]}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var ips = await client.GetFileContactedIpsAsync("abc");
+
+        Assert.NotNull(ips);
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/files/abc/contacted_ips", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal("1.2.3.4", ips![0].Attributes.IpAddress);
+    }
+
+    [Fact]
+    public async Task GetFileContactedIpsAsync_ThrowsApiException()
+    {
+        var errorJson = "{\"error\":{\"code\":\"NotFoundError\",\"message\":\"not found\"}}";
+        var response = new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent(errorJson, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var ex = await Assert.ThrowsAsync<ApiException>(() => client.GetFileContactedIpsAsync("abc"));
+        Assert.Equal("NotFoundError", ex.Error?.Code);
+        Assert.Equal("not found", ex.Message);
+    }
+
+    [Fact]
+    public async Task GetFileReferrerFilesAsync_DeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"file1\",\"type\":\"file\"}]}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var files = await client.GetFileReferrerFilesAsync("abc");
+
+        Assert.NotNull(files);
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/files/abc/referrer_files", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal("file1", files![0].Id);
+    }
+
+    [Fact]
+    public async Task GetFileReferrerFilesAsync_ThrowsApiException()
+    {
+        var errorJson = "{\"error\":{\"code\":\"NotFoundError\",\"message\":\"not found\"}}";
+        var response = new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent(errorJson, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var ex = await Assert.ThrowsAsync<ApiException>(() => client.GetFileReferrerFilesAsync("abc"));
+        Assert.Equal("NotFoundError", ex.Error?.Code);
+        Assert.Equal("not found", ex.Message);
+    }
+}
+

--- a/VirusTotalAnalyzer/Models/DomainSummary.cs
+++ b/VirusTotalAnalyzer/Models/DomainSummary.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class DomainSummary
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("type")]
+    public ResourceType Type { get; set; }
+
+    [JsonPropertyName("attributes")]
+    public DomainSummaryAttributes Attributes { get; set; } = new();
+}
+
+public sealed class DomainSummaryAttributes
+{
+    [JsonPropertyName("domain")]
+    public string Domain { get; set; } = string.Empty;
+
+    [JsonPropertyName("last_analysis_stats")]
+    public AnalysisStats LastAnalysisStats { get; set; } = new();
+}
+
+public sealed class DomainSummariesResponse
+{
+    [JsonPropertyName("data")]
+    public List<DomainSummary> Data { get; set; } = new();
+}

--- a/VirusTotalAnalyzer/Models/IpAddressSummary.cs
+++ b/VirusTotalAnalyzer/Models/IpAddressSummary.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class IpAddressSummary
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("type")]
+    public ResourceType Type { get; set; }
+
+    [JsonPropertyName("attributes")]
+    public IpAddressSummaryAttributes Attributes { get; set; } = new();
+}
+
+public sealed class IpAddressSummaryAttributes
+{
+    [JsonPropertyName("ip_address")]
+    public string IpAddress { get; set; } = string.Empty;
+
+    [JsonPropertyName("last_analysis_stats")]
+    public AnalysisStats LastAnalysisStats { get; set; } = new();
+}
+
+public sealed class IpAddressSummariesResponse
+{
+    [JsonPropertyName("data")]
+    public List<IpAddressSummary> Data { get; set; } = new();
+}

--- a/VirusTotalAnalyzer/Models/UrlSummary.cs
+++ b/VirusTotalAnalyzer/Models/UrlSummary.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class UrlSummary
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("type")]
+    public ResourceType Type { get; set; }
+
+    [JsonPropertyName("attributes")]
+    public UrlSummaryAttributes Attributes { get; set; } = new();
+}
+
+public sealed class UrlSummaryAttributes
+{
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = string.Empty;
+
+    [JsonPropertyName("last_analysis_stats")]
+    public AnalysisStats LastAnalysisStats { get; set; } = new();
+}
+
+public sealed class UrlSummariesResponse
+{
+    [JsonPropertyName("data")]
+    public List<UrlSummary> Data { get; set; } = new();
+}

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -93,6 +93,58 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
+    public async Task<IReadOnlyList<UrlSummary>?> GetFileContactedUrlsAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"files/{id}/contacted_urls", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<UrlSummariesResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+        return result?.Data;
+    }
+
+    public async Task<IReadOnlyList<DomainSummary>?> GetFileContactedDomainsAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"files/{id}/contacted_domains", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<DomainSummariesResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+        return result?.Data;
+    }
+
+    public async Task<IReadOnlyList<IpAddressSummary>?> GetFileContactedIpsAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"files/{id}/contacted_ips", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<IpAddressSummariesResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+        return result?.Data;
+    }
+
+    public async Task<IReadOnlyList<Relationship>?> GetFileReferrerFilesAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"files/{id}/referrer_files", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<RelationshipResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+        return result?.Data;
+    }
+
     public async Task<Stream> DownloadFileAsync(string id, CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.GetAsync($"files/{id}/download", HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- add UrlSummary, DomainSummary, and IpAddressSummary models
- add VirusTotalClient helpers for file relationship lookups
- cover new helpers with unit tests and examples

## Testing
- `dotnet build -c Release`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6899d1f89634832e8393f37077d66e13