### PR TITLE
Add relationship methods for domain and IP data

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetDomainResolutionsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetDomainResolutionsExample.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetDomainResolutionsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var resolutions = await client.GetDomainResolutionsAsync("example.com");
+            Console.WriteLine(resolutions?.Count);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Examples/GetDomainSubmissionsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetDomainSubmissionsExample.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetDomainSubmissionsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var submissions = await client.GetDomainSubmissionsAsync("example.com");
+            Console.WriteLine(submissions?.Count);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Examples/GetIpAddressResolutionsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetIpAddressResolutionsExample.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetIpAddressResolutionsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var resolutions = await client.GetIpAddressResolutionsAsync("1.2.3.4");
+            Console.WriteLine(resolutions?.Count);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Examples/GetIpAddressSubmissionsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetIpAddressSubmissionsExample.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetIpAddressSubmissionsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var submissions = await client.GetIpAddressSubmissionsAsync("1.2.3.4");
+            Console.WriteLine(submissions?.Count);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Relationships.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Relationships.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public partial class VirusTotalClientTests
+{
+    [Fact]
+    public async Task GetDomainResolutionsAsync_UsesCorrectPathAndDeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"r1\",\"type\":\"resolution\",\"data\":{\"attributes\":{\"host_name\":\"example.com\",\"ip_address\":\"1.2.3.4\",\"date\":1}}}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var resolutions = await client.GetDomainResolutionsAsync("example.com");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/domains/example.com/resolutions", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.NotNull(resolutions);
+        Assert.Single(resolutions!);
+        Assert.Equal("1.2.3.4", resolutions[0].Data.Attributes.IpAddress);
+    }
+
+    [Fact]
+    public async Task GetDomainSubmissionsAsync_UsesCorrectPathAndDeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"s1\",\"type\":\"submission\",\"data\":{\"attributes\":{\"date\":1}}}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var submissions = await client.GetDomainSubmissionsAsync("example.com");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/domains/example.com/submissions", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.NotNull(submissions);
+        Assert.Single(submissions!);
+        Assert.Equal(1, submissions[0].Data.Attributes.Date.ToUnixTimeSeconds());
+    }
+
+    [Fact]
+    public async Task GetIpAddressResolutionsAsync_UsesCorrectPathAndDeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"r1\",\"type\":\"resolution\",\"data\":{\"attributes\":{\"host_name\":\"example.com\",\"ip_address\":\"1.2.3.4\",\"date\":1}}}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var resolutions = await client.GetIpAddressResolutionsAsync("1.2.3.4");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/ip_addresses/1.2.3.4/resolutions", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.NotNull(resolutions);
+        Assert.Single(resolutions!);
+        Assert.Equal("example.com", resolutions[0].Data.Attributes.HostName);
+    }
+
+    [Fact]
+    public async Task GetIpAddressSubmissionsAsync_UsesCorrectPathAndDeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"s1\",\"type\":\"submission\",\"data\":{\"attributes\":{\"date\":1}}}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var submissions = await client.GetIpAddressSubmissionsAsync("1.2.3.4");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/ip_addresses/1.2.3.4/submissions", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.NotNull(submissions);
+        Assert.Single(submissions!);
+        Assert.Equal(1, submissions[0].Data.Attributes.Date.ToUnixTimeSeconds());
+    }
+}

--- a/VirusTotalAnalyzer/Models/Resolution.cs
+++ b/VirusTotalAnalyzer/Models/Resolution.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class Resolution
+{
+    public string Id { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public ResolutionData Data { get; set; } = new();
+}
+
+public sealed class ResolutionData
+{
+    public ResolutionAttributes Attributes { get; set; } = new();
+}
+
+public sealed class ResolutionAttributes
+{
+    [JsonPropertyName("date")]
+    public DateTimeOffset Date { get; set; }
+
+    [JsonPropertyName("host_name")]
+    public string? HostName { get; set; }
+
+    [JsonPropertyName("ip_address")]
+    public string? IpAddress { get; set; }
+}
+
+public sealed class ResolutionsResponse
+{
+    [JsonPropertyName("data")]
+    public List<Resolution> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public PaginationMetadata? Meta { get; set; }
+}

--- a/VirusTotalAnalyzer/Models/Submission.cs
+++ b/VirusTotalAnalyzer/Models/Submission.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class Submission
+{
+    public string Id { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public SubmissionData Data { get; set; } = new();
+}
+
+public sealed class SubmissionData
+{
+    public SubmissionAttributes Attributes { get; set; } = new();
+}
+
+public sealed class SubmissionAttributes
+{
+    [JsonPropertyName("date")]
+    public DateTimeOffset Date { get; set; }
+}
+
+public sealed class SubmissionsResponse
+{
+    [JsonPropertyName("data")]
+    public List<Submission> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public PaginationMetadata? Meta { get; set; }
+}

--- a/VirusTotalAnalyzer/VirusTotalClient.Relationships.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Relationships.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer;
+
+public sealed partial class VirusTotalClient
+{
+    public Task<IReadOnlyList<Resolution>?> GetDomainResolutionsAsync(string id, CancellationToken cancellationToken = default)
+        => GetResolutionsAsync(ResourceType.Domain, id, cancellationToken);
+
+    public Task<IReadOnlyList<Submission>?> GetDomainSubmissionsAsync(string id, CancellationToken cancellationToken = default)
+        => GetSubmissionsAsync(ResourceType.Domain, id, cancellationToken);
+
+    public Task<IReadOnlyList<Resolution>?> GetIpAddressResolutionsAsync(string id, CancellationToken cancellationToken = default)
+        => GetResolutionsAsync(ResourceType.IpAddress, id, cancellationToken);
+
+    public Task<IReadOnlyList<Submission>?> GetIpAddressSubmissionsAsync(string id, CancellationToken cancellationToken = default)
+        => GetSubmissionsAsync(ResourceType.IpAddress, id, cancellationToken);
+
+    private async Task<IReadOnlyList<Resolution>?> GetResolutionsAsync(ResourceType resourceType, string id, CancellationToken cancellationToken)
+    {
+        using var response = await _httpClient.GetAsync($"{GetPath(resourceType)}/{id}/resolutions", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<ResolutionsResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+        return result?.Data;
+    }
+
+    private async Task<IReadOnlyList<Submission>?> GetSubmissionsAsync(ResourceType resourceType, string id, CancellationToken cancellationToken)
+    {
+        using var response = await _httpClient.GetAsync($"{GetPath(resourceType)}/{id}/submissions", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<SubmissionsResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+        return result?.Data;
+    }
+}


### PR DESCRIPTION
## Summary
- add `GetDomainResolutionsAsync`/`GetDomainSubmissionsAsync`
- add `GetIpAddressResolutionsAsync`/`GetIpAddressSubmissionsAsync`
- model resolution and submission responses
- cover new helpers with tests and examples

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6899d1fdcf0c832e8cef64c26b60cd15