### PR TITLE
Add file classification retrieval support

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetFileClassificationExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileClassificationExample.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetFileClassificationExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var classification = await client.GetFileClassificationAsync("44d88612fea8a8f36de82e1278abb02f");
+            Console.WriteLine(classification?.Data.Attributes.SuggestedThreatLabel);
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}
+

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
@@ -652,6 +652,30 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetFileClassificationAsync_DeserializesResponseAndUsesCorrectPath()
+    {
+        var json = "{\"data\":{\"id\":\"f1\",\"type\":\"file\",\"attributes\":{\"popular_threat_name\":\"Trojan\",\"popular_threat_category\":\"malware\",\"suggested_threat_label\":\"malicious\"}}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var classification = await client.GetFileClassificationAsync("abc");
+
+        Assert.NotNull(classification);
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/files/abc/classification", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal("Trojan", classification!.Data.Attributes.PopularThreatName);
+        Assert.Equal("malware", classification.Data.Attributes.PopularThreatCategory);
+        Assert.Equal("malicious", classification.Data.Attributes.SuggestedThreatLabel);
+    }
+
+    [Fact]
     public async Task GetFileStringsAsync_DeserializesResponseAndUsesCorrectPath()
     {
         var json = "{\"data\":[\"s1\",\"s2\"]}";

--- a/VirusTotalAnalyzer/Models/FileClassification.cs
+++ b/VirusTotalAnalyzer/Models/FileClassification.cs
@@ -1,0 +1,34 @@
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class FileClassification
+{
+    [JsonPropertyName("data")]
+    public FileClassificationData Data { get; set; } = new();
+}
+
+public sealed class FileClassificationData
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
+
+    [JsonPropertyName("attributes")]
+    public FileClassificationAttributes Attributes { get; set; } = new();
+}
+
+public sealed class FileClassificationAttributes
+{
+    [JsonPropertyName("popular_threat_name")]
+    public string? PopularThreatName { get; set; }
+
+    [JsonPropertyName("popular_threat_category")]
+    public string? PopularThreatCategory { get; set; }
+
+    [JsonPropertyName("suggested_threat_label")]
+    public string? SuggestedThreatLabel { get; set; }
+}
+

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -80,6 +80,19 @@ public sealed partial class VirusTotalClient
             .ConfigureAwait(false);
     }
 
+    public async Task<FileClassification?> GetFileClassificationAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"files/{id}/classification", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<FileClassification>(stream, _jsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     public async Task<IReadOnlyList<string>?> GetFileStringsAsync(string id, CancellationToken cancellationToken = default)
     {
         using var response = await _httpClient.GetAsync($"files/{id}/strings", cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- add `GetFileClassificationAsync` for `files/{id}/classification`
- define `FileClassification` model for classification responses
- test classification request path and mapping

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b952fb164832eb020c0e6cf355e31