### PR TITLE
Normalize URL canonicalization

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetUrlIdExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetUrlIdExample.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetUrlIdExample
+{
+    public static void Run()
+    {
+        var id = VirusTotalClientExtensions.GetUrlId("https://virustotal.com");
+        Console.WriteLine(id);
+    }
+}

--- a/VirusTotalAnalyzer.Tests/UrlIdTests.cs
+++ b/VirusTotalAnalyzer.Tests/UrlIdTests.cs
@@ -7,11 +7,14 @@ namespace VirusTotalAnalyzer.Tests;
 
 public class UrlIdTests
 {
-    [Fact]
-    public void GetUrlId_CanonicalizesAndEncodes()
+    [Theory]
+    [InlineData("HTTP://Virustotal.com", "http://virustotal.com/")]
+    [InlineData("https://virustotal.com:443/#frag", "https://virustotal.com/")]
+    [InlineData("http://virustotal.com:80/path", "http://virustotal.com/path")]
+    [InlineData("http://virustotal.com#fragment", "http://virustotal.com/")]
+    public void GetUrlId_CanonicalizesAndEncodes(string url, string canonical)
     {
-        var id = VirusTotalClientExtensions.GetUrlId("HTTP://Virustotal.com");
-        const string canonical = "http://virustotal.com/";
+        var id = VirusTotalClientExtensions.GetUrlId(url);
         var expected = Convert.ToBase64String(Encoding.UTF8.GetBytes(canonical))
             .TrimEnd('=')
             .Replace('+', '-')

--- a/VirusTotalAnalyzer/VirusTotalClientExtensions.cs
+++ b/VirusTotalAnalyzer/VirusTotalClientExtensions.cs
@@ -14,7 +14,23 @@ public static class VirusTotalClientExtensions
         if (url == null) throw new ArgumentNullException(nameof(url));
 
         var uri = new Uri(url, UriKind.Absolute);
-        var canonical = uri.GetComponents(UriComponents.AbsoluteUri, UriFormat.SafeUnescaped);
+        var builder = new UriBuilder(uri)
+        {
+            Fragment = string.Empty
+        };
+
+        if ((builder.Scheme == Uri.UriSchemeHttp && builder.Port == 80) ||
+            (builder.Scheme == Uri.UriSchemeHttps && builder.Port == 443))
+        {
+            builder.Port = -1;
+        }
+
+        if (string.IsNullOrEmpty(builder.Path))
+        {
+            builder.Path = "/";
+        }
+
+        var canonical = builder.Uri.GetComponents(UriComponents.AbsoluteUri, UriFormat.SafeUnescaped);
         var bytes = Encoding.UTF8.GetBytes(canonical);
         return Convert.ToBase64String(bytes)
             .TrimEnd('=')


### PR DESCRIPTION
## Summary
- Strip default ports, ensure trailing slash and remove fragments when computing URL IDs
- Add regression tests for URL canonicalization cases
- Provide example demonstrating GetUrlId usage

## Testing
- `dotnet test -f net8.0 --no-restore`
- `apt-get install -y dotnet-sdk-9.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689c5977bf54832ea47c2014c5f2e950