### PR TITLE
feat: support ordering in intelligence search

### DIFF
--- a/VirusTotalAnalyzer.Examples/SearchExample.cs
+++ b/VirusTotalAnalyzer.Examples/SearchExample.cs
@@ -11,11 +11,11 @@ public static class SearchExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var response = await client.SearchAsync("type:file", limit: 10);
+            var response = await client.SearchAsync("type:file", limit: 10, order: "last_analysis_date", descriptor: "asc");
             Console.WriteLine(response?.Data.Count);
             if (!string.IsNullOrEmpty(response?.Meta?.Cursor))
             {
-                var nextPage = await client.SearchAsync("type:file", cursor: response.Meta.Cursor);
+                var nextPage = await client.SearchAsync("type:file", cursor: response.Meta.Cursor, order: "last_analysis_date", descriptor: "asc");
                 Console.WriteLine(nextPage?.Data.Count);
             }
         }

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
@@ -487,6 +487,26 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task SearchAsync_BuildsQueryWithOrderAndDescriptor()
+    {
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"data\":[]}", Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.SearchAsync("demo query", order: "last_analysis_date", descriptor: "asc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/intelligence/search", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal("query=demo%20query&order=last_analysis_date&descriptor=asc", handler.Request!.RequestUri!.Query.TrimStart('?'));
+    }
+
+    [Fact]
     public async Task SearchAsync_DeserializesCursor()
     {
         var json = "{\"data\":[],\"meta\":{\"cursor\":\"next\"}}";

--- a/VirusTotalAnalyzer/VirusTotalClient.Intelligence.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Intelligence.cs
@@ -265,7 +265,7 @@ public sealed partial class VirusTotalClient
         return await JsonSerializer.DeserializeAsync<RelationshipResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<SearchResponse?> SearchAsync(string query, int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
+    public async Task<SearchResponse?> SearchAsync(string query, int? limit = null, string? cursor = null, string? order = null, string? descriptor = null, CancellationToken cancellationToken = default)
     {
         var sb = new StringBuilder($"intelligence/search?query={Uri.EscapeDataString(query)}");
         if (limit.HasValue)
@@ -275,6 +275,14 @@ public sealed partial class VirusTotalClient
         if (!string.IsNullOrEmpty(cursor))
         {
             sb.Append("&cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+        if (!string.IsNullOrEmpty(order))
+        {
+            sb.Append("&order=").Append(Uri.EscapeDataString(order));
+        }
+        if (!string.IsNullOrEmpty(descriptor))
+        {
+            sb.Append("&descriptor=").Append(Uri.EscapeDataString(descriptor));
         }
         using var response = await _httpClient.GetAsync(sb.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- allow specifying `order` and `descriptor` when calling `SearchAsync`
- cover `order` and `descriptor` in search tests
- update search example to demonstrate ordering

## Testing
- `dotnet build VirusTotalAnalyzer.sln`
- `dotnet test VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6899db7f6ebc832ebe1f9ec75efbf76c