### PR TITLE
Add pagination to relationships requests

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetRelationshipsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetRelationshipsExample.cs
@@ -11,7 +11,7 @@ public static class GetRelationshipsExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var response = await client.GetRelationshipsAsync(ResourceType.File, "file-id", "comments");
+            var response = await client.GetRelationshipsAsync(ResourceType.File, "file-id", "comments", limit: 10);
             Console.WriteLine(response?.Data.Count);
         }
         catch (RateLimitExceededException ex)

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
@@ -385,6 +385,27 @@ public partial class VirusTotalClientTests
         Assert.Equal("r1", relationships.Data[0].Id);
         Assert.NotNull(handler.Request);
         Assert.Equal("/api/v3/files/abc/relationships/comments", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal(string.Empty, handler.Request!.RequestUri!.Query);
+    }
+
+    [Fact]
+    public async Task GetRelationshipsAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"data\":[]}", Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetRelationshipsAsync(ResourceType.File, "abc", "comments", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/files/abc/relationships/comments", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal("limit=10&cursor=abc", handler.Request!.RequestUri!.Query.TrimStart('?'));
     }
 
     [Fact]

--- a/VirusTotalAnalyzer/VirusTotalClient.Intelligence.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Intelligence.cs
@@ -265,9 +265,21 @@ public sealed partial class VirusTotalClient
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<RelationshipResponse?> GetRelationshipsAsync(ResourceType resourceType, string id, string relationship, CancellationToken cancellationToken = default)
+    public async Task<RelationshipResponse?> GetRelationshipsAsync(ResourceType resourceType, string id, string relationship, int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"{GetPath(resourceType)}/{id}/relationships/{relationship}", cancellationToken).ConfigureAwait(false);
+        var sb = new StringBuilder($"{GetPath(resourceType)}/{id}/relationships/{relationship}");
+        var hasQuery = false;
+        if (limit.HasValue)
+        {
+            sb.Append("?limit=").Append(limit.Value);
+            hasQuery = true;
+        }
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            sb.Append(hasQuery ? "&" : "?").Append("cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+
+        using var response = await _httpClient.GetAsync(sb.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- allow `GetRelationshipsAsync` to accept optional `limit` and `cursor` parameters
- test relationship pagination parameters
- show limit usage in relationships example

## Testing
- `dotnet test VirusTotalAnalyzer.sln`


------
https://chatgpt.com/codex/tasks/task_e_689ba83db3b8832e8f411688904f6bf1