### PR TITLE
Use documented header for password-protected file submissions

### DIFF
--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
@@ -152,7 +152,7 @@ public partial class VirusTotalClientTests
             Assert.NotNull(report);
             Assert.NotNull(handler.Request);
             Assert.Equal("/api/v3/files", handler.Request!.RequestUri!.AbsolutePath);
-            Assert.True(handler.Request.Headers.Contains("password"));
+            Assert.True(handler.Request.Headers.Contains("x-virustotal-password"));
         }
         finally
         {
@@ -192,7 +192,7 @@ public partial class VirusTotalClientTests
         Assert.Equal(2, handler.Requests.Count);
         Assert.Equal("/api/v3/files/upload_url", handler.Requests[0].RequestUri!.AbsolutePath);
         Assert.Equal("https://upload.example/upload", handler.Requests[1].RequestUri!.ToString());
-        Assert.True(handler.Requests[1].Headers.Contains("password"));
+        Assert.True(handler.Requests[1].Headers.Contains("x-virustotal-password"));
     }
 
     [Fact]

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.cs
@@ -299,7 +299,29 @@ public partial class VirusTotalClientTests
         Assert.NotNull(report);
         Assert.NotNull(handler.Request);
         Assert.Equal("/api/v3/private/analyses", handler.Request!.RequestUri!.AbsolutePath);
-        Assert.True(handler.Request.Headers.Contains("password"));
+        Assert.True(handler.Request.Headers.Contains("x-virustotal-password"));
+    }
+
+    [Fact]
+    public async Task SubmitFileAsync_SendsPasswordHeader()
+    {
+        var analysisJson = "{\"id\":\"an\",\"type\":\"analysis\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(analysisJson, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        using var ms = new System.IO.MemoryStream(new byte[1]);
+        var report = await client.SubmitFileAsync(ms, "demo.bin", AnalysisType.File, "pass");
+
+        Assert.NotNull(report);
+        Assert.NotNull(handler.Request);
+        Assert.True(handler.Request!.Headers.Contains("x-virustotal-password"));
     }
 
     [Fact]

--- a/VirusTotalAnalyzer/VirusTotalClient.Submissions.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Submissions.cs
@@ -33,6 +33,7 @@ public sealed partial class VirusTotalClient
         return new Uri(result.Data);
     }
 
+    /// <param name="password">Password for password-protected files. Sent via the <c>x-virustotal-password</c> header.</param>
     public async Task<AnalysisReport?> SubmitFileAsync(Stream stream, string fileName, AnalysisType analysisType = AnalysisType.File, string? password = null, CancellationToken cancellationToken = default)
     {
         if (analysisType != AnalysisType.File)
@@ -74,7 +75,8 @@ public sealed partial class VirusTotalClient
         };
         if (!string.IsNullOrEmpty(password))
         {
-            request.Headers.Add("password", password);
+            // Use the documented header name for password-protected files.
+            request.Headers.Add("x-virustotal-password", password);
         }
         using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -100,6 +102,7 @@ public sealed partial class VirusTotalClient
     public Task<AnalysisReport?> SubmitFileAsync(Stream stream, string fileName, CancellationToken cancellationToken = default)
         => SubmitFileAsync(stream, fileName, AnalysisType.File, null, cancellationToken);
 
+    /// <param name="password">Password for password-protected files. Sent via the <c>x-virustotal-password</c> header.</param>
     public async Task<PrivateAnalysis?> SubmitPrivateFileAsync(
         Stream stream,
         string fileName,
@@ -114,7 +117,8 @@ public sealed partial class VirusTotalClient
         };
         if (!string.IsNullOrEmpty(password))
         {
-            request.Headers.Add("password", password);
+            // Use the documented header name for password-protected files.
+            request.Headers.Add("x-virustotal-password", password);
         }
         using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- send password in `x-virustotal-password` header for file and private file submissions
- document password parameter behavior
- verify header usage with unit tests

## Testing
- `~/.dotnet/dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_689c3059cc30832e9a73db328e1ec487