### PR TITLE
Add file submissions example and .NET Framework support

### DIFF
--- a/VirusTotalAnalyzer.Examples/DownloadLivehuntNotificationFileExample.cs
+++ b/VirusTotalAnalyzer.Examples/DownloadLivehuntNotificationFileExample.cs
@@ -12,9 +12,15 @@ public static class DownloadLivehuntNotificationFileExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
+#if NET472
+            using var stream = await client.DownloadLivehuntNotificationFileAsync("notification-file-id");
+            using var file = File.Create("notification_file.bin");
+            await stream.CopyToAsync(file);
+#else
             await using var stream = await client.DownloadLivehuntNotificationFileAsync("notification-file-id");
             await using var file = File.Create("notification_file.bin");
             await stream.CopyToAsync(file);
+#endif
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/DownloadPcapExample.cs
+++ b/VirusTotalAnalyzer.Examples/DownloadPcapExample.cs
@@ -12,9 +12,15 @@ public static class DownloadPcapExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
+#if NET472
+            using var stream = await client.DownloadPcapAsync("ANALYSIS_ID");
+            using var file = File.Create("analysis.pcap");
+            await stream.CopyToAsync(file);
+#else
             await using var stream = await client.DownloadPcapAsync("ANALYSIS_ID");
             await using var file = File.Create("analysis.pcap");
             await stream.CopyToAsync(file);
+#endif
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/GetFileSubmissionsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileSubmissionsExample.cs
@@ -1,26 +1,18 @@
 using System;
-using System.IO;
 using System.Threading.Tasks;
 using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Examples;
 
-public static class DownloadFileExample
+public static class GetFileSubmissionsExample
 {
     public static async Task RunAsync()
     {
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-#if NET472
-            using var stream = await client.DownloadFileAsync("44d88612fea8a8f36de82e1278abb02f");
-            using var file = File.Create("downloaded_file.bin");
-            await stream.CopyToAsync(file);
-#else
-            await using var stream = await client.DownloadFileAsync("44d88612fea8a8f36de82e1278abb02f");
-            await using var file = File.Create("downloaded_file.bin");
-            await stream.CopyToAsync(file);
-#endif
+            var submissions = await client.GetFileSubmissionsAsync("44d88612fea8a8f36de82e1278abb02f");
+            Console.WriteLine(submissions?.Count);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Examples/VirusTotalAnalyzer.Examples.csproj
+++ b/VirusTotalAnalyzer.Examples/VirusTotalAnalyzer.Examples.csproj
@@ -1,11 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../VirusTotalAnalyzer/VirusTotalAnalyzer.csproj" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 </Project>

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Relationships.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Relationships.cs
@@ -11,6 +11,30 @@ namespace VirusTotalAnalyzer.Tests;
 public partial class VirusTotalClientTests
 {
     [Fact]
+    public async Task GetFileSubmissionsAsync_UsesCorrectPathAndDeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"s1\",\"type\":\"submission\",\"data\":{\"attributes\":{\"date\":1}}}]}"; 
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var submissions = await client.GetFileSubmissionsAsync("abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/files/abc/submissions", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.NotNull(submissions);
+        Assert.Single(submissions!);
+        Assert.Equal(1, submissions[0].Data.Attributes.Date.ToUnixTimeSeconds());
+    }
+
+    [Fact]
     public async Task GetDomainResolutionsAsync_UsesCorrectPathAndDeserializesResponse()
     {
         var json = "{\"data\":[{\"id\":\"r1\",\"type\":\"resolution\",\"data\":{\"attributes\":{\"host_name\":\"example.com\",\"ip_address\":\"1.2.3.4\",\"date\":1}}}]}";

--- a/VirusTotalAnalyzer/VirusTotalClient.Relationships.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Relationships.cs
@@ -9,6 +9,9 @@ namespace VirusTotalAnalyzer;
 
 public sealed partial class VirusTotalClient
 {
+    public Task<IReadOnlyList<Submission>?> GetFileSubmissionsAsync(string id, CancellationToken cancellationToken = default)
+        => GetSubmissionsAsync(ResourceType.File, id, cancellationToken);
+
     public Task<IReadOnlyList<Resolution>?> GetDomainResolutionsAsync(string id, CancellationToken cancellationToken = default)
         => GetResolutionsAsync(ResourceType.Domain, id, cancellationToken);
 


### PR DESCRIPTION
## Summary
- add GetFileSubmissionsAsync API wrapper and tests
- provide GetFileSubmissionsExample and target .NET 4.7.2 in examples
- adjust download examples for .NET Framework compatibility

## Testing
- `dotnet build VirusTotalAnalyzer.sln -c Release`
- `dotnet test VirusTotalAnalyzer.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_689b4183d338832ea182515acdc37e53