### PR TITLE
Add file download URL API support

### DIFF
--- a/VirusTotalAnalyzer.Examples/DownloadFileExample.cs
+++ b/VirusTotalAnalyzer.Examples/DownloadFileExample.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Net.Http;
 using System.Threading.Tasks;
 using VirusTotalAnalyzer.Models;
 
@@ -12,12 +13,19 @@ public static class DownloadFileExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
+            var url = await client.GetFileDownloadUrlAsync("44d88612fea8a8f36de82e1278abb02f");
+            if (url is null)
+            {
+                Console.WriteLine("Download URL was not provided.");
+                return;
+            }
+            using var httpClient = new HttpClient();
 #if NET472
-            using var stream = await client.DownloadFileAsync("44d88612fea8a8f36de82e1278abb02f");
+            using var stream = await httpClient.GetStreamAsync(url);
             using var file = File.Create("downloaded_file.bin");
             await stream.CopyToAsync(file);
 #else
-            await using var stream = await client.DownloadFileAsync("44d88612fea8a8f36de82e1278abb02f");
+            await using var stream = await httpClient.GetStreamAsync(url);
             await using var file = File.Create("downloaded_file.bin");
             await stream.CopyToAsync(file);
 #endif

--- a/VirusTotalAnalyzer.Examples/GetFileDownloadUrlExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileDownloadUrlExample.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetFileDownloadUrlExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var url = await client.GetFileDownloadUrlAsync("44d88612fea8a8f36de82e1278abb02f");
+            Console.WriteLine(url);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Examples/Program.cs
+++ b/VirusTotalAnalyzer.Examples/Program.cs
@@ -27,6 +27,8 @@ using VirusTotalAnalyzer.Examples;
 // await SearchExample.RunAsync();
 // await GetFeedExample.RunAsync();
 // await GetUploadUrlExample.RunAsync();
+// await GetFileDownloadUrlExample.RunAsync();
+// await DownloadFileExample.RunAsync();
 // await SubmitFileExample.RunAsync();
 // await SubmitFileSimpleExample.RunAsync();
 // await ReanalyzeHashExample.RunAsync();

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
@@ -102,6 +102,28 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetFileDownloadUrlAsync_ReturnsUri()
+    {
+        var json = "{\"data\":\"https://download.example/file\"}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var uri = await client.GetFileDownloadUrlAsync("abc");
+
+        Assert.NotNull(uri);
+        Assert.Equal("https://download.example/file", uri!.ToString());
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/files/abc/download_url", handler.Request!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
     public async Task SubmitFileAsync_PostsDirectlyToFiles_ForSmallFiles()
     {
         var analysisJson = "{\"id\":\"an\",\"type\":\"analysis\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}";

--- a/VirusTotalAnalyzer/Models/DownloadUrlResponse.cs
+++ b/VirusTotalAnalyzer/Models/DownloadUrlResponse.cs
@@ -1,0 +1,6 @@
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class DownloadUrlResponse
+{
+    public string Data { get; set; } = string.Empty;
+}


### PR DESCRIPTION
## Summary
- add `GetFileDownloadUrlAsync` to retrieve file download URLs
- expose `DownloadUrlResponse` model
- demonstrate download URL usage in examples
- test download URL path and parsing

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689b5a9c18d4832eb2c59963adc13e61