### PR TITLE
Add whois lookups for domains and IPs

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetDomainWhoisExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetDomainWhoisExample.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetDomainWhoisExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var whois = await client.GetDomainWhoisAsync("example.com");
+            Console.WriteLine(whois?.Data.Attributes.Whois);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Examples/GetIpAddressWhoisExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetIpAddressWhoisExample.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetIpAddressWhoisExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var whois = await client.GetIpAddressWhoisAsync("1.1.1.1");
+            Console.WriteLine(whois?.Data.Attributes.Whois);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
@@ -106,6 +106,54 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetDomainWhoisAsync_DeserializesResponseAndUsesCorrectPath()
+    {
+        var json = "{\"id\":\"example.com\",\"type\":\"domain\",\"data\":{\"attributes\":{\"whois\":\"domain whois\"}}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var whois = await client.GetDomainWhoisAsync("example.com");
+
+        Assert.NotNull(whois);
+        Assert.Equal("example.com", whois!.Id);
+        Assert.Equal(ResourceType.Domain, whois.Type);
+        Assert.Equal("domain whois", whois.Data.Attributes.Whois);
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/domains/example.com/whois", handler.Request!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task GetIpAddressWhoisAsync_DeserializesResponseAndUsesCorrectPath()
+    {
+        var json = "{\"id\":\"1.1.1.1\",\"type\":\"ipAddress\",\"data\":{\"attributes\":{\"whois\":\"ip whois\"}}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var whois = await client.GetIpAddressWhoisAsync("1.1.1.1");
+
+        Assert.NotNull(whois);
+        Assert.Equal("1.1.1.1", whois!.Id);
+        Assert.Equal(ResourceType.IpAddress, whois.Type);
+        Assert.Equal("ip whois", whois.Data.Attributes.Whois);
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/ip_addresses/1.1.1.1/whois", handler.Request!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
     public async Task GetAnalysisAsync_DeserializesResponseAndUsesCorrectPath()
     {
         var json = "{\"id\":\"an1\",\"type\":\"analysis\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}";

--- a/VirusTotalAnalyzer/Models/DomainWhois.cs
+++ b/VirusTotalAnalyzer/Models/DomainWhois.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class DomainWhois
+{
+    public string Id { get; set; } = string.Empty;
+    public ResourceType Type { get; set; }
+    public DomainWhoisData Data { get; set; } = new();
+}
+
+public sealed class DomainWhoisData
+{
+    public DomainWhoisAttributes Attributes { get; set; } = new();
+}
+
+public sealed class DomainWhoisAttributes
+{
+    [JsonPropertyName("whois")]
+    public string Whois { get; set; } = string.Empty;
+}

--- a/VirusTotalAnalyzer/Models/IpWhois.cs
+++ b/VirusTotalAnalyzer/Models/IpWhois.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class IpWhois
+{
+    public string Id { get; set; } = string.Empty;
+    public ResourceType Type { get; set; }
+    public IpWhoisData Data { get; set; } = new();
+}
+
+public sealed class IpWhoisData
+{
+    public IpWhoisAttributes Attributes { get; set; } = new();
+}
+
+public sealed class IpWhoisAttributes
+{
+    [JsonPropertyName("whois")]
+    public string Whois { get; set; } = string.Empty;
+}

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -201,6 +201,19 @@ public sealed partial class VirusTotalClient
             .ConfigureAwait(false);
     }
 
+    public async Task<IpWhois?> GetIpAddressWhoisAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"ip_addresses/{id}/whois", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<IpWhois>(stream, _jsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     public async Task<DomainReport?> GetDomainReportAsync(string id, CancellationToken cancellationToken = default)
     {
         using var response = await _httpClient.GetAsync($"domains/{id}", cancellationToken).ConfigureAwait(false);
@@ -211,6 +224,19 @@ public sealed partial class VirusTotalClient
         await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #endif
         return await JsonSerializer.DeserializeAsync<DomainReport>(stream, _jsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<DomainWhois?> GetDomainWhoisAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"domains/{id}/whois", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<DomainWhois>(stream, _jsonOptions, cancellationToken)
             .ConfigureAwait(false);
     }
 


### PR DESCRIPTION
## Summary
- add domain and IP whois models
- support fetching whois for domains and IPs
- include examples and tests for whois endpoints

## Testing
- `dotnet test VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj -c Release -p:TargetFrameworks=net8.0`
- `dotnet build VirusTotalAnalyzer.Examples/VirusTotalAnalyzer.Examples.csproj -c Release -p:TargetFrameworks=net8.0`


------
https://chatgpt.com/codex/tasks/task_e_689b54c77c98832e856f4072a2060f98