### PR TITLE
feat: support pagination for resolutions and submissions

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetDomainResolutionsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetDomainResolutionsExample.cs
@@ -11,7 +11,7 @@ public static class GetDomainResolutionsExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var resolutions = await client.GetDomainResolutionsAsync("example.com");
+            var resolutions = await client.GetDomainResolutionsAsync("example.com", limit: 10);
             Console.WriteLine(resolutions?.Count);
         }
         catch (RateLimitExceededException ex)

--- a/VirusTotalAnalyzer.Examples/GetDomainSubmissionsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetDomainSubmissionsExample.cs
@@ -11,7 +11,7 @@ public static class GetDomainSubmissionsExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var submissions = await client.GetDomainSubmissionsAsync("example.com");
+            var submissions = await client.GetDomainSubmissionsAsync("example.com", limit: 10);
             Console.WriteLine(submissions?.Count);
         }
         catch (RateLimitExceededException ex)

--- a/VirusTotalAnalyzer.Examples/GetFileSubmissionsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileSubmissionsExample.cs
@@ -11,7 +11,7 @@ public static class GetFileSubmissionsExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var submissions = await client.GetFileSubmissionsAsync("44d88612fea8a8f36de82e1278abb02f");
+            var submissions = await client.GetFileSubmissionsAsync("44d88612fea8a8f36de82e1278abb02f", limit: 10);
             Console.WriteLine(submissions?.Count);
         }
         catch (RateLimitExceededException ex)

--- a/VirusTotalAnalyzer.Examples/GetIpAddressResolutionsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetIpAddressResolutionsExample.cs
@@ -11,7 +11,7 @@ public static class GetIpAddressResolutionsExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var resolutions = await client.GetIpAddressResolutionsAsync("1.2.3.4");
+            var resolutions = await client.GetIpAddressResolutionsAsync("1.2.3.4", limit: 10);
             Console.WriteLine(resolutions?.Count);
         }
         catch (RateLimitExceededException ex)

--- a/VirusTotalAnalyzer.Examples/GetIpAddressSubmissionsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetIpAddressSubmissionsExample.cs
@@ -11,7 +11,7 @@ public static class GetIpAddressSubmissionsExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var submissions = await client.GetIpAddressSubmissionsAsync("1.2.3.4");
+            var submissions = await client.GetIpAddressSubmissionsAsync("1.2.3.4", limit: 10);
             Console.WriteLine(submissions?.Count);
         }
         catch (RateLimitExceededException ex)

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Relationships.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Relationships.cs
@@ -59,6 +59,26 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetDomainResolutionsAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetDomainResolutionsAsync("example.com", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
+    }
+
+    [Fact]
     public async Task GetDomainSubmissionsAsync_UsesCorrectPathAndDeserializesResponse()
     {
         var json = "{\"data\":[{\"id\":\"s1\",\"type\":\"submission\",\"data\":{\"attributes\":{\"date\":1}}}]}";
@@ -128,6 +148,26 @@ public partial class VirusTotalClientTests
         Assert.NotNull(submissions);
         Assert.Single(submissions!);
         Assert.Equal(1, submissions[0].Data.Attributes.Date.ToUnixTimeSeconds());
+    }
+
+    [Fact]
+    public async Task GetIpAddressSubmissionsAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetIpAddressSubmissionsAsync("1.2.3.4", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
     }
 
     [Fact]

--- a/VirusTotalAnalyzer/VirusTotalClient.Relationships.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Relationships.cs
@@ -10,14 +10,26 @@ namespace VirusTotalAnalyzer;
 
 public sealed partial class VirusTotalClient
 {
-    public Task<IReadOnlyList<Submission>?> GetFileSubmissionsAsync(string id, CancellationToken cancellationToken = default)
-        => GetSubmissionsAsync(ResourceType.File, id, cancellationToken);
+    public Task<IReadOnlyList<Submission>?> GetFileSubmissionsAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
+        => GetSubmissionsAsync(ResourceType.File, id, limit, cursor, cancellationToken);
 
-    public Task<IReadOnlyList<Resolution>?> GetDomainResolutionsAsync(string id, CancellationToken cancellationToken = default)
-        => GetResolutionsAsync(ResourceType.Domain, id, cancellationToken);
+    public Task<IReadOnlyList<Resolution>?> GetDomainResolutionsAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
+        => GetResolutionsAsync(ResourceType.Domain, id, limit, cursor, cancellationToken);
 
-    public Task<IReadOnlyList<Submission>?> GetDomainSubmissionsAsync(string id, CancellationToken cancellationToken = default)
-        => GetSubmissionsAsync(ResourceType.Domain, id, cancellationToken);
+    public Task<IReadOnlyList<Submission>?> GetDomainSubmissionsAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
+        => GetSubmissionsAsync(ResourceType.Domain, id, limit, cursor, cancellationToken);
 
     public Task<IReadOnlyList<DomainSummary>?> GetDomainSubdomainsAsync(string id, CancellationToken cancellationToken = default)
         => GetDomainRelationshipsAsync<DomainSubdomainsResponse, DomainSummary>(id, "subdomains", r => r.Data, cancellationToken);
@@ -37,11 +49,19 @@ public sealed partial class VirusTotalClient
     public Task<IReadOnlyList<FileReport>?> GetDomainDownloadedFilesAsync(string id, CancellationToken cancellationToken = default)
         => GetDomainRelationshipsAsync<FileReportsResponse, FileReport>(id, "downloaded_files", r => r.Data, cancellationToken);
 
-    public Task<IReadOnlyList<Resolution>?> GetIpAddressResolutionsAsync(string id, CancellationToken cancellationToken = default)
-        => GetResolutionsAsync(ResourceType.IpAddress, id, cancellationToken);
+    public Task<IReadOnlyList<Resolution>?> GetIpAddressResolutionsAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
+        => GetResolutionsAsync(ResourceType.IpAddress, id, limit, cursor, cancellationToken);
 
-    public Task<IReadOnlyList<Submission>?> GetIpAddressSubmissionsAsync(string id, CancellationToken cancellationToken = default)
-        => GetSubmissionsAsync(ResourceType.IpAddress, id, cancellationToken);
+    public Task<IReadOnlyList<Submission>?> GetIpAddressSubmissionsAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
+        => GetSubmissionsAsync(ResourceType.IpAddress, id, limit, cursor, cancellationToken);
 
     public async Task<IReadOnlyList<FileReport>?> GetIpAddressCommunicatingFilesAsync(string id, CancellationToken cancellationToken = default)
     {
@@ -112,9 +132,25 @@ public sealed partial class VirusTotalClient
         return result == null ? null : selector(result);
     }
 
-    private async Task<IReadOnlyList<Resolution>?> GetResolutionsAsync(ResourceType resourceType, string id, CancellationToken cancellationToken)
+    private async Task<IReadOnlyList<Resolution>?> GetResolutionsAsync(
+        ResourceType resourceType,
+        string id,
+        int? limit,
+        string? cursor,
+        CancellationToken cancellationToken)
     {
-        using var response = await _httpClient.GetAsync($"{GetPath(resourceType)}/{id}/resolutions", cancellationToken).ConfigureAwait(false);
+        var path = new System.Text.StringBuilder($"{GetPath(resourceType)}/{id}/resolutions");
+        var hasQuery = false;
+        if (limit.HasValue)
+        {
+            path.Append("?limit=").Append(limit.Value);
+            hasQuery = true;
+        }
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -125,9 +161,25 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
-    private async Task<IReadOnlyList<Submission>?> GetSubmissionsAsync(ResourceType resourceType, string id, CancellationToken cancellationToken)
+    private async Task<IReadOnlyList<Submission>?> GetSubmissionsAsync(
+        ResourceType resourceType,
+        string id,
+        int? limit,
+        string? cursor,
+        CancellationToken cancellationToken)
     {
-        using var response = await _httpClient.GetAsync($"{GetPath(resourceType)}/{id}/submissions", cancellationToken).ConfigureAwait(false);
+        var path = new System.Text.StringBuilder($"{GetPath(resourceType)}/{id}/submissions");
+        var hasQuery = false;
+        if (limit.HasValue)
+        {
+            path.Append("?limit=").Append(limit.Value);
+            hasQuery = true;
+        }
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- allow resolution and submission lookups to take optional `limit` and `cursor`
- update public wrappers and examples to pass pagination parameters
- add unit tests verifying query construction for limit and cursor

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689c5f8bf2f0832ebe0d8e99ce78750c