### PR TITLE
Clarify file submission API for VirusTotal analyzer

### DIFF
--- a/VirusTotalAnalyzer.Examples/SubmitFileExample.cs
+++ b/VirusTotalAnalyzer.Examples/SubmitFileExample.cs
@@ -24,7 +24,7 @@ public static class SubmitFileExample
 #else
             await using var stream = File.OpenRead(path);
 #endif
-            var report = await client.SubmitFileAsync(stream, Path.GetFileName(path), AnalysisType.File);
+            var report = await client.SubmitFileAsync(stream, Path.GetFileName(path));
             Console.WriteLine(report?.Id);
         }
         catch (RateLimitExceededException ex)

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
@@ -147,7 +147,7 @@ public partial class VirusTotalClientTests
 #endif
         try
         {
-            var report = await client.SubmitFileAsync(stream, "demo.bin", AnalysisType.File, "pass");
+            var report = await client.SubmitFileAsync(stream, "demo.bin", "pass");
 
             Assert.NotNull(report);
             Assert.NotNull(handler.Request);
@@ -186,7 +186,7 @@ public partial class VirusTotalClientTests
         var client = new VirusTotalClient(httpClient);
 
         using var ms = new System.IO.MemoryStream(new byte[33554433]);
-        var report = await client.SubmitFileAsync(ms, "demo.bin", AnalysisType.File, "pass");
+        var report = await client.SubmitFileAsync(ms, "demo.bin", "pass");
 
         Assert.NotNull(report);
         Assert.Equal(2, handler.Requests.Count);

--- a/VirusTotalAnalyzer/VirusTotalClient.Submissions.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Submissions.cs
@@ -33,12 +33,8 @@ public sealed partial class VirusTotalClient
         return new Uri(result.Data);
     }
 
-    public async Task<AnalysisReport?> SubmitFileAsync(Stream stream, string fileName, AnalysisType analysisType = AnalysisType.File, string? password = null, CancellationToken cancellationToken = default)
+    public async Task<AnalysisReport?> SubmitFileAsync(Stream stream, string fileName, string? password = null, CancellationToken cancellationToken = default)
     {
-        if (analysisType != AnalysisType.File)
-        {
-            throw new ArgumentOutOfRangeException(nameof(analysisType));
-        }
 
         Stream uploadStream = stream;
         bool disposeUploadStream = false;
@@ -97,8 +93,8 @@ public sealed partial class VirusTotalClient
         }
     }
 
-    public Task<AnalysisReport?> SubmitFileAsync(Stream stream, string fileName, CancellationToken cancellationToken = default)
-        => SubmitFileAsync(stream, fileName, AnalysisType.File, null, cancellationToken);
+    public Task<AnalysisReport?> SubmitFileAsync(Stream stream, string fileName, CancellationToken cancellationToken)
+        => SubmitFileAsync(stream, fileName, null, cancellationToken);
 
     public async Task<PrivateAnalysis?> SubmitPrivateFileAsync(
         Stream stream,

--- a/VirusTotalAnalyzer/VirusTotalClientExtensions.cs
+++ b/VirusTotalAnalyzer/VirusTotalClientExtensions.cs
@@ -22,27 +22,27 @@ public static class VirusTotalClientExtensions
             .Replace('/', '_');
     }
 
-    public static Task<AnalysisReport?> ScanFileAsync(this VirusTotalClient client, string filePath, CancellationToken cancellationToken = default)
+    public static Task<AnalysisReport?> ScanFileAsync(this VirusTotalClient client, string filePath, string? password = null, CancellationToken cancellationToken = default)
     {
         if (client == null) throw new ArgumentNullException(nameof(client));
 #if NET472
-        return ScanFileFrameworkAsync(client, filePath, cancellationToken);
+        return ScanFileFrameworkAsync(client, filePath, password, cancellationToken);
 #else
-        return ScanFileInternalAsync(client, filePath, cancellationToken);
+        return ScanFileInternalAsync(client, filePath, password, cancellationToken);
 #endif
     }
 
 #if NET472
-    private static async Task<AnalysisReport?> ScanFileFrameworkAsync(VirusTotalClient client, string filePath, CancellationToken cancellationToken)
+    private static async Task<AnalysisReport?> ScanFileFrameworkAsync(VirusTotalClient client, string filePath, string? password, CancellationToken cancellationToken)
     {
         using var stream = File.OpenRead(filePath);
-        return await client.SubmitFileAsync(stream, Path.GetFileName(filePath), cancellationToken).ConfigureAwait(false);
+        return await client.SubmitFileAsync(stream, Path.GetFileName(filePath), password, cancellationToken).ConfigureAwait(false);
     }
 #else
-    private static async Task<AnalysisReport?> ScanFileInternalAsync(VirusTotalClient client, string filePath, CancellationToken cancellationToken)
+    private static async Task<AnalysisReport?> ScanFileInternalAsync(VirusTotalClient client, string filePath, string? password, CancellationToken cancellationToken)
     {
         await using var stream = File.OpenRead(filePath);
-        return await client.SubmitFileAsync(stream, Path.GetFileName(filePath), cancellationToken).ConfigureAwait(false);
+        return await client.SubmitFileAsync(stream, Path.GetFileName(filePath), password, cancellationToken).ConfigureAwait(false);
     }
 #endif
 


### PR DESCRIPTION
## Summary
- Drop unused `analysisType` parameter from `SubmitFileAsync`
- Allow passwords via `ScanFileAsync` helper
- Update examples and tests for public and private file submissions

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689c3061c34c832e84a493d2e021c3ca