### PR TITLE
Add URL relationship APIs

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetUrlRelationshipsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetUrlRelationshipsExample.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetUrlRelationshipsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var downloaded = await client.GetUrlDownloadedFilesAsync("url-id");
+            Console.WriteLine(downloaded?.Count);
+
+            var referrers = await client.GetUrlReferrerFilesAsync("url-id");
+            Console.WriteLine(referrers?.Count);
+
+            var ips = await client.GetUrlContactedIpsAsync("url-id");
+            Console.WriteLine(ips?.Count);
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Examples/Program.cs
+++ b/VirusTotalAnalyzer.Examples/Program.cs
@@ -6,6 +6,7 @@ using VirusTotalAnalyzer.Examples;
 // await GetFileReportExample.RunAsync();
 // await GetUrlReportExample.RunAsync();
 // await GetUrlReportFromUrlExample.RunAsync();
+// await GetUrlRelationshipsExample.RunAsync();
 // await GetIpAddressReportExample.RunAsync();
 // await GetDomainReportExample.RunAsync();
 // await GetAnalysisExample.RunAsync();

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.AnalysisRelationships.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.AnalysisRelationships.cs
@@ -203,6 +203,78 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetUrlDownloadedFilesAsync_UsesCorrectPathAndDeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"data\":{\"attributes\":{\"md5\":\"abc\"}}}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var files = await client.GetUrlDownloadedFilesAsync("abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/urls/abc/downloaded_files", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.NotNull(files);
+        Assert.Single(files!);
+        Assert.Equal("abc", files[0].Data.Attributes.Md5);
+    }
+
+    [Fact]
+    public async Task GetUrlReferrerFilesAsync_UsesCorrectPathAndDeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"data\":{\"attributes\":{\"md5\":\"abc\"}}}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var files = await client.GetUrlReferrerFilesAsync("abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/urls/abc/referrer_files", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.NotNull(files);
+        Assert.Single(files!);
+        Assert.Equal("abc", files[0].Data.Attributes.Md5);
+    }
+
+    [Fact]
+    public async Task GetUrlContactedIpsAsync_UsesCorrectPathAndDeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"i1\",\"type\":\"ipAddress\",\"data\":{\"attributes\":{\"ip_address\":\"1.2.3.4\"}}}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var ips = await client.GetUrlContactedIpsAsync("abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/urls/abc/contacted_ips", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.NotNull(ips);
+        Assert.Single(ips!);
+        Assert.Equal("1.2.3.4", ips[0].Data.Attributes.IpAddress);
+    }
+
+    [Fact]
     public async Task WaitForAnalysisCompletionAsync_HandlesNullData_ThrowsTimeout()
     {
         var json = "{\"id\":\"an\",\"type\":\"analysis\",\"data\":null}";

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -285,6 +285,45 @@ public sealed partial class VirusTotalClient
         return GetUrlReportAsync(VirusTotalClientExtensions.GetUrlId(url.ToString()), cancellationToken);
     }
 
+    public async Task<IReadOnlyList<FileReport>?> GetUrlDownloadedFilesAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"urls/{id}/downloaded_files", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<FileReportsResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+        return result?.Data;
+    }
+
+    public async Task<IReadOnlyList<FileReport>?> GetUrlReferrerFilesAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"urls/{id}/referrer_files", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<FileReportsResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+        return result?.Data;
+    }
+
+    public async Task<IReadOnlyList<IpAddressSummary>?> GetUrlContactedIpsAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"urls/{id}/contacted_ips", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<IpAddressSummariesResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+        return result?.Data;
+    }
+
     public async Task<IpAddressReport?> GetIpAddressReportAsync(string id, CancellationToken cancellationToken = default)
     {
         using var response = await _httpClient.GetAsync($"ip_addresses/{id}", cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- add VirusTotalClient methods for url downloaded files, referrer files, and contacted IPs
- unit tests for new url relationship methods
- example demonstrating url relationship lookups

## Testing
- `dotnet test VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj -p:TargetFrameworks=net8.0`
- `dotnet test VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj -p:TargetFrameworks=net472` *(fails: testhost.net472.exe missing)*
- `dotnet build VirusTotalAnalyzer/VirusTotalAnalyzer.csproj -p:TargetFrameworks=net472`


------
https://chatgpt.com/codex/tasks/task_e_689c28b2c09c832ea1184572ebda8ebb