### PR TITLE
Handle null analysis data in polling

### DIFF
--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.AnalysisRelationships.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.AnalysisRelationships.cs
@@ -105,5 +105,20 @@ public partial class VirusTotalClientTests
         Assert.Single(files!);
         Assert.Equal("abc", files[0].Data.Attributes.Md5);
     }
+
+    [Fact]
+    public async Task WaitForAnalysisCompletionAsync_HandlesNullData_ThrowsTimeout()
+    {
+        var json = "{\"id\":\"an\",\"type\":\"analysis\",\"data\":null}";
+        var handler = new StubHandler(json);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            client.WaitForAnalysisCompletionAsync("an", TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(10)));
+    }
 }
 

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -298,13 +298,13 @@ public sealed partial class VirusTotalClient
             cancellationToken.ThrowIfCancellationRequested();
 
             var report = await GetAnalysisAsync(id, cancellationToken).ConfigureAwait(false);
-            var status = report?.Data.Attributes.Status;
+            var status = report?.Data?.Attributes?.Status;
             if (status == AnalysisStatus.Completed)
             {
                 return report;
             }
 
-            var error = report?.Data.Attributes.Error;
+            var error = report?.Data?.Attributes?.Error;
             if (status == AnalysisStatus.Error || status == AnalysisStatus.Cancelled)
             {
                 var apiError = string.IsNullOrEmpty(error) ? null : new ApiError { Message = error };


### PR DESCRIPTION
## Summary
- Handle null `Data` in `WaitForAnalysisCompletionAsync`
- Test analysis polling when API returns null data

## Testing
- `dotnet test VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj -p:TargetFramework=net8.0 -p:TargetFrameworks=net8.0`


------
https://chatgpt.com/codex/tasks/task_e_689b8ef373bc832ebc69c486c7b577e8