### PR TITLE
Add file classification retrieval

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetFileClassificationExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileClassificationExample.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetFileClassificationExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var classification = await client.GetFileClassificationAsync("44d88612fea8a8f36de82e1278abb02f");
+            Console.WriteLine(classification?.Data.Attributes.Classification.Label);
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
@@ -651,6 +651,47 @@ public partial class VirusTotalClientTests
         await Assert.ThrowsAsync<ApiException>(() => client.GetFilePeInfoAsync("abc"));
     }
 
+
+    [Fact]
+    public async Task GetFileClassificationAsync_DeserializesResponseAndUsesCorrectPath()
+    {
+        var json = "{\"data\":{\"attributes\":{\"classification\":{\"label\":\"pup\"}}}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var classification = await client.GetFileClassificationAsync("abc");
+
+        Assert.NotNull(classification);
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/files/abc/classification", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal("pup", classification!.Data.Attributes.Classification.Label);
+    }
+
+    [Fact]
+    public async Task GetFileClassificationAsync_ThrowsApiException()
+    {
+        var errorJson = "{\"error\":{\"code\":\"NotFoundError\",\"message\":\"not found\"}}";
+        var response = new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent(errorJson, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await Assert.ThrowsAsync<ApiException>(() => client.GetFileClassificationAsync("abc"));
+    }
+
     [Fact]
     public async Task GetFileNamesAsync_DeserializesResponseAndUsesCorrectPath()
     {

--- a/VirusTotalAnalyzer/Models/FileClassification.cs
+++ b/VirusTotalAnalyzer/Models/FileClassification.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class FileClassification
+{
+    [JsonPropertyName("data")]
+    public FileClassificationData Data { get; set; } = new();
+}
+
+public sealed class FileClassificationData
+{
+    [JsonPropertyName("attributes")]
+    public FileClassificationAttributes Attributes { get; set; } = new();
+}
+
+public sealed class FileClassificationAttributes
+{
+    [JsonPropertyName("classification")]
+    public ClassificationResult Classification { get; set; } = new();
+}
+
+public sealed class ClassificationResult
+{
+    [JsonPropertyName("label")]
+    public string? Label { get; set; }
+}

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -80,6 +80,20 @@ public sealed partial class VirusTotalClient
             .ConfigureAwait(false);
     }
 
+    public async Task<FileClassification?> GetFileClassificationAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"files/{id}/classification", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<FileClassification>(stream, _jsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+
     public async Task<IReadOnlyList<CrowdsourcedYaraResult>?> GetCrowdsourcedYaraResultsAsync(string id, CancellationToken cancellationToken = default)
     {
         using var response = await _httpClient.GetAsync($"files/{id}/crowdsourced_yara_results", cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- add FileClassification data model
- support `/files/{id}/classification` via `GetFileClassificationAsync`
- cover file classification path & deserialization with unit tests and example

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b8f15a830832ea781914847e5ff5d