### PR TITLE
Add IOC stream endpoint support

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetIocStreamExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetIocStreamExample.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetIocStreamExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var stream = await client.GetIocStreamAsync("type:file", limit: 10, descriptorsOnly: true);
+            Console.WriteLine(stream?.Data.Count);
+            if (!string.IsNullOrEmpty(stream?.Meta?.Cursor))
+            {
+                var next = await client.GetIocStreamAsync("type:file", cursor: stream.Meta.Cursor);
+                Console.WriteLine(next?.Data.Count);
+            }
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer/Models/IocStreamResponse.cs
+++ b/VirusTotalAnalyzer/Models/IocStreamResponse.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class IocStreamResponse
+{
+    [JsonPropertyName("data")]
+    public List<IocStreamItem> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public PaginationMetadata? Meta { get; set; }
+}
+
+public sealed class IocStreamItem
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
+
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("attributes")]
+    public Dictionary<string, JsonElement>? Attributes { get; set; }
+}


### PR DESCRIPTION
## Summary
- add `GetIocStreamAsync` to call the IOC stream endpoint with filters, limits, descriptors, and cursor support
- model IOC stream responses with `IocStreamResponse`
- cover IOC stream usage with unit tests and an example

## Testing
- `/root/.dotnet/dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689c642ba024832e8beb842a5ebc66c1