### PR TITLE
Add URL submissions relationship

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetUrlSubmissionsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetUrlSubmissionsExample.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetUrlSubmissionsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var submissions = await client.GetUrlSubmissionsAsync("url-id", limit: 10);
+            Console.WriteLine(submissions?.Count);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Relationships.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Relationships.cs
@@ -13,7 +13,7 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task GetFileSubmissionsAsync_UsesCorrectPathAndDeserializesResponse()
     {
-        var json = "{\"data\":[{\"id\":\"s1\",\"type\":\"submission\",\"data\":{\"attributes\":{\"date\":1}}}]}"; 
+        var json = "{\"data\":[{\"id\":\"s1\",\"type\":\"submission\",\"data\":{\"attributes\":{\"date\":1}}}]}";
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -32,6 +32,50 @@ public partial class VirusTotalClientTests
         Assert.NotNull(submissions);
         Assert.Single(submissions!);
         Assert.Equal(1, submissions[0].Data.Attributes.Date.ToUnixTimeSeconds());
+    }
+
+    [Fact]
+    public async Task GetUrlSubmissionsAsync_UsesCorrectPathAndDeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"s1\",\"type\":\"submission\",\"data\":{\"attributes\":{\"date\":1}}}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var submissions = await client.GetUrlSubmissionsAsync("url-id");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/urls/url-id/submissions", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.NotNull(submissions);
+        Assert.Single(submissions!);
+        Assert.Equal(1, submissions[0].Data.Attributes.Date.ToUnixTimeSeconds());
+    }
+
+    [Fact]
+    public async Task GetUrlSubmissionsAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetUrlSubmissionsAsync("url-id", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
     }
 
     [Fact]

--- a/VirusTotalAnalyzer/VirusTotalClient.Relationships.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Relationships.cs
@@ -17,6 +17,13 @@ public sealed partial class VirusTotalClient
         CancellationToken cancellationToken = default)
         => GetSubmissionsAsync(ResourceType.File, id, limit, cursor, cancellationToken);
 
+    public Task<IReadOnlyList<Submission>?> GetUrlSubmissionsAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
+        => GetSubmissionsAsync(ResourceType.Url, id, limit, cursor, cancellationToken);
+
     public Task<IReadOnlyList<Resolution>?> GetDomainResolutionsAsync(
         string id,
         int? limit = null,


### PR DESCRIPTION
## Summary
- add GetUrlSubmissionsAsync to fetch URL submissions
- document usage with new example
- cover URL submissions with unit tests

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689c6424dad8832e9fdb7703ccd15b95