### PR TITLE
Add graph comment management

### DIFF
--- a/VirusTotalAnalyzer.Examples/GraphCommentsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GraphCommentsExample.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GraphCommentsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var comment = await client.AddGraphCommentAsync("graph-id", "Nice graph");
+            Console.WriteLine(comment?.Id);
+
+            var comments = await client.GetGraphCommentsAsync("graph-id", limit: 10);
+            Console.WriteLine($"Retrieved {comments?.Data.Count} comments");
+
+            if (comment != null)
+            {
+                await client.DeleteGraphCommentAsync("graph-id", comment.Id);
+                Console.WriteLine("Comment deleted");
+            }
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Examples/Program.cs
+++ b/VirusTotalAnalyzer.Examples/Program.cs
@@ -27,6 +27,7 @@ using VirusTotalAnalyzer.Examples;
 // await ListGraphsExample.RunAsync();
 // await ListCollectionsExample.RunAsync();
 // await ListBundlesExample.RunAsync();
+// await GraphCommentsExample.RunAsync();
 // await GetRelationshipsExample.RunAsync();
 // await SearchExample.RunAsync();
 // await GetFeedExample.RunAsync();

--- a/VirusTotalAnalyzer.Tests/GraphCollectionBundleTests.cs
+++ b/VirusTotalAnalyzer.Tests/GraphCollectionBundleTests.cs
@@ -118,6 +118,66 @@ public class GraphCollectionBundleTests
     }
 
     [Fact]
+    public async Task GetGraphCommentsAsync_GetsComments()
+    {
+        var json = @"{""data"":[{""id"":""c1"",""type"":""comment"",""data"":{""attributes"":{""text"":""hi""}}}]}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var response = await client.GetGraphCommentsAsync("g1");
+
+        Assert.NotNull(response);
+        Assert.Single(response.Data);
+        Assert.Equal(HttpMethod.Get, handler.Request!.Method);
+        Assert.Equal("/api/v3/graphs/g1/comments", handler.Request.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task AddGraphCommentAsync_PostsComment()
+    {
+        var json = @"{""data"":{""id"":""c1"",""type"":""comment"",""data"":{""attributes"":{""text"":""hi""}}}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var comment = await client.AddGraphCommentAsync("g1", "hi");
+
+        Assert.NotNull(comment);
+        Assert.Equal(HttpMethod.Post, handler.Request!.Method);
+        Assert.Equal("/api/v3/graphs/g1/comments", handler.Request.RequestUri!.AbsolutePath);
+        Assert.Contains("\"text\":\"hi\"", handler.Content);
+    }
+
+    [Fact]
+    public async Task DeleteGraphCommentAsync_UsesDelete()
+    {
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.NoContent));
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.DeleteGraphCommentAsync("g1", "c1");
+
+        Assert.Equal(HttpMethod.Delete, handler.Request!.Method);
+        Assert.Equal("/api/v3/graphs/g1/comments/c1", handler.Request.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
     public async Task CreateGraphAsync_ThrowsOnError()
     {
         var error = "{\"error\":{\"message\":\"bad\"}}";

--- a/VirusTotalAnalyzer/VirusTotalClient.Resources.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Resources.cs
@@ -85,6 +85,21 @@ public sealed partial class VirusTotalClient
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
+    public Task<CommentsResponse?> GetGraphCommentsAsync(string id, int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
+        => GetCommentsAsync(ResourceType.Graph, id, limit, cursor, cancellationToken);
+
+    public Task<Comment?> AddGraphCommentAsync(string id, string text, CancellationToken cancellationToken = default)
+        => CreateCommentAsync(ResourceType.Graph, id, text, cancellationToken);
+
+    public Task<Comment?> AddGraphCommentAsync(string id, CreateCommentRequest request, CancellationToken cancellationToken = default)
+        => CreateCommentAsync(ResourceType.Graph, id, request, cancellationToken);
+
+    public async Task DeleteGraphCommentAsync(string graphId, string commentId, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.DeleteAsync($"graphs/{graphId}/comments/{commentId}", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task<PagedResponse<Collection>?> ListCollectionsAsync(int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
     {
         var path = new StringBuilder("collections");


### PR DESCRIPTION
## Summary
- add API helpers for graph comment list, create and delete
- cover new graph comment APIs with unit tests
- include example showing graph comment usage

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689c643fa000832eb26ea3cbc80713fe