### PR TITLE
Add domain and IP relationship helpers

### DIFF
--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.DomainRelationships.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.DomainRelationships.cs
@@ -107,4 +107,52 @@ public partial class VirusTotalClientTests
         Assert.Equal("1.2.3.4", records[0].Data.Attributes.Value);
         Assert.Equal(300, records[0].Data.Attributes.Ttl);
     }
+
+    [Fact]
+    public async Task GetDomainReferrerFilesAsync_UsesCorrectPathAndDeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"data\":{\"attributes\":{\"md5\":\"abc\"}}}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var files = await client.GetDomainReferrerFilesAsync("example.com");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/domains/example.com/referrer_files", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.NotNull(files);
+        Assert.Single(files!);
+        Assert.Equal("abc", files[0].Data.Attributes.Md5);
+    }
+
+    [Fact]
+    public async Task GetDomainDownloadedFilesAsync_UsesCorrectPathAndDeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"data\":{\"attributes\":{\"md5\":\"abc\"}}}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var files = await client.GetDomainDownloadedFilesAsync("example.com");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/domains/example.com/downloaded_files", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.NotNull(files);
+        Assert.Single(files!);
+        Assert.Equal("abc", files[0].Data.Attributes.Md5);
+    }
 }

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Relationships.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Relationships.cs
@@ -129,4 +129,28 @@ public partial class VirusTotalClientTests
         Assert.Single(submissions!);
         Assert.Equal(1, submissions[0].Data.Attributes.Date.ToUnixTimeSeconds());
     }
+
+    [Fact]
+    public async Task GetIpAddressCommunicatingFilesAsync_UsesCorrectPathAndDeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"data\":{\"attributes\":{\"md5\":\"abc\"}}}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var files = await client.GetIpAddressCommunicatingFilesAsync("1.2.3.4");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/ip_addresses/1.2.3.4/communicating_files", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.NotNull(files);
+        Assert.Single(files!);
+        Assert.Equal("abc", files[0].Data.Attributes.Md5);
+    }
 }


### PR DESCRIPTION
## Summary
- support domain relationships for referrer and downloaded files
- add IP address helper for communicating files
- test relationship endpoints and responses

## Testing
- `dotnet test -p:TargetFrameworks=net8.0`
- :warning: `dotnet test` *(missing .NET 9 SDK)*

------
https://chatgpt.com/codex/tasks/task_e_689c28b9374c832e806361282988a5ff