### PR TITLE
Add paged results and cursor support for intelligence listing APIs

### DIFF
--- a/VirusTotalAnalyzer.Examples/ListLivehuntNotificationsExample.cs
+++ b/VirusTotalAnalyzer.Examples/ListLivehuntNotificationsExample.cs
@@ -11,11 +11,12 @@ public static class ListLivehuntNotificationsExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var notifications = await client.ListLivehuntNotificationsAsync();
-            foreach (var notification in notifications)
+            var page = await client.ListLivehuntNotificationsAsync(fetchAll: false);
+            foreach (var notification in page.Data)
             {
                 Console.WriteLine(notification.Id);
             }
+            Console.WriteLine($"Next cursor: {page.NextCursor}");
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/ListRetrohuntJobsExample.cs
+++ b/VirusTotalAnalyzer.Examples/ListRetrohuntJobsExample.cs
@@ -11,11 +11,12 @@ public static class ListRetrohuntJobsExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var jobs = await client.ListRetrohuntJobsAsync();
-            foreach (var job in jobs)
+            var page = await client.ListRetrohuntJobsAsync(fetchAll: false);
+            foreach (var job in page.Data)
             {
                 Console.WriteLine(job.Id);
             }
+            Console.WriteLine($"Next cursor: {page.NextCursor}");
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/StartRetrohuntJobExample.cs
+++ b/VirusTotalAnalyzer.Examples/StartRetrohuntJobExample.cs
@@ -26,11 +26,12 @@ public static class StartRetrohuntJobExample
             }
             while (current != null && current.Data.Attributes.Status != "done");
 
-            var notifications = await client.ListRetrohuntNotificationsAsync();
-            foreach (var n in notifications)
+            var page = await client.ListRetrohuntNotificationsAsync(fetchAll: false);
+            foreach (var n in page.Data)
             {
                 Console.WriteLine($"Notification {n.Id} from job {n.Data.Attributes.JobId}");
             }
+            Console.WriteLine($"Next cursor: {page.NextCursor}");
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
@@ -29,12 +29,34 @@ public partial class VirusTotalClientTests
 
         var notifications = await client.ListRetrohuntNotificationsAsync(limit: 1);
 
-        Assert.Equal(2, notifications.Count);
-        Assert.Equal("n1", notifications[0].Id);
-        Assert.Equal("n2", notifications[1].Id);
+        Assert.Equal(2, notifications.Data.Count);
+        Assert.Null(notifications.NextCursor);
+        Assert.Equal("n1", notifications.Data[0].Id);
+        Assert.Equal("n2", notifications.Data[1].Id);
         Assert.Equal(2, handler.Requests.Count);
         Assert.Contains("limit=1", handler.Requests[0].RequestUri!.Query);
         Assert.Contains("cursor=abc", handler.Requests[1].RequestUri!.Query);
+    }
+
+    [Fact]
+    public async Task ListRetrohuntNotificationsAsync_SinglePage()
+    {
+        var first = "{\"data\":[{\"id\":\"n1\",\"type\":\"retrohuntNotification\",\"data\":{\"attributes\":{\"job_id\":\"j1\"}}}],\"meta\":{\"cursor\":\"abc\"}}";
+        var handler = new QueueHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(first, Encoding.UTF8, "application/json") });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var page = await client.ListRetrohuntNotificationsAsync(limit: 1, fetchAll: false);
+
+        Assert.Single(page.Data);
+        Assert.Equal("n1", page.Data[0].Id);
+        Assert.Equal("abc", page.NextCursor);
+        Assert.Single(handler.Requests);
+        Assert.Contains("limit=1", handler.Requests[0].RequestUri!.Query);
     }
 
     [Fact]
@@ -339,12 +361,37 @@ public partial class VirusTotalClientTests
 
         var jobs = await client.ListRetrohuntJobsAsync(limit: 1);
 
-        Assert.Equal(2, jobs.Count);
-        Assert.Equal("j1", jobs[0].Id);
-        Assert.Equal("j2", jobs[1].Id);
+        Assert.Equal(2, jobs.Data.Count);
+        Assert.Null(jobs.NextCursor);
+        Assert.Equal("j1", jobs.Data[0].Id);
+        Assert.Equal("j2", jobs.Data[1].Id);
         Assert.Equal(2, handler.Requests.Count);
         Assert.Contains("limit=1", handler.Requests[0].RequestUri!.Query);
         Assert.Contains("cursor=abc", handler.Requests[1].RequestUri!.Query);
+    }
+
+    [Fact]
+    public async Task ListRetrohuntJobsAsync_SinglePage()
+    {
+        var first = "{\"data\":[{\"id\":\"j1\",\"type\":\"retrohuntJob\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}],\"meta\":{\"cursor\":\"abc\"}}";
+        var handler = new QueueHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(first, Encoding.UTF8, "application/json")
+            });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var page = await client.ListRetrohuntJobsAsync(limit: 1, fetchAll: false);
+
+        Assert.Single(page.Data);
+        Assert.Equal("j1", page.Data[0].Id);
+        Assert.Equal("abc", page.NextCursor);
+        Assert.Single(handler.Requests);
+        Assert.Contains("limit=1", handler.Requests[0].RequestUri!.Query);
     }
 
     [Fact]

--- a/VirusTotalAnalyzer/Models/Page.cs
+++ b/VirusTotalAnalyzer/Models/Page.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class Page<T>
+{
+    public Page(List<T> data, string? nextCursor)
+    {
+        Data = data;
+        NextCursor = nextCursor;
+    }
+
+    public IReadOnlyList<T> Data { get; }
+
+    public string? NextCursor { get; }
+}
+

--- a/VirusTotalAnalyzer/VirusTotalClient.Intelligence.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Intelligence.cs
@@ -27,17 +27,17 @@ public sealed partial class VirusTotalClient
         return await JsonSerializer.DeserializeAsync<LivehuntNotification>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<IReadOnlyList<LivehuntNotification>> ListLivehuntNotificationsAsync(int limit = 10, CancellationToken cancellationToken = default)
+    public async Task<Page<LivehuntNotification>> ListLivehuntNotificationsAsync(int limit = 10, string? cursor = null, bool fetchAll = true, CancellationToken cancellationToken = default)
     {
         var results = new List<LivehuntNotification>();
-        string? cursor = null;
+        var nextCursor = cursor;
 
         do
         {
             var url = $"intelligence/hunting_notifications?limit={limit}";
-            if (!string.IsNullOrEmpty(cursor))
+            if (!string.IsNullOrEmpty(nextCursor))
             {
-                url += $"&cursor={Uri.EscapeDataString(cursor)}";
+                url += $"&cursor={Uri.EscapeDataString(nextCursor)}";
             }
             using var response = await _httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
             await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -51,11 +51,15 @@ public sealed partial class VirusTotalClient
             {
                 results.AddRange(page.Data);
             }
-            cursor = page?.Meta?.Cursor;
+            nextCursor = page?.Meta?.Cursor;
+            if (!fetchAll)
+            {
+                break;
+            }
         }
-        while (!string.IsNullOrEmpty(cursor));
+        while (!string.IsNullOrEmpty(nextCursor));
 
-        return results;
+        return new Page<LivehuntNotification>(results, nextCursor);
     }
 
     public async Task<RetrohuntJob?> GetRetrohuntJobAsync(string id, CancellationToken cancellationToken = default)
@@ -70,17 +74,17 @@ public sealed partial class VirusTotalClient
         return await JsonSerializer.DeserializeAsync<RetrohuntJob>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<IReadOnlyList<RetrohuntJob>> ListRetrohuntJobsAsync(int limit = 10, CancellationToken cancellationToken = default)
+    public async Task<Page<RetrohuntJob>> ListRetrohuntJobsAsync(int limit = 10, string? cursor = null, bool fetchAll = true, CancellationToken cancellationToken = default)
     {
         var results = new List<RetrohuntJob>();
-        string? cursor = null;
+        var nextCursor = cursor;
 
         do
         {
             var url = $"intelligence/retrohunt_jobs?limit={limit}";
-            if (!string.IsNullOrEmpty(cursor))
+            if (!string.IsNullOrEmpty(nextCursor))
             {
-                url += $"&cursor={Uri.EscapeDataString(cursor)}";
+                url += $"&cursor={Uri.EscapeDataString(nextCursor)}";
             }
             using var response = await _httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
             await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -94,11 +98,15 @@ public sealed partial class VirusTotalClient
             {
                 results.AddRange(page.Data);
             }
-            cursor = page?.Meta?.Cursor;
+            nextCursor = page?.Meta?.Cursor;
+            if (!fetchAll)
+            {
+                break;
+            }
         }
-        while (!string.IsNullOrEmpty(cursor));
+        while (!string.IsNullOrEmpty(nextCursor));
 
-        return results;
+        return new Page<RetrohuntJob>(results, nextCursor);
     }
 
     public async Task<RetrohuntJob?> CreateRetrohuntJobAsync(RetrohuntJobRequest request, CancellationToken cancellationToken = default)
@@ -134,17 +142,17 @@ public sealed partial class VirusTotalClient
         return await JsonSerializer.DeserializeAsync<RetrohuntNotification>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<IReadOnlyList<RetrohuntNotification>> ListRetrohuntNotificationsAsync(int limit = 10, CancellationToken cancellationToken = default)
+    public async Task<Page<RetrohuntNotification>> ListRetrohuntNotificationsAsync(int limit = 10, string? cursor = null, bool fetchAll = true, CancellationToken cancellationToken = default)
     {
         var results = new List<RetrohuntNotification>();
-        string? cursor = null;
+        var nextCursor = cursor;
 
         do
         {
             var url = $"intelligence/retrohunt_notifications?limit={limit}";
-            if (!string.IsNullOrEmpty(cursor))
+            if (!string.IsNullOrEmpty(nextCursor))
             {
-                url += $"&cursor={Uri.EscapeDataString(cursor)}";
+                url += $"&cursor={Uri.EscapeDataString(nextCursor)}";
             }
             using var response = await _httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
             await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -158,11 +166,15 @@ public sealed partial class VirusTotalClient
             {
                 results.AddRange(page.Data);
             }
-            cursor = page?.Meta?.Cursor;
+            nextCursor = page?.Meta?.Cursor;
+            if (!fetchAll)
+            {
+                break;
+            }
         }
-        while (!string.IsNullOrEmpty(cursor));
+        while (!string.IsNullOrEmpty(nextCursor));
 
-        return results;
+        return new Page<RetrohuntNotification>(results, nextCursor);
     }
 
     public async Task<MonitorItem?> GetMonitorItemAsync(string id, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- add generic `Page<T>` wrapper
- support optional `cursor` and `fetchAll` parameters for listing livehunt notifications, retrohunt jobs, and retrohunt notifications
- add tests for single-page and multi-page scenarios

## Testing
- `/root/.dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6899db84a270832eb1b5265457ab0c6d