### PR TITLE
Add URL analyses pagination support

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetUrlAnalysesExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetUrlAnalysesExample.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetUrlAnalysesExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var (analyses, cursor) = await client.GetUrlAnalysesAsync("44d88612fea8a8f36de82e1278abb02f");
+            foreach (var analysis in analyses)
+            {
+                Console.WriteLine($"{analysis.Id} - {analysis.Data.Attributes.Status}");
+            }
+            if (cursor != null)
+            {
+                Console.WriteLine($"More analyses available. Next cursor: {cursor}");
+            }
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer/Models/AnalysisReport.cs
+++ b/VirusTotalAnalyzer/Models/AnalysisReport.cs
@@ -33,3 +33,12 @@ public sealed class AnalysisAttributes
     [JsonPropertyName("error")]
     public string? Error { get; set; }
 }
+
+public sealed class AnalysisReportsResponse
+{
+    [JsonPropertyName("data")]
+    public List<AnalysisReport> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public PaginationMetadata? Meta { get; set; }
+}


### PR DESCRIPTION
## Summary
- add `GetUrlAnalysesAsync` for paginated URL analysis retrieval
- support `AnalysisReportsResponse` model
- test and example for listing URL analyses

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689c641aa588832eb334a77381fee894