### PR TITLE
Add URL graph retrieval

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetUrlGraphsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetUrlGraphsExample.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetUrlGraphsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var graphs = await client.GetUrlGraphsAsync("url-id");
+            foreach (var graph in graphs)
+            {
+                Console.WriteLine(graph.Id);
+            }
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}
+

--- a/VirusTotalAnalyzer.Examples/Program.cs
+++ b/VirusTotalAnalyzer.Examples/Program.cs
@@ -20,6 +20,7 @@ using VirusTotalAnalyzer.Examples;
 // await GetUserExample.RunAsync();
 // await GetUserQuotaExample.RunAsync();
 // await GetGraphExample.RunAsync();
+// await GetUrlGraphsExample.RunAsync();
 // await GetCollectionExample.RunAsync();
 // await CreateGraphExample.RunAsync();
 // await CreateCollectionExample.RunAsync();

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.UrlGraphs.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.UrlGraphs.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public partial class VirusTotalClientTests
+{
+    [Fact]
+    public async Task GetUrlGraphsAsync_GetsGraphs()
+    {
+        var relationshipsJson = "{\"data\":[{\"id\":\"g1\",\"type\":\"graph\"},{\"id\":\"g2\",\"type\":\"graph\"}]}";
+        var graph1Json = "{\"id\":\"g1\",\"type\":\"graph\",\"data\":{\"attributes\":{\"name\":\"one\"}}}";
+        var graph2Json = "{\"id\":\"g2\",\"type\":\"graph\",\"data\":{\"attributes\":{\"name\":\"two\"}}}";
+
+        var handler = new QueueHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(relationshipsJson, Encoding.UTF8, "application/json")
+            },
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(graph1Json, Encoding.UTF8, "application/json")
+            },
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(graph2Json, Encoding.UTF8, "application/json")
+            }
+        );
+
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var graphs = await client.GetUrlGraphsAsync("url-id");
+
+        Assert.NotNull(graphs);
+        Assert.Equal(2, graphs.Count);
+        Assert.Equal("g1", graphs[0].Id);
+        Assert.Equal("g2", graphs[1].Id);
+        Assert.Equal("/api/v3/urls/url-id/relationships/graphs", handler.Requests[0].RequestUri!.AbsolutePath);
+        Assert.Equal("/api/v3/graphs/g1", handler.Requests[1].RequestUri!.AbsolutePath);
+        Assert.Equal("/api/v3/graphs/g2", handler.Requests[2].RequestUri!.AbsolutePath);
+    }
+}
+

--- a/VirusTotalAnalyzer/VirusTotalClient.Relationships.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Relationships.cs
@@ -24,6 +24,27 @@ public sealed partial class VirusTotalClient
         CancellationToken cancellationToken = default)
         => GetSubmissionsAsync(ResourceType.Url, id, limit, cursor, cancellationToken);
 
+    public async Task<IReadOnlyList<Graph>> GetUrlGraphsAsync(string id, CancellationToken cancellationToken = default)
+    {
+        var relationships = await GetRelationshipsAsync(ResourceType.Url, id, "graphs", cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (relationships == null || relationships.Data.Count == 0)
+        {
+            return Array.Empty<Graph>();
+        }
+
+        var graphs = new List<Graph>(relationships.Data.Count);
+        foreach (var relationship in relationships.Data)
+        {
+            var graph = await GetGraphAsync(relationship.Id, cancellationToken).ConfigureAwait(false);
+            if (graph != null)
+            {
+                graphs.Add(graph);
+            }
+        }
+
+        return graphs;
+    }
+
     public Task<IReadOnlyList<Resolution>?> GetDomainResolutionsAsync(
         string id,
         int? limit = null,


### PR DESCRIPTION
## Summary
- add GetUrlGraphsAsync to retrieve graphs related to a URL
- include example usage for listing URL graphs
- test URL graph retrieval

## Testing
- `dotnet build VirusTotalAnalyzer.sln`
- `dotnet test VirusTotalAnalyzer.sln`


------
https://chatgpt.com/codex/tasks/task_e_689c6a4e94c0832e950ca5d32c364b85