### PR TITLE
Add monitor events listing support

### DIFF
--- a/VirusTotalAnalyzer.Examples/ListMonitorEventsExample.cs
+++ b/VirusTotalAnalyzer.Examples/ListMonitorEventsExample.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class ListMonitorEventsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var events = await client.ListMonitorEventsAsync();
+            if (events != null)
+            {
+                foreach (var e in events.Data)
+                {
+                    Console.WriteLine(e.Id);
+                }
+            }
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}
+

--- a/VirusTotalAnalyzer.Examples/Program.cs
+++ b/VirusTotalAnalyzer.Examples/Program.cs
@@ -50,5 +50,6 @@ using VirusTotalAnalyzer.Examples;
 // await DownloadPcapExample.RunAsync();
 // await ListRetrohuntJobsExample.RunAsync();
 // await StartRetrohuntJobExample.RunAsync();
+// await ListMonitorEventsExample.RunAsync();
 
 await Task.CompletedTask;

--- a/VirusTotalAnalyzer.Tests/MonitorEventTests.cs
+++ b/VirusTotalAnalyzer.Tests/MonitorEventTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public class MonitorEventTests
+{
+    [Fact]
+    public async Task ListMonitorEventsAsync_GetsEvents()
+    {
+        var json = "{\"data\":[{\"id\":\"e1\",\"type\":\"monitor_event\",\"data\":{\"attributes\":{\"path\":\"/foo\",\"event_type\":\"created\"}}}]}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var response = await client.ListMonitorEventsAsync();
+
+        Assert.NotNull(response);
+        Assert.Single(response.Data);
+        Assert.Equal(HttpMethod.Get, handler.Request!.Method);
+        Assert.Equal("/api/v3/monitor/events", handler.Request.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task ListMonitorEventsAsync_WithParameters_AppendsToUrlAndReturnsCursor()
+    {
+        var json = "{\"data\":[],\"meta\":{\"cursor\":\"next_cursor\"}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var response = await client.ListMonitorEventsAsync(filter: "type:foo", limit: 10, cursor: "abc");
+
+        Assert.NotNull(response);
+        Assert.Equal("next_cursor", response.NextCursor);
+        Assert.Equal(HttpMethod.Get, handler.Request!.Method);
+        Assert.Equal("/api/v3/monitor/events", handler.Request.RequestUri!.AbsolutePath);
+        Assert.Equal("?filter=type%3Afoo&limit=10&cursor=abc", handler.Request.RequestUri.Query);
+    }
+}
+

--- a/VirusTotalAnalyzer/Models/MonitorEvent.cs
+++ b/VirusTotalAnalyzer/Models/MonitorEvent.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class MonitorEvent
+{
+    public string Id { get; set; } = string.Empty;
+    public ResourceType Type { get; set; }
+    public MonitorEventData Data { get; set; } = new();
+}
+
+public sealed class MonitorEventData
+{
+    public MonitorEventAttributes Attributes { get; set; } = new();
+}
+
+public sealed class MonitorEventAttributes
+{
+    [JsonPropertyName("item_id")]
+    public string ItemId { get; set; } = string.Empty;
+
+    [JsonPropertyName("path")]
+    public string Path { get; set; } = string.Empty;
+
+    [JsonPropertyName("event_type")]
+    public string EventType { get; set; } = string.Empty;
+}
+

--- a/VirusTotalAnalyzer/ResourceType.cs
+++ b/VirusTotalAnalyzer/ResourceType.cs
@@ -64,6 +64,9 @@ public enum ResourceType
     [EnumMember(Value = "monitor_item")]
     MonitorItem,
 
+    [EnumMember(Value = "monitor_event")]
+    MonitorEvent,
+
     [EnumMember(Value = "intelligence_hunting_ruleset")]
     IntelligenceHuntingRuleset
 }


### PR DESCRIPTION
## Summary
- add MonitorEvent model and resource type
- implement ListMonitorEventsAsync to fetch monitor events with filter, pagination
- cover monitor events with example and tests

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689c64367dbc832ebf80c21819622372