### PR TITLE
Add domain relationship endpoints

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetDomainSiblingsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetDomainSiblingsExample.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetDomainSiblingsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var siblings = await client.GetDomainSiblingsAsync("example.com");
+            Console.WriteLine(siblings?.Count);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Examples/GetDomainSubdomainsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetDomainSubdomainsExample.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetDomainSubdomainsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var subdomains = await client.GetDomainSubdomainsAsync("example.com");
+            Console.WriteLine(subdomains?.Count);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Examples/GetDomainUrlsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetDomainUrlsExample.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetDomainUrlsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var urls = await client.GetDomainUrlsAsync("example.com");
+            Console.WriteLine(urls?.Count);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.DomainRelationships.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.DomainRelationships.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public partial class VirusTotalClientTests
+{
+    [Fact]
+    public async Task GetDomainSubdomainsAsync_UsesCorrectPathAndDeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"d1\",\"type\":\"domain\",\"data\":{\"attributes\":{\"domain\":\"sub.example.com\"}}}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var subdomains = await client.GetDomainSubdomainsAsync("example.com");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/domains/example.com/subdomains", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.NotNull(subdomains);
+        Assert.Single(subdomains!);
+        Assert.Equal("sub.example.com", subdomains[0].Data.Attributes.Domain);
+    }
+
+    [Fact]
+    public async Task GetDomainSiblingsAsync_UsesCorrectPathAndDeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"d1\",\"type\":\"domain\",\"data\":{\"attributes\":{\"domain\":\"sibling.com\"}}}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var siblings = await client.GetDomainSiblingsAsync("example.com");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/domains/example.com/siblings", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.NotNull(siblings);
+        Assert.Single(siblings!);
+        Assert.Equal("sibling.com", siblings[0].Data.Attributes.Domain);
+    }
+
+    [Fact]
+    public async Task GetDomainUrlsAsync_UsesCorrectPathAndDeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"u1\",\"type\":\"url\",\"data\":{\"attributes\":{\"url\":\"http://example.com/\"}}}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var urls = await client.GetDomainUrlsAsync("example.com");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/domains/example.com/urls", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.NotNull(urls);
+        Assert.Single(urls!);
+        Assert.Equal("http://example.com/", urls[0].Data.Attributes.Url);
+    }
+}

--- a/VirusTotalAnalyzer/Models/DomainRelationships.cs
+++ b/VirusTotalAnalyzer/Models/DomainRelationships.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class DomainSubdomainsResponse
+{
+    [JsonPropertyName("data")]
+    public List<DomainSummary> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public PaginationMetadata? Meta { get; set; }
+}
+
+public sealed class DomainSiblingsResponse
+{
+    [JsonPropertyName("data")]
+    public List<DomainSummary> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public PaginationMetadata? Meta { get; set; }
+}
+
+public sealed class DomainUrlsResponse
+{
+    [JsonPropertyName("data")]
+    public List<UrlSummary> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public PaginationMetadata? Meta { get; set; }
+}
+

--- a/VirusTotalAnalyzer/VirusTotalClient.Relationships.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Relationships.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text.Json;
@@ -18,11 +19,37 @@ public sealed partial class VirusTotalClient
     public Task<IReadOnlyList<Submission>?> GetDomainSubmissionsAsync(string id, CancellationToken cancellationToken = default)
         => GetSubmissionsAsync(ResourceType.Domain, id, cancellationToken);
 
+    public Task<IReadOnlyList<DomainSummary>?> GetDomainSubdomainsAsync(string id, CancellationToken cancellationToken = default)
+        => GetDomainRelationshipsAsync<DomainSubdomainsResponse, DomainSummary>(id, "subdomains", r => r.Data, cancellationToken);
+
+    public Task<IReadOnlyList<DomainSummary>?> GetDomainSiblingsAsync(string id, CancellationToken cancellationToken = default)
+        => GetDomainRelationshipsAsync<DomainSiblingsResponse, DomainSummary>(id, "siblings", r => r.Data, cancellationToken);
+
+    public Task<IReadOnlyList<UrlSummary>?> GetDomainUrlsAsync(string id, CancellationToken cancellationToken = default)
+        => GetDomainRelationshipsAsync<DomainUrlsResponse, UrlSummary>(id, "urls", r => r.Data, cancellationToken);
+
     public Task<IReadOnlyList<Resolution>?> GetIpAddressResolutionsAsync(string id, CancellationToken cancellationToken = default)
         => GetResolutionsAsync(ResourceType.IpAddress, id, cancellationToken);
 
     public Task<IReadOnlyList<Submission>?> GetIpAddressSubmissionsAsync(string id, CancellationToken cancellationToken = default)
         => GetSubmissionsAsync(ResourceType.IpAddress, id, cancellationToken);
+
+    private async Task<IReadOnlyList<T>?> GetDomainRelationshipsAsync<TResponse, T>(
+        string id,
+        string relationship,
+        Func<TResponse, List<T>> selector,
+        CancellationToken cancellationToken)
+    {
+        using var response = await _httpClient.GetAsync($"domains/{id}/{relationship}", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<TResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+        return result == null ? null : selector(result);
+    }
 
     private async Task<IReadOnlyList<Resolution>?> GetResolutionsAsync(ResourceType resourceType, string id, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
## Summary
- support domain subdomains, siblings, and urls relationships
- add example usages for new domain relationship methods
- test relationship endpoints for correct paths and deserialization

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b6478af28832e93a42ffd6461245c