### PR TITLE
Add domain DNS records relationship and example

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetDomainDnsRecordsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetDomainDnsRecordsExample.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetDomainDnsRecordsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var records = await client.GetDomainDnsRecordsAsync("example.com");
+            Console.WriteLine(records?.Count);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer/Models/DnsRecord.cs
+++ b/VirusTotalAnalyzer/Models/DnsRecord.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class DnsRecord
+{
+    public string Id { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public DnsRecordData Data { get; set; } = new();
+}
+
+public sealed class DnsRecordData
+{
+    public DnsRecordAttributes Attributes { get; set; } = new();
+}
+
+public sealed class DnsRecordAttributes
+{
+    [JsonPropertyName("type")]
+    public string? RecordType { get; set; }
+
+    [JsonPropertyName("value")]
+    public string? Value { get; set; }
+
+    [JsonPropertyName("ttl")]
+    public int? Ttl { get; set; }
+}
+
+public sealed class DnsRecordsResponse
+{
+    [JsonPropertyName("data")]
+    public List<DnsRecord> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public PaginationMetadata? Meta { get; set; }
+}

--- a/VirusTotalAnalyzer/VirusTotalClient.Relationships.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Relationships.cs
@@ -28,6 +28,9 @@ public sealed partial class VirusTotalClient
     public Task<IReadOnlyList<UrlSummary>?> GetDomainUrlsAsync(string id, CancellationToken cancellationToken = default)
         => GetDomainRelationshipsAsync<DomainUrlsResponse, UrlSummary>(id, "urls", r => r.Data, cancellationToken);
 
+    public Task<IReadOnlyList<DnsRecord>?> GetDomainDnsRecordsAsync(string id, CancellationToken cancellationToken = default)
+        => GetDomainRelationshipsAsync<DnsRecordsResponse, DnsRecord>(id, "dns_records", r => r.Data, cancellationToken);
+
     public Task<IReadOnlyList<Resolution>?> GetIpAddressResolutionsAsync(string id, CancellationToken cancellationToken = default)
         => GetResolutionsAsync(ResourceType.IpAddress, id, cancellationToken);
 


### PR DESCRIPTION
## Summary
- add GetDomainDnsRecordsAsync to retrieve domain DNS records
- add DnsRecord model and example
- test DNS record relationship path and parsing

## Testing
- `dotnet test VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj -p:TargetFrameworks=net8.0 -p:TargetFramework=net8.0`


------
https://chatgpt.com/codex/tasks/task_e_689b8416dd18832eb7a867815720ec42