### PR TITLE
Add pagination support for monitor items

### DIFF
--- a/VirusTotalAnalyzer.Examples/CreateMonitorItemExample.cs
+++ b/VirusTotalAnalyzer.Examples/CreateMonitorItemExample.cs
@@ -19,9 +19,12 @@ public static class CreateMonitorItemExample
             Console.WriteLine(item?.Id);
 
             var items = await client.ListMonitorItemsAsync();
-            foreach (var i in items)
+            if (items != null)
             {
-                Console.WriteLine(i.Id);
+                foreach (var i in items.Data)
+                {
+                    Console.WriteLine(i.Id);
+                }
             }
 
             if (item != null)

--- a/VirusTotalAnalyzer/Models/MonitorItem.cs
+++ b/VirusTotalAnalyzer/Models/MonitorItem.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
@@ -19,15 +18,6 @@ public sealed class MonitorItemAttributes
 {
     [JsonPropertyName("path")]
     public string Path { get; set; } = string.Empty;
-}
-
-public sealed class MonitorItemsResponse
-{
-    [JsonPropertyName("data")]
-    public List<MonitorItem> Data { get; set; } = new();
-
-    [JsonPropertyName("meta")]
-    public Meta? Meta { get; set; }
 }
 
 public sealed class CreateMonitorItemRequest

--- a/VirusTotalAnalyzer/Models/PagedResponse.cs
+++ b/VirusTotalAnalyzer/Models/PagedResponse.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class PagedResponse<T>
+{
+    [JsonPropertyName("data")]
+    public List<T> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public Meta? Meta { get; set; }
+
+    public string? NextCursor => Meta?.Cursor;
+}


### PR DESCRIPTION
## Summary
- allow specifying `limit` and `cursor` when listing monitor items
- return paged monitor items with access to next cursor
- test pagination query and cursor handling

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6899db7b859c832e83ba4e32cc9d61e9