### PR TITLE
Use proper VirusTotal password header

### DIFF
--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
@@ -152,7 +152,7 @@ public partial class VirusTotalClientTests
             Assert.NotNull(report);
             Assert.NotNull(handler.Request);
             Assert.Equal("/api/v3/files", handler.Request!.RequestUri!.AbsolutePath);
-            Assert.True(handler.Request.Headers.Contains("password"));
+            Assert.True(handler.Request.Headers.Contains("x-virustotal-password"));
         }
         finally
         {
@@ -192,7 +192,7 @@ public partial class VirusTotalClientTests
         Assert.Equal(2, handler.Requests.Count);
         Assert.Equal("/api/v3/files/upload_url", handler.Requests[0].RequestUri!.AbsolutePath);
         Assert.Equal("https://upload.example/upload", handler.Requests[1].RequestUri!.ToString());
-        Assert.True(handler.Requests[1].Headers.Contains("password"));
+        Assert.True(handler.Requests[1].Headers.Contains("x-virustotal-password"));
     }
 
     [Fact]

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.cs
@@ -280,6 +280,28 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task SubmitFileAsync_IncludesPasswordHeader()
+    {
+        var analysisJson = "{\"id\":\"an\",\"type\":\"analysis\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(analysisJson, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        using var ms = new System.IO.MemoryStream(new byte[1]);
+        var report = await client.SubmitFileAsync(ms, "demo.bin", "pass");
+
+        Assert.NotNull(report);
+        Assert.NotNull(handler.Request);
+        Assert.True(handler.Request!.Headers.Contains("x-virustotal-password"));
+    }
+
+    [Fact]
     public async Task SubmitPrivateFileAsync_PostsToPrivateAnalyses()
     {
         var json = "{\"id\":\"pa\",\"type\":\"private_analysis\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}";
@@ -299,7 +321,7 @@ public partial class VirusTotalClientTests
         Assert.NotNull(report);
         Assert.NotNull(handler.Request);
         Assert.Equal("/api/v3/private/analyses", handler.Request!.RequestUri!.AbsolutePath);
-        Assert.True(handler.Request.Headers.Contains("password"));
+        Assert.True(handler.Request.Headers.Contains("x-virustotal-password"));
     }
 
     [Fact]

--- a/VirusTotalAnalyzer/VirusTotalClient.Submissions.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Submissions.cs
@@ -33,6 +33,14 @@ public sealed partial class VirusTotalClient
         return new Uri(result.Data);
     }
 
+    /// <summary>
+    /// Submits a file for analysis.
+    /// </summary>
+    /// <param name="stream">The file stream to upload.</param>
+    /// <param name="fileName">The name of the file.</param>
+    /// <param name="password">Optional password for the file; sent via the <c>x-virustotal-password</c> header.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
+    /// <returns>An <see cref="AnalysisReport"/> for the submitted file or <see langword="null"/> if the response is empty.</returns>
     public async Task<AnalysisReport?> SubmitFileAsync(Stream stream, string fileName, string? password = null, CancellationToken cancellationToken = default)
     {
 
@@ -70,7 +78,7 @@ public sealed partial class VirusTotalClient
         };
         if (!string.IsNullOrEmpty(password))
         {
-            request.Headers.Add("password", password);
+            request.Headers.Add("x-virustotal-password", password);
         }
         using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -96,6 +104,14 @@ public sealed partial class VirusTotalClient
     public Task<AnalysisReport?> SubmitFileAsync(Stream stream, string fileName, CancellationToken cancellationToken)
         => SubmitFileAsync(stream, fileName, null, cancellationToken);
 
+    /// <summary>
+    /// Submits a private file for analysis.
+    /// </summary>
+    /// <param name="stream">The file stream to upload.</param>
+    /// <param name="fileName">The name of the file.</param>
+    /// <param name="password">Optional password for the file; sent via the <c>x-virustotal-password</c> header.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
+    /// <returns>A <see cref="PrivateAnalysis"/> describing the analysis.</returns>
     public async Task<PrivateAnalysis?> SubmitPrivateFileAsync(
         Stream stream,
         string fileName,
@@ -110,7 +126,7 @@ public sealed partial class VirusTotalClient
         };
         if (!string.IsNullOrEmpty(password))
         {
-            request.Headers.Add("password", password);
+            request.Headers.Add("x-virustotal-password", password);
         }
         using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- send `x-virustotal-password` when submitting files to VirusTotal
- document password header behavior in submission methods
- test that file submissions apply the correct password header

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689c35f1319c832e968ba86e7e11d8b7