### PR TITLE
Add URL last serving IP address lookup

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetUrlRelationshipsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetUrlRelationshipsExample.cs
@@ -19,6 +19,9 @@ public static class GetUrlRelationshipsExample
 
             var ips = await client.GetUrlContactedIpsAsync("url-id");
             Console.WriteLine(ips?.Count);
+
+            var lastIp = await client.GetUrlLastServingIpAddressAsync("url-id");
+            Console.WriteLine(lastIp?.Data.Attributes.IpAddress);
         }
         catch (ApiException ex)
         {

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.AnalysisRelationships.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.AnalysisRelationships.cs
@@ -275,6 +275,29 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetUrlLastServingIpAddressAsync_UsesCorrectPathAndDeserializesResponse()
+    {
+        var json = "{\"data\":{\"id\":\"i1\",\"type\":\"ip_address\",\"data\":{\"attributes\":{\"ip_address\":\"1.2.3.4\"}}}}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var ip = await client.GetUrlLastServingIpAddressAsync("abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/urls/abc/last_serving_ip_address", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.NotNull(ip);
+        Assert.Equal("1.2.3.4", ip!.Data.Attributes.IpAddress);
+    }
+
+    [Fact]
     public async Task WaitForAnalysisCompletionAsync_HandlesNullData_ThrowsTimeout()
     {
         var json = "{\"id\":\"an\",\"type\":\"analysis\",\"data\":null}";

--- a/VirusTotalAnalyzer/Models/IpAddressSummary.cs
+++ b/VirusTotalAnalyzer/Models/IpAddressSummary.cs
@@ -10,6 +10,12 @@ public sealed class IpAddressSummary
     public IpAddressSummaryData Data { get; set; } = new();
 }
 
+public sealed class IpAddressSummaryResponse
+{
+    [JsonPropertyName("data")]
+    public IpAddressSummary Data { get; set; } = new();
+}
+
 public sealed class IpAddressSummaryData
 {
     public IpAddressSummaryAttributes Attributes { get; set; } = new();

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -326,6 +326,20 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
+    public async Task<IpAddressSummary?> GetUrlLastServingIpAddressAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"urls/{id}/last_serving_ip_address", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<IpAddressSummaryResponse>(stream, _jsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+        return result?.Data;
+    }
+
     public async Task<IpAddressReport?> GetIpAddressReportAsync(string id, CancellationToken cancellationToken = default)
     {
         using var response = await _httpClient.GetAsync($"ip_addresses/{id}", cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- add IpAddressSummaryResponse model
- support retrieving a URL's last serving IP address
- test and example for last serving IP address lookup

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689c59700b5c832e9cd2e71c702eb337