### PR TITLE
Add file relationship helpers and summary models

### DIFF
--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.AnalysisRelationships.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.AnalysisRelationships.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public partial class VirusTotalClientTests
+{
+    [Fact]
+    public async Task GetFileContactedUrlsAsync_UsesCorrectPathAndDeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"u1\",\"type\":\"url\",\"data\":{\"attributes\":{\"url\":\"https://example.com\"}}}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var urls = await client.GetFileContactedUrlsAsync("abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/files/abc/contacted_urls", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.NotNull(urls);
+        Assert.Single(urls!);
+        Assert.Equal("https://example.com", urls[0].Data.Attributes.Url);
+    }
+
+    [Fact]
+    public async Task GetFileContactedDomainsAsync_UsesCorrectPathAndDeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"d1\",\"type\":\"domain\",\"data\":{\"attributes\":{\"domain\":\"example.com\"}}}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var domains = await client.GetFileContactedDomainsAsync("abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/files/abc/contacted_domains", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.NotNull(domains);
+        Assert.Single(domains!);
+        Assert.Equal("example.com", domains[0].Data.Attributes.Domain);
+    }
+
+    [Fact]
+    public async Task GetFileContactedIpsAsync_UsesCorrectPathAndDeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"i1\",\"type\":\"ipAddress\",\"data\":{\"attributes\":{\"ip_address\":\"1.2.3.4\"}}}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var ips = await client.GetFileContactedIpsAsync("abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/files/abc/contacted_ips", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.NotNull(ips);
+        Assert.Single(ips!);
+        Assert.Equal("1.2.3.4", ips[0].Data.Attributes.IpAddress);
+    }
+
+    [Fact]
+    public async Task GetFileReferrerFilesAsync_UsesCorrectPathAndDeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"data\":{\"attributes\":{\"md5\":\"abc\"}}}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var files = await client.GetFileReferrerFilesAsync("abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/files/abc/referrer_files", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.NotNull(files);
+        Assert.Single(files!);
+        Assert.Equal("abc", files[0].Data.Attributes.Md5);
+    }
+}
+

--- a/VirusTotalAnalyzer/Models/DomainSummary.cs
+++ b/VirusTotalAnalyzer/Models/DomainSummary.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class DomainSummary
+{
+    public string Id { get; set; } = string.Empty;
+    public ResourceType Type { get; set; }
+    public DomainSummaryData Data { get; set; } = new();
+}
+
+public sealed class DomainSummaryData
+{
+    public DomainSummaryAttributes Attributes { get; set; } = new();
+}
+
+public sealed class DomainSummaryAttributes
+{
+    [JsonPropertyName("domain")]
+    public string Domain { get; set; } = string.Empty;
+
+    [JsonPropertyName("last_analysis_stats")]
+    public AnalysisStats LastAnalysisStats { get; set; } = new();
+
+    [JsonPropertyName("total_votes")]
+    public TotalVotes TotalVotes { get; set; } = new();
+}
+
+public sealed class DomainSummariesResponse
+{
+    [JsonPropertyName("data")]
+    public List<DomainSummary> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public PaginationMetadata? Meta { get; set; }
+}
+

--- a/VirusTotalAnalyzer/Models/FileReport.cs
+++ b/VirusTotalAnalyzer/Models/FileReport.cs
@@ -72,3 +72,13 @@ public sealed class FileAttributes
     [JsonPropertyName("crowdsourced_verdicts")]
     public List<CrowdsourcedVerdict> CrowdsourcedVerdicts { get; set; } = new();
 }
+
+public sealed class FileReportsResponse
+{
+    [JsonPropertyName("data")]
+    public List<FileReport> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public PaginationMetadata? Meta { get; set; }
+}
+

--- a/VirusTotalAnalyzer/Models/IpAddressSummary.cs
+++ b/VirusTotalAnalyzer/Models/IpAddressSummary.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class IpAddressSummary
+{
+    public string Id { get; set; } = string.Empty;
+    public ResourceType Type { get; set; }
+    public IpAddressSummaryData Data { get; set; } = new();
+}
+
+public sealed class IpAddressSummaryData
+{
+    public IpAddressSummaryAttributes Attributes { get; set; } = new();
+}
+
+public sealed class IpAddressSummaryAttributes
+{
+    [JsonPropertyName("ip_address")]
+    public string IpAddress { get; set; } = string.Empty;
+
+    [JsonPropertyName("last_analysis_stats")]
+    public AnalysisStats LastAnalysisStats { get; set; } = new();
+
+    [JsonPropertyName("total_votes")]
+    public TotalVotes TotalVotes { get; set; } = new();
+}
+
+public sealed class IpAddressSummariesResponse
+{
+    [JsonPropertyName("data")]
+    public List<IpAddressSummary> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public PaginationMetadata? Meta { get; set; }
+}
+

--- a/VirusTotalAnalyzer/Models/UrlSummary.cs
+++ b/VirusTotalAnalyzer/Models/UrlSummary.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class UrlSummary
+{
+    public string Id { get; set; } = string.Empty;
+    public ResourceType Type { get; set; }
+    public UrlSummaryData Data { get; set; } = new();
+}
+
+public sealed class UrlSummaryData
+{
+    public UrlSummaryAttributes Attributes { get; set; } = new();
+}
+
+public sealed class UrlSummaryAttributes
+{
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = string.Empty;
+
+    [JsonPropertyName("last_analysis_stats")]
+    public AnalysisStats LastAnalysisStats { get; set; } = new();
+
+    [JsonPropertyName("total_votes")]
+    public TotalVotes TotalVotes { get; set; } = new();
+}
+
+public sealed class UrlSummariesResponse
+{
+    [JsonPropertyName("data")]
+    public List<UrlSummary> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public PaginationMetadata? Meta { get; set; }
+}
+

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -106,6 +106,58 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
+    public async Task<IReadOnlyList<UrlSummary>?> GetFileContactedUrlsAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"files/{id}/contacted_urls", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<UrlSummariesResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+        return result?.Data;
+    }
+
+    public async Task<IReadOnlyList<DomainSummary>?> GetFileContactedDomainsAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"files/{id}/contacted_domains", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<DomainSummariesResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+        return result?.Data;
+    }
+
+    public async Task<IReadOnlyList<IpAddressSummary>?> GetFileContactedIpsAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"files/{id}/contacted_ips", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<IpAddressSummariesResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+        return result?.Data;
+    }
+
+    public async Task<IReadOnlyList<FileReport>?> GetFileReferrerFilesAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"files/{id}/referrer_files", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<FileReportsResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+        return result?.Data;
+    }
+
     public async Task<Stream> DownloadFileAsync(string id, CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.GetAsync($"files/{id}/download", HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- add typed helpers for file relationship endpoints including contacted URLs, domains, IPs, and referrer files
- introduce URL, domain, and IP address summary models and support collection responses
- test each new helper for proper path usage and deserialization

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6899d6b7da10832e8c5472ce1816d924