### PR TITLE
Handle large non-seekable streams

### DIFF
--- a/VirusTotalAnalyzer.Tests/NonSeekableStream.cs
+++ b/VirusTotalAnalyzer.Tests/NonSeekableStream.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VirusTotalAnalyzer.Tests;
+
+internal sealed class NonSeekableStream : Stream
+{
+    private readonly Stream _inner;
+
+    public NonSeekableStream(byte[] data) => _inner = new MemoryStream(data);
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => _inner.Length;
+    public override long Position
+    {
+        get => _inner.Position;
+        set => throw new NotSupportedException();
+    }
+
+    public override void Flush() => _inner.Flush();
+    public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        => _inner.ReadAsync(buffer, offset, count, cancellationToken);
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _inner.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+
+#if !NETFRAMEWORK
+    public override ValueTask DisposeAsync()
+    {
+        return _inner.DisposeAsync();
+    }
+#endif
+}

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.LargeStream.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.LargeStream.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer;
+using VirusTotalAnalyzer.Models;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public partial class VirusTotalClientTests
+{
+    [Fact]
+    public async Task SubmitFileAsync_NonSeekableLargeStream_UsesUploadUrl()
+    {
+        var uploadUrl = "https://upload.example.com/";
+        var uploadUrlJson = $"{{\"data\":\"{uploadUrl}\"}}";
+        var analysisJson = "{\"id\":\"an\",\"type\":\"analysis\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}";
+        var handler = new QueueHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(uploadUrlJson, Encoding.UTF8, "application/json")
+            },
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(analysisJson, Encoding.UTF8, "application/json")
+            }
+        );
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var data = new byte[33554433];
+        using var stream = new NonSeekableStream(data);
+
+        var report = await client.SubmitFileAsync(stream, "large.bin", CancellationToken.None);
+
+        Assert.NotNull(report);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal("/api/v3/files/upload_url", handler.Requests[0].RequestUri!.AbsolutePath);
+        Assert.Equal(uploadUrl, handler.Requests[1].RequestUri!.ToString());
+    }
+}


### PR DESCRIPTION
## Summary
- buffer non-seekable streams to determine size and obtain upload URL for files over 32MB
- add helper non-seekable stream and test for routing oversized streams to large-file endpoint

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b8ef7c510832ebca32bbe1bf953b8