### PR TITLE
Add response wrappers and enum converter

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetFileReportExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileReportExample.cs
@@ -13,7 +13,7 @@ public static class GetFileReportExample
         {
             var report = await client.GetFileReportAsync("44d88612fea8a8f36de82e1278abb02f");
             Console.WriteLine(report?.Id);
-            Console.WriteLine(report?.Data?.Attributes.CreationDate);
+            Console.WriteLine(report?.Attributes.CreationDate);
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Tests/AttributeSerializationTests.cs
+++ b/VirusTotalAnalyzer.Tests/AttributeSerializationTests.cs
@@ -19,36 +19,33 @@ public class AttributeSerializationTests
         {
             Id = "file1",
             Type = ResourceType.File,
-            Data = new FileData
+            Attributes = new FileAttributes
             {
-                Attributes = new FileAttributes
+                Md5 = "md5",
+                Reputation = 1,
+                CreationDate = DateTimeOffset.FromUnixTimeSeconds(42),
+                Tags = new List<string> { "tag" },
+                Size = 100,
+                FirstSubmissionDate = DateTimeOffset.FromUnixTimeSeconds(10),
+                CrowdsourcedVerdicts =
                 {
-                    Md5 = "md5",
-                    Reputation = 1,
-                    CreationDate = DateTimeOffset.FromUnixTimeSeconds(42),
-                    Tags = new List<string> { "tag" },
-                    Size = 100,
-                    FirstSubmissionDate = DateTimeOffset.FromUnixTimeSeconds(10),
-                    CrowdsourcedVerdicts =
-                    {
-                        new CrowdsourcedVerdict { Source = "cs", Verdict = Verdict.Harmless, Timestamp = DateTimeOffset.FromUnixTimeSeconds(1) }
-                    },
-                    LastAnalysisResults = new Dictionary<string, AnalysisResult>
-                    {
-                        ["engine"] = new AnalysisResult { Category = "harmless", EngineName = "engine" }
-                    }
+                    new CrowdsourcedVerdict { Source = "cs", Verdict = Verdict.Harmless, Timestamp = DateTimeOffset.FromUnixTimeSeconds(1) }
+                },
+                LastAnalysisResults = new Dictionary<string, AnalysisResult>
+                {
+                    ["engine"] = new AnalysisResult { Category = "harmless", EngineName = "engine" }
                 }
             }
         };
 
         var json = JsonSerializer.Serialize(report, options);
         var roundtrip = JsonSerializer.Deserialize<FileReport>(json, options);
-        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(42), roundtrip!.Data.Attributes.CreationDate);
-        Assert.Equal("tag", Assert.Single(roundtrip.Data.Attributes.Tags));
-        Assert.Equal("harmless", roundtrip.Data.Attributes.LastAnalysisResults["engine"].Category);
-        Assert.Equal(100, roundtrip.Data.Attributes.Size);
-        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(10), roundtrip.Data.Attributes.FirstSubmissionDate);
-        Assert.Equal(Verdict.Harmless, roundtrip.Data.Attributes.CrowdsourcedVerdicts[0].Verdict);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(42), roundtrip!.Attributes.CreationDate);
+        Assert.Equal("tag", Assert.Single(roundtrip.Attributes.Tags));
+        Assert.Equal("harmless", roundtrip.Attributes.LastAnalysisResults["engine"].Category);
+        Assert.Equal(100, roundtrip.Attributes.Size);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(10), roundtrip.Attributes.FirstSubmissionDate);
+        Assert.Equal(Verdict.Harmless, roundtrip.Attributes.CrowdsourcedVerdicts[0].Verdict);
     }
 
     [Fact]
@@ -61,34 +58,31 @@ public class AttributeSerializationTests
         {
             Id = "url1",
             Type = ResourceType.Url,
-            Data = new UrlData
+            Attributes = new UrlAttributes
             {
-                Attributes = new UrlAttributes
+                Url = "https://example.com",
+                Reputation = 2,
+                CreationDate = DateTimeOffset.FromUnixTimeSeconds(84),
+                Tags = new List<string> { "tag" },
+                FirstSubmissionDate = DateTimeOffset.FromUnixTimeSeconds(11),
+                CrowdsourcedVerdicts =
                 {
-                    Url = "https://example.com",
-                    Reputation = 2,
-                    CreationDate = DateTimeOffset.FromUnixTimeSeconds(84),
-                    Tags = new List<string> { "tag" },
-                    FirstSubmissionDate = DateTimeOffset.FromUnixTimeSeconds(11),
-                    CrowdsourcedVerdicts =
-                    {
-                        new CrowdsourcedVerdict { Source = "cs", Verdict = Verdict.Malicious, Timestamp = DateTimeOffset.FromUnixTimeSeconds(2) }
-                    },
-                    LastAnalysisResults = new Dictionary<string, AnalysisResult>
-                    {
-                        ["engine"] = new AnalysisResult { Category = "malicious", EngineName = "engine" }
-                    }
+                    new CrowdsourcedVerdict { Source = "cs", Verdict = Verdict.Malicious, Timestamp = DateTimeOffset.FromUnixTimeSeconds(2) }
+                },
+                LastAnalysisResults = new Dictionary<string, AnalysisResult>
+                {
+                    ["engine"] = new AnalysisResult { Category = "malicious", EngineName = "engine" }
                 }
             }
         };
 
         var json = JsonSerializer.Serialize(report, options);
         var roundtrip = JsonSerializer.Deserialize<UrlReport>(json, options);
-        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(84), roundtrip!.Data.Attributes.CreationDate);
-        Assert.Equal("tag", Assert.Single(roundtrip.Data.Attributes.Tags));
-        Assert.Equal("malicious", roundtrip.Data.Attributes.LastAnalysisResults["engine"].Category);
-        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(11), roundtrip.Data.Attributes.FirstSubmissionDate);
-        Assert.Equal(Verdict.Malicious, roundtrip.Data.Attributes.CrowdsourcedVerdicts[0].Verdict);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(84), roundtrip!.Attributes.CreationDate);
+        Assert.Equal("tag", Assert.Single(roundtrip.Attributes.Tags));
+        Assert.Equal("malicious", roundtrip.Attributes.LastAnalysisResults["engine"].Category);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(11), roundtrip.Attributes.FirstSubmissionDate);
+        Assert.Equal(Verdict.Malicious, roundtrip.Attributes.CrowdsourcedVerdicts[0].Verdict);
     }
 
     [Fact]
@@ -131,27 +125,24 @@ public class AttributeSerializationTests
         {
             Id = "domain1",
             Type = ResourceType.Domain,
-            Data = new DomainData
+            Attributes = new DomainAttributes
             {
-                Attributes = new DomainAttributes
+                Domain = "example.com",
+                Reputation = 3,
+                CreationDate = DateTimeOffset.FromUnixTimeSeconds(21),
+                Tags = new List<string> { "tag" },
+                LastAnalysisResults = new Dictionary<string, AnalysisResult>
                 {
-                    Domain = "example.com",
-                    Reputation = 3,
-                    CreationDate = DateTimeOffset.FromUnixTimeSeconds(21),
-                    Tags = new List<string> { "tag" },
-                    LastAnalysisResults = new Dictionary<string, AnalysisResult>
-                    {
-                        ["engine"] = new AnalysisResult { Category = "suspicious", EngineName = "engine" }
-                    }
+                    ["engine"] = new AnalysisResult { Category = "suspicious", EngineName = "engine" }
                 }
             }
         };
 
         var json = JsonSerializer.Serialize(report, options);
         var roundtrip = JsonSerializer.Deserialize<DomainReport>(json, options);
-        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(21), roundtrip!.Data.Attributes.CreationDate);
-        Assert.Equal("tag", Assert.Single(roundtrip.Data.Attributes.Tags));
-        Assert.Equal("suspicious", roundtrip.Data.Attributes.LastAnalysisResults["engine"].Category);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(21), roundtrip!.Attributes.CreationDate);
+        Assert.Equal("tag", Assert.Single(roundtrip.Attributes.Tags));
+        Assert.Equal("suspicious", roundtrip.Attributes.LastAnalysisResults["engine"].Category);
     }
 
     [Fact]
@@ -164,26 +155,23 @@ public class AttributeSerializationTests
         {
             Id = "ip1",
             Type = ResourceType.IpAddress,
-            Data = new IpAddressData
+            Attributes = new IpAddressAttributes
             {
-                Attributes = new IpAddressAttributes
+                IpAddress = "1.2.3.4",
+                Reputation = 4,
+                CreationDate = DateTimeOffset.FromUnixTimeSeconds(63),
+                Tags = new List<string> { "tag" },
+                LastAnalysisResults = new Dictionary<string, AnalysisResult>
                 {
-                    IpAddress = "1.2.3.4",
-                    Reputation = 4,
-                    CreationDate = DateTimeOffset.FromUnixTimeSeconds(63),
-                    Tags = new List<string> { "tag" },
-                    LastAnalysisResults = new Dictionary<string, AnalysisResult>
-                    {
-                        ["engine"] = new AnalysisResult { Category = "undetected", EngineName = "engine" }
-                    }
+                    ["engine"] = new AnalysisResult { Category = "undetected", EngineName = "engine" }
                 }
             }
         };
 
         var json = JsonSerializer.Serialize(report, options);
         var roundtrip = JsonSerializer.Deserialize<IpAddressReport>(json, options);
-        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(63), roundtrip!.Data.Attributes.CreationDate);
-        Assert.Equal("tag", Assert.Single(roundtrip.Data.Attributes.Tags));
-        Assert.Equal("undetected", roundtrip.Data.Attributes.LastAnalysisResults["engine"].Category);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(63), roundtrip!.Attributes.CreationDate);
+        Assert.Equal("tag", Assert.Single(roundtrip.Attributes.Tags));
+        Assert.Equal("undetected", roundtrip.Attributes.LastAnalysisResults["engine"].Category);
     }
 }

--- a/VirusTotalAnalyzer.Tests/MonitorItemTests.cs
+++ b/VirusTotalAnalyzer.Tests/MonitorItemTests.cs
@@ -13,7 +13,7 @@ public class MonitorItemTests
     [Fact]
     public async Task ListMonitorItemsAsync_GetsItems()
     {
-        var json = "{\"data\":[{\"id\":\"m1\",\"type\":\"monitorItem\",\"data\":{\"attributes\":{\"path\":\"/foo\"}}}]}";
+        var json = "{\"data\":[{\"id\":\"m1\",\"type\":\"monitor_item\",\"data\":{\"attributes\":{\"path\":\"/foo\"}}}]}";
         var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -58,7 +58,7 @@ public class MonitorItemTests
     [Fact]
     public async Task CreateMonitorItemAsync_PostsItem()
     {
-        var json = "{\"id\":\"m1\",\"type\":\"monitorItem\",\"data\":{\"attributes\":{\"path\":\"/foo\"}}}";
+        var json = "{\"id\":\"m1\",\"type\":\"monitor_item\",\"data\":{\"attributes\":{\"path\":\"/foo\"}}}";
         var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -81,7 +81,7 @@ public class MonitorItemTests
     [Fact]
     public async Task UpdateMonitorItemAsync_PatchesItem()
     {
-        var json = "{\"id\":\"m1\",\"type\":\"monitorItem\",\"data\":{\"attributes\":{\"path\":\"/bar\"}}}";
+        var json = "{\"id\":\"m1\",\"type\":\"monitor_item\",\"data\":{\"attributes\":{\"path\":\"/bar\"}}}";
         var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.AnalysisRelationships.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.AnalysisRelationships.cs
@@ -61,7 +61,7 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task GetFileContactedIpsAsync_UsesCorrectPathAndDeserializesResponse()
     {
-        var json = "{\"data\":[{\"id\":\"i1\",\"type\":\"ipAddress\",\"data\":{\"attributes\":{\"ip_address\":\"1.2.3.4\"}}}]}";
+        var json = "{\"data\":[{\"id\":\"i1\",\"type\":\"ip_address\",\"data\":{\"attributes\":{\"ip_address\":\"1.2.3.4\"}}}]}";
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -85,7 +85,7 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task GetFileReferrerFilesAsync_UsesCorrectPathAndDeserializesResponse()
     {
-        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"data\":{\"attributes\":{\"md5\":\"abc\"}}}]}";
+        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"attributes\":{\"md5\":\"abc\"}}]}";
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -103,13 +103,13 @@ public partial class VirusTotalClientTests
         Assert.Equal("/api/v3/files/abc/referrer_files", handler.Request!.RequestUri!.AbsolutePath);
         Assert.NotNull(files);
         Assert.Single(files!);
-        Assert.Equal("abc", files[0].Data.Attributes.Md5);
+        Assert.Equal("abc", files[0].Attributes.Md5);
     }
 
     [Fact]
     public async Task GetFileDownloadedFilesAsync_UsesCorrectPathAndDeserializesResponse()
     {
-        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"data\":{\"attributes\":{\"md5\":\"abc\"}}}]}";
+        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"attributes\":{\"md5\":\"abc\"}}]}";
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -127,13 +127,13 @@ public partial class VirusTotalClientTests
         Assert.Equal("/api/v3/files/abc/downloaded_files", handler.Request!.RequestUri!.AbsolutePath);
         Assert.NotNull(files);
         Assert.Single(files!);
-        Assert.Equal("abc", files[0].Data.Attributes.Md5);
+        Assert.Equal("abc", files[0].Attributes.Md5);
     }
 
     [Fact]
     public async Task GetFileBundledFilesAsync_UsesCorrectPathAndDeserializesResponse()
     {
-        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"data\":{\"attributes\":{\"md5\":\"abc\"}}}]}";
+        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"attributes\":{\"md5\":\"abc\"}}]}";
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -151,13 +151,13 @@ public partial class VirusTotalClientTests
         Assert.Equal("/api/v3/files/abc/bundled_files", handler.Request!.RequestUri!.AbsolutePath);
         Assert.NotNull(files);
         Assert.Single(files!);
-        Assert.Equal("abc", files[0].Data.Attributes.Md5);
+        Assert.Equal("abc", files[0].Attributes.Md5);
     }
 
     [Fact]
     public async Task GetFileDroppedFilesAsync_UsesCorrectPathAndDeserializesResponse()
     {
-        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"data\":{\"attributes\":{\"md5\":\"abc\"}}}]}";
+        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"attributes\":{\"md5\":\"abc\"}}]}";
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -175,13 +175,13 @@ public partial class VirusTotalClientTests
         Assert.Equal("/api/v3/files/abc/dropped_files", handler.Request!.RequestUri!.AbsolutePath);
         Assert.NotNull(files);
         Assert.Single(files!);
-        Assert.Equal("abc", files[0].Data.Attributes.Md5);
+        Assert.Equal("abc", files[0].Attributes.Md5);
     }
 
     [Fact]
     public async Task GetFileSimilarFilesAsync_UsesCorrectPathAndDeserializesResponse()
     {
-        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"data\":{\"attributes\":{\"md5\":\"abc\"}}}]}";
+        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"attributes\":{\"md5\":\"abc\"}}]}";
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -199,13 +199,13 @@ public partial class VirusTotalClientTests
         Assert.Equal("/api/v3/files/abc/similar_files", handler.Request!.RequestUri!.AbsolutePath);
         Assert.NotNull(files);
         Assert.Single(files!);
-        Assert.Equal("abc", files[0].Data.Attributes.Md5);
+        Assert.Equal("abc", files[0].Attributes.Md5);
     }
 
     [Fact]
     public async Task GetUrlDownloadedFilesAsync_UsesCorrectPathAndDeserializesResponse()
     {
-        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"data\":{\"attributes\":{\"md5\":\"abc\"}}}]}";
+        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"attributes\":{\"md5\":\"abc\"}}]}";
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -223,13 +223,13 @@ public partial class VirusTotalClientTests
         Assert.Equal("/api/v3/urls/abc/downloaded_files", handler.Request!.RequestUri!.AbsolutePath);
         Assert.NotNull(files);
         Assert.Single(files!);
-        Assert.Equal("abc", files[0].Data.Attributes.Md5);
+        Assert.Equal("abc", files[0].Attributes.Md5);
     }
 
     [Fact]
     public async Task GetUrlReferrerFilesAsync_UsesCorrectPathAndDeserializesResponse()
     {
-        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"data\":{\"attributes\":{\"md5\":\"abc\"}}}]}";
+        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"attributes\":{\"md5\":\"abc\"}}]}";
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -247,13 +247,13 @@ public partial class VirusTotalClientTests
         Assert.Equal("/api/v3/urls/abc/referrer_files", handler.Request!.RequestUri!.AbsolutePath);
         Assert.NotNull(files);
         Assert.Single(files!);
-        Assert.Equal("abc", files[0].Data.Attributes.Md5);
+        Assert.Equal("abc", files[0].Attributes.Md5);
     }
 
     [Fact]
     public async Task GetUrlContactedIpsAsync_UsesCorrectPathAndDeserializesResponse()
     {
-        var json = "{\"data\":[{\"id\":\"i1\",\"type\":\"ipAddress\",\"data\":{\"attributes\":{\"ip_address\":\"1.2.3.4\"}}}]}";
+        var json = "{\"data\":[{\"id\":\"i1\",\"type\":\"ip_address\",\"data\":{\"attributes\":{\"ip_address\":\"1.2.3.4\"}}}]}";
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Core.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Core.cs
@@ -32,7 +32,7 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task GetFileReportAsync_DeserializesResponse()
     {
-        var json = "{\"id\":\"abc\",\"type\":\"file\",\"data\":{\"attributes\":{\"md5\":\"demo\"}}}";
+        var json = "{\"data\":{\"id\":\"abc\",\"type\":\"file\",\"attributes\":{\"md5\":\"demo\"}}}";
         var handler = new StubHandler(json);
         var httpClient = new HttpClient(handler)
         {
@@ -45,7 +45,7 @@ public partial class VirusTotalClientTests
         Assert.NotNull(report);
         Assert.Equal("abc", report!.Id);
         Assert.Equal(ResourceType.File, report.Type);
-        Assert.Equal("demo", report.Data.Attributes.Md5);
+        Assert.Equal("demo", report.Attributes.Md5);
     }
 
     [Fact]
@@ -255,7 +255,7 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task GetUrlReportAsync_DeserializesResponse()
     {
-        var json = "{\"id\":\"def\",\"type\":\"url\",\"data\":{\"attributes\":{\"url\":\"https://example.com\"}}}";
+        var json = "{\"data\":{\"id\":\"def\",\"type\":\"url\",\"attributes\":{\"url\":\"https://example.com\"}}}";
         var handler = new StubHandler(json);
         var httpClient = new HttpClient(handler)
         {
@@ -268,7 +268,7 @@ public partial class VirusTotalClientTests
         Assert.NotNull(report);
         Assert.Equal("def", report!.Id);
         Assert.Equal(ResourceType.Url, report.Type);
-        Assert.Equal("https://example.com", report.Data.Attributes.Url);
+        Assert.Equal("https://example.com", report.Attributes.Url);
     }
 
     [Fact]
@@ -298,7 +298,7 @@ public partial class VirusTotalClientTests
     {
         var url = new Uri("https://example.com");
         var id = VirusTotalClientExtensions.GetUrlId(url.ToString());
-        var json = $"{{\"id\":\"{id}\",\"type\":\"url\"}}";
+        var json = $"{{\"data\":{{\"id\":\"{id}\",\"type\":\"url\"}}}}";
         var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.DomainRelationships.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.DomainRelationships.cs
@@ -111,7 +111,7 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task GetDomainReferrerFilesAsync_UsesCorrectPathAndDeserializesResponse()
     {
-        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"data\":{\"attributes\":{\"md5\":\"abc\"}}}]}";
+        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"attributes\":{\"md5\":\"abc\"}}]}";
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -129,13 +129,13 @@ public partial class VirusTotalClientTests
         Assert.Equal("/api/v3/domains/example.com/referrer_files", handler.Request!.RequestUri!.AbsolutePath);
         Assert.NotNull(files);
         Assert.Single(files!);
-        Assert.Equal("abc", files[0].Data.Attributes.Md5);
+        Assert.Equal("abc", files[0].Attributes.Md5);
     }
 
     [Fact]
     public async Task GetDomainDownloadedFilesAsync_UsesCorrectPathAndDeserializesResponse()
     {
-        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"data\":{\"attributes\":{\"md5\":\"abc\"}}}]}";
+        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"attributes\":{\"md5\":\"abc\"}}]}";
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -153,6 +153,6 @@ public partial class VirusTotalClientTests
         Assert.Equal("/api/v3/domains/example.com/downloaded_files", handler.Request!.RequestUri!.AbsolutePath);
         Assert.NotNull(files);
         Assert.Single(files!);
-        Assert.Equal("abc", files[0].Data.Attributes.Md5);
+        Assert.Equal("abc", files[0].Attributes.Md5);
     }
 }

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Relationships.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Relationships.cs
@@ -133,7 +133,7 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task GetIpAddressCommunicatingFilesAsync_UsesCorrectPathAndDeserializesResponse()
     {
-        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"data\":{\"attributes\":{\"md5\":\"abc\"}}}]}";
+        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"attributes\":{\"md5\":\"abc\"}}]}";
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -151,6 +151,6 @@ public partial class VirusTotalClientTests
         Assert.Equal("/api/v3/ip_addresses/1.2.3.4/communicating_files", handler.Request!.RequestUri!.AbsolutePath);
         Assert.NotNull(files);
         Assert.Single(files!);
-        Assert.Equal("abc", files[0].Data.Attributes.Md5);
+        Assert.Equal("abc", files[0].Attributes.Md5);
     }
 }

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
@@ -16,8 +16,8 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task ListRetrohuntNotificationsAsync_PagesThroughResults()
     {
-        var first = "{\"data\":[{\"id\":\"n1\",\"type\":\"retrohuntNotification\",\"data\":{\"attributes\":{\"job_id\":\"j1\"}}}],\"meta\":{\"cursor\":\"abc\"}}";
-        var second = "{\"data\":[{\"id\":\"n2\",\"type\":\"retrohuntNotification\",\"data\":{\"attributes\":{\"job_id\":\"j2\"}}}]}";
+        var first = "{\"data\":[{\"id\":\"n1\",\"type\":\"retrohunt_notification\",\"data\":{\"attributes\":{\"job_id\":\"j1\"}}}],\"meta\":{\"cursor\":\"abc\"}}";
+        var second = "{\"data\":[{\"id\":\"n2\",\"type\":\"retrohunt_notification\",\"data\":{\"attributes\":{\"job_id\":\"j2\"}}}]}";
         var handler = new QueueHandler(
             new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(first, Encoding.UTF8, "application/json") },
             new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(second, Encoding.UTF8, "application/json") });
@@ -41,7 +41,7 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task ListRetrohuntNotificationsAsync_SinglePage()
     {
-        var first = "{\"data\":[{\"id\":\"n1\",\"type\":\"retrohuntNotification\",\"data\":{\"attributes\":{\"job_id\":\"j1\"}}}],\"meta\":{\"cursor\":\"abc\"}}";
+        var first = "{\"data\":[{\"id\":\"n1\",\"type\":\"retrohunt_notification\",\"data\":{\"attributes\":{\"job_id\":\"j1\"}}}],\"meta\":{\"cursor\":\"abc\"}}";
         var handler = new QueueHandler(
             new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(first, Encoding.UTF8, "application/json") });
         var httpClient = new HttpClient(handler)
@@ -62,7 +62,7 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task GetIpAddressReportAsync_DeserializesResponseAndUsesCorrectPath()
     {
-        var json = "{\"id\":\"1.1.1.1\",\"type\":\"ipAddress\",\"data\":{\"attributes\":{\"ip_address\":\"1.1.1.1\"}}}";
+        var json = "{\"data\":{\"id\":\"1.1.1.1\",\"type\":\"ip_address\",\"attributes\":{\"ip_address\":\"1.1.1.1\"}}}";
         var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -85,7 +85,7 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task GetDomainReportAsync_DeserializesResponseAndUsesCorrectPath()
     {
-        var json = "{\"id\":\"example.com\",\"type\":\"domain\",\"data\":{\"attributes\":{\"domain\":\"example.com\"}}}";
+        var json = "{\"data\":{\"id\":\"example.com\",\"type\":\"domain\",\"attributes\":{\"domain\":\"example.com\"}}}";
         var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -132,7 +132,7 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task GetIpAddressWhoisAsync_DeserializesResponseAndUsesCorrectPath()
     {
-        var json = "{\"id\":\"1.1.1.1\",\"type\":\"ipAddress\",\"data\":{\"attributes\":{\"whois\":\"ip whois\"}}}";
+        var json = "{\"id\":\"1.1.1.1\",\"type\":\"ip_address\",\"data\":{\"attributes\":{\"whois\":\"ip whois\"}}}";
         var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -453,8 +453,8 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task ListRetrohuntJobsAsync_PagesThroughResults()
     {
-        var first = "{\"data\":[{\"id\":\"j1\",\"type\":\"retrohuntJob\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}],\"meta\":{\"cursor\":\"abc\"}}";
-        var second = "{\"data\":[{\"id\":\"j2\",\"type\":\"retrohuntJob\",\"data\":{\"attributes\":{\"status\":\"done\"}}}]}";
+        var first = "{\"data\":[{\"id\":\"j1\",\"type\":\"retrohunt_job\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}],\"meta\":{\"cursor\":\"abc\"}}";
+        var second = "{\"data\":[{\"id\":\"j2\",\"type\":\"retrohunt_job\",\"data\":{\"attributes\":{\"status\":\"done\"}}}]}";
         var handler = new QueueHandler(
             new HttpResponseMessage(HttpStatusCode.OK)
             {
@@ -484,7 +484,7 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task ListRetrohuntJobsAsync_SinglePage()
     {
-        var first = "{\"data\":[{\"id\":\"j1\",\"type\":\"retrohuntJob\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}],\"meta\":{\"cursor\":\"abc\"}}";
+        var first = "{\"data\":[{\"id\":\"j1\",\"type\":\"retrohunt_job\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}],\"meta\":{\"cursor\":\"abc\"}}";
         var handler = new QueueHandler(
             new HttpResponseMessage(HttpStatusCode.OK)
             {

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.cs
@@ -90,7 +90,7 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task GetLivehuntNotificationAsync_DeserializesResponse()
     {
-        var json = "{\"id\":\"ln1\",\"type\":\"livehuntNotification\",\"data\":{\"attributes\":{\"rule_name\":\"r1\"}}}";
+        var json = "{\"data\":{\"id\":\"ln1\",\"type\":\"livehunt_notification\",\"attributes\":{\"rule_name\":\"r1\"}}}";
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -106,7 +106,7 @@ public partial class VirusTotalClientTests
 
         Assert.NotNull(notification);
         Assert.Equal("ln1", notification!.Id);
-        Assert.Equal("r1", notification.Data.Attributes.RuleName);
+        Assert.Equal("r1", notification.Attributes.RuleName);
         Assert.NotNull(handler.Request);
         Assert.Equal("/api/v3/livehunt_notifications/ln1", handler.Request!.RequestUri!.AbsolutePath);
     }
@@ -132,7 +132,7 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task GetRetrohuntJobAsync_DeserializesResponse()
     {
-        var json = "{\"id\":\"rj1\",\"type\":\"retrohuntJob\",\"data\":{\"attributes\":{\"status\":\"done\"}}}";
+        var json = "{\"id\":\"rj1\",\"type\":\"retrohunt_job\",\"data\":{\"attributes\":{\"status\":\"done\"}}}";
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -174,7 +174,7 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task GetRetrohuntNotificationAsync_DeserializesResponse()
     {
-        var json = "{\"id\":\"rn1\",\"type\":\"retrohuntNotification\",\"data\":{\"attributes\":{\"job_id\":\"j1\"}}}";
+        var json = "{\"id\":\"rn1\",\"type\":\"retrohunt_notification\",\"data\":{\"attributes\":{\"job_id\":\"j1\"}}}";
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -216,7 +216,7 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task GetMonitorItemAsync_DeserializesResponse()
     {
-        var json = "{\"id\":\"mi1\",\"type\":\"monitorItem\",\"data\":{\"attributes\":{\"path\":\"/tmp\"}}}";
+        var json = "{\"id\":\"mi1\",\"type\":\"monitor_item\",\"data\":{\"attributes\":{\"path\":\"/tmp\"}}}";
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -282,7 +282,7 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task SubmitPrivateFileAsync_PostsToPrivateAnalyses()
     {
-        var json = "{\"id\":\"pa\",\"type\":\"privateAnalysis\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}";
+        var json = "{\"id\":\"pa\",\"type\":\"private_analysis\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}";
         var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -305,7 +305,7 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task GetPrivateAnalysisAsync_DeserializesResponse()
     {
-        var json = "{\"id\":\"pa\",\"type\":\"privateAnalysis\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}";
+        var json = "{\"id\":\"pa\",\"type\":\"private_analysis\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}";
         var handler = new StubHandler(json);
         var httpClient = new HttpClient(handler)
         {
@@ -345,8 +345,8 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task ListLivehuntNotificationsAsync_PagesThroughResults()
     {
-        var first = "{\"data\":[{\"id\":\"n1\",\"type\":\"livehuntNotification\",\"data\":{\"attributes\":{\"rule_name\":\"r1\"}}}],\"meta\":{\"cursor\":\"abc\"}}";
-        var second = "{\"data\":[{\"id\":\"n2\",\"type\":\"livehuntNotification\",\"data\":{\"attributes\":{\"rule_name\":\"r2\"}}}]}";
+        var first = "{\"data\":[{\"id\":\"n1\",\"type\":\"livehunt_notification\",\"attributes\":{\"rule_name\":\"r1\"}}],\"meta\":{\"cursor\":\"abc\"}}";
+        var second = "{\"data\":[{\"id\":\"n2\",\"type\":\"livehunt_notification\",\"attributes\":{\"rule_name\":\"r2\"}}]}";
         var handler = new QueueHandler(
             new HttpResponseMessage(HttpStatusCode.OK)
             {
@@ -376,7 +376,7 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task ListLivehuntNotificationsAsync_SinglePage()
     {
-        var first = "{\"data\":[{\"id\":\"n1\",\"type\":\"livehuntNotification\",\"data\":{\"attributes\":{\"rule_name\":\"r1\"}}}],\"meta\":{\"cursor\":\"abc\"}}"; 
+        var first = "{\"data\":[{\"id\":\"n1\",\"type\":\"livehunt_notification\",\"attributes\":{\"rule_name\":\"r1\"}}],\"meta\":{\"cursor\":\"abc\"}}";
         var handler = new QueueHandler(
             new HttpResponseMessage(HttpStatusCode.OK)
             {
@@ -402,7 +402,7 @@ public partial class VirusTotalClientTests
     {
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
-            Content = new StringContent("{\"data\":{\"id\":\"rj1\",\"type\":\"retrohuntJob\",\"attributes\":{\"status\":\"queued\"}}}", Encoding.UTF8, "application/json")
+            Content = new StringContent("{\"data\":{\"id\":\"rj1\",\"type\":\"retrohunt_job\",\"attributes\":{\"status\":\"queued\"}}}", Encoding.UTF8, "application/json")
         };
         var handler = new SingleResponseHandler(response);
         var httpClient = new HttpClient(handler)

--- a/VirusTotalAnalyzer/JsonStringEnumMemberConverter.cs
+++ b/VirusTotalAnalyzer/JsonStringEnumMemberConverter.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer;
+
+internal sealed class JsonStringEnumMemberConverter : JsonConverterFactory
+{
+    public override bool CanConvert(Type typeToConvert) => typeToConvert.IsEnum;
+
+    public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        => (JsonConverter)Activator.CreateInstance(typeof(EnumMemberConverter<>).MakeGenericType(typeToConvert))!;
+
+    private sealed class EnumMemberConverter<T> : JsonConverter<T> where T : struct, Enum
+    {
+        private static readonly Dictionary<T, string> _toString;
+        private static readonly Dictionary<string, T> _fromString;
+
+        static EnumMemberConverter()
+        {
+            _toString = new Dictionary<T, string>();
+            _fromString = new Dictionary<string, T>(StringComparer.OrdinalIgnoreCase);
+            foreach (var field in typeof(T).GetFields(BindingFlags.Public | BindingFlags.Static))
+            {
+                var value = (T)field.GetValue(null)!;
+                var enumMember = field.GetCustomAttribute<EnumMemberAttribute>();
+                var name = enumMember?.Value ?? field.Name;
+                _toString[value] = name;
+                _fromString[name] = value;
+            }
+        }
+
+        public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var str = reader.GetString();
+            if (str != null && _fromString.TryGetValue(str, out var value))
+            {
+                return value;
+            }
+            throw new JsonException($"Unknown value '{str}' for enum '{typeof(T)}'.");
+        }
+
+        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+        {
+            if (_toString.TryGetValue(value, out var name))
+            {
+                writer.WriteStringValue(name);
+                return;
+            }
+            writer.WriteStringValue(value.ToString());
+        }
+    }
+}

--- a/VirusTotalAnalyzer/Models/DomainReport.cs
+++ b/VirusTotalAnalyzer/Models/DomainReport.cs
@@ -8,12 +8,15 @@ public sealed class DomainReport
 {
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
-    public DomainData Data { get; set; } = new();
+
+    [JsonPropertyName("attributes")]
+    public DomainAttributes Attributes { get; set; } = new();
 }
 
-public sealed class DomainData
+public sealed class DomainReportResponse
 {
-    public DomainAttributes Attributes { get; set; } = new();
+    [JsonPropertyName("data")]
+    public DomainReport Data { get; set; } = new();
 }
 
 public sealed class DomainAttributes

--- a/VirusTotalAnalyzer/Models/FileReport.cs
+++ b/VirusTotalAnalyzer/Models/FileReport.cs
@@ -8,12 +8,15 @@ public sealed class FileReport
 {
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
-    public FileData Data { get; set; } = new();
+
+    [JsonPropertyName("attributes")]
+    public FileAttributes Attributes { get; set; } = new();
 }
 
-public sealed class FileData
+public sealed class FileReportResponse
 {
-    public FileAttributes Attributes { get; set; } = new();
+    [JsonPropertyName("data")]
+    public FileReport Data { get; set; } = new();
 }
 
 public sealed class FileAttributes

--- a/VirusTotalAnalyzer/Models/IpAddressReport.cs
+++ b/VirusTotalAnalyzer/Models/IpAddressReport.cs
@@ -8,12 +8,15 @@ public sealed class IpAddressReport
 {
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
-    public IpAddressData Data { get; set; } = new();
+
+    [JsonPropertyName("attributes")]
+    public IpAddressAttributes Attributes { get; set; } = new();
 }
 
-public sealed class IpAddressData
+public sealed class IpAddressReportResponse
 {
-    public IpAddressAttributes Attributes { get; set; } = new();
+    [JsonPropertyName("data")]
+    public IpAddressReport Data { get; set; } = new();
 }
 
 public sealed class IpAddressAttributes

--- a/VirusTotalAnalyzer/Models/LivehuntNotification.cs
+++ b/VirusTotalAnalyzer/Models/LivehuntNotification.cs
@@ -7,12 +7,15 @@ public sealed class LivehuntNotification
 {
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
-    public LivehuntNotificationData Data { get; set; } = new();
+
+    [JsonPropertyName("attributes")]
+    public LivehuntNotificationAttributes Attributes { get; set; } = new();
 }
 
-public sealed class LivehuntNotificationData
+public sealed class LivehuntNotificationResponse
 {
-    public LivehuntNotificationAttributes Attributes { get; set; } = new();
+    [JsonPropertyName("data")]
+    public LivehuntNotification Data { get; set; } = new();
 }
 
 public sealed class LivehuntNotificationAttributes

--- a/VirusTotalAnalyzer/Models/UrlReport.cs
+++ b/VirusTotalAnalyzer/Models/UrlReport.cs
@@ -8,12 +8,15 @@ public sealed class UrlReport
 {
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
-    public UrlData Data { get; set; } = new();
+
+    [JsonPropertyName("attributes")]
+    public UrlAttributes Attributes { get; set; } = new();
 }
 
-public sealed class UrlData
+public sealed class UrlReportResponse
 {
-    public UrlAttributes Attributes { get; set; } = new();
+    [JsonPropertyName("data")]
+    public UrlReport Data { get; set; } = new();
 }
 
 public sealed class UrlAttributes

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -24,8 +24,9 @@ public sealed partial class VirusTotalClient
 #else
         await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #endif
-        return await JsonSerializer.DeserializeAsync<FileReport>(stream, _jsonOptions, cancellationToken)
+        var result = await JsonSerializer.DeserializeAsync<FileReportResponse>(stream, _jsonOptions, cancellationToken)
             .ConfigureAwait(false);
+        return result?.Data;
     }
 
     public async Task<FileBehavior?> GetFileBehaviorAsync(string id, CancellationToken cancellationToken = default)
@@ -275,8 +276,9 @@ public sealed partial class VirusTotalClient
 #else
         await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #endif
-        return await JsonSerializer.DeserializeAsync<UrlReport>(stream, _jsonOptions, cancellationToken)
+        var result = await JsonSerializer.DeserializeAsync<UrlReportResponse>(stream, _jsonOptions, cancellationToken)
             .ConfigureAwait(false);
+        return result?.Data;
     }
 
     public Task<UrlReport?> GetUrlReportAsync(Uri url, CancellationToken cancellationToken = default)
@@ -333,8 +335,9 @@ public sealed partial class VirusTotalClient
 #else
         await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #endif
-        return await JsonSerializer.DeserializeAsync<IpAddressReport>(stream, _jsonOptions, cancellationToken)
+        var result = await JsonSerializer.DeserializeAsync<IpAddressReportResponse>(stream, _jsonOptions, cancellationToken)
             .ConfigureAwait(false);
+        return result?.Data;
     }
 
     public async Task<IpWhois?> GetIpAddressWhoisAsync(string id, CancellationToken cancellationToken = default)
@@ -359,8 +362,9 @@ public sealed partial class VirusTotalClient
 #else
         await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #endif
-        return await JsonSerializer.DeserializeAsync<DomainReport>(stream, _jsonOptions, cancellationToken)
+        var result = await JsonSerializer.DeserializeAsync<DomainReportResponse>(stream, _jsonOptions, cancellationToken)
             .ConfigureAwait(false);
+        return result?.Data;
     }
 
     public async Task<DomainWhois?> GetDomainWhoisAsync(string id, CancellationToken cancellationToken = default)

--- a/VirusTotalAnalyzer/VirusTotalClient.Intelligence.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Intelligence.cs
@@ -24,7 +24,8 @@ public sealed partial class VirusTotalClient
 #else
         await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #endif
-        return await JsonSerializer.DeserializeAsync<LivehuntNotification>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+        var result = await JsonSerializer.DeserializeAsync<LivehuntNotificationResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+        return result?.Data;
     }
 
     public async Task<Page<LivehuntNotification>> ListLivehuntNotificationsAsync(int limit = 10, string? cursor = null, bool fetchAll = true, CancellationToken cancellationToken = default)

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -52,7 +52,7 @@ public sealed partial class VirusTotalClient : IDisposable
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };
-        _jsonOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+        _jsonOptions.Converters.Add(new JsonStringEnumMemberConverter());
         _jsonOptions.Converters.Add(new UnixTimestampConverter());
     }
 


### PR DESCRIPTION
## Summary
- wrap resource responses such as files, URLs and IP addresses to align with VT API payloads
- return inner resource data from client methods and deserialize using enum-member aware converter
- update examples and tests with realistic JSON structures

## Testing
- `dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_689c3055b40c832eac4a050f6596cf26