### PR TITLE
Add popular threat categories endpoint

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetPopularThreatCategoriesExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetPopularThreatCategoriesExample.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetPopularThreatCategoriesExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var categories = await client.GetPopularThreatCategoriesAsync();
+            foreach (var category in categories)
+            {
+                Console.WriteLine($"{category.Id}: {category.Attributes.Count}");
+            }
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
@@ -670,9 +670,32 @@ public partial class VirusTotalClientTests
 
         var item = Assert.Single(stream!.Data);
         Assert.Equal("abc", item.Id);
-        Assert.Equal("file", item.Type);
-        Assert.Equal("demo", item.Attributes!["md5"].GetString());
-        Assert.Equal("next", stream.Meta?.Cursor);
+       Assert.Equal("file", item.Type);
+       Assert.Equal("demo", item.Attributes!["md5"].GetString());
+       Assert.Equal("next", stream.Meta?.Cursor);
+    }
+
+    [Fact]
+    public async Task GetPopularThreatCategoriesAsync_UsesCorrectPathAndDeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"malware\",\"type\":\"popular_threat_category\",\"attributes\":{\"count\":1234}}]}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var categories = await client.GetPopularThreatCategoriesAsync();
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/intelligence/popular_threat_categories", handler.Request!.RequestUri!.AbsolutePath);
+        var category = Assert.Single(categories);
+        Assert.Equal("malware", category.Id);
+        Assert.Equal(1234, category.Attributes.Count);
     }
 
 }

--- a/VirusTotalAnalyzer/Models/ThreatCategory.cs
+++ b/VirusTotalAnalyzer/Models/ThreatCategory.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class ThreatCategory
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
+
+    [JsonPropertyName("attributes")]
+    public ThreatCategoryAttributes Attributes { get; set; } = new();
+}
+
+public sealed class ThreatCategoryAttributes
+{
+    [JsonPropertyName("count")]
+    public long Count { get; set; }
+}
+
+public sealed class ThreatCategoriesResponse
+{
+    [JsonPropertyName("data")]
+    public List<ThreatCategory> Data { get; set; } = new();
+}

--- a/VirusTotalAnalyzer/VirusTotalClient.Intelligence.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Intelligence.cs
@@ -302,6 +302,19 @@ public sealed partial class VirusTotalClient
         return await JsonSerializer.DeserializeAsync<RelationshipResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task<IReadOnlyList<ThreatCategory>> GetPopularThreatCategoriesAsync(CancellationToken ct = default)
+    {
+        using var response = await _httpClient.GetAsync("intelligence/popular_threat_categories", ct).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, ct).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<ThreatCategoriesResponse>(stream, _jsonOptions, ct).ConfigureAwait(false);
+        return result?.Data ?? new List<ThreatCategory>();
+    }
+
     public async Task<SearchResponse?> SearchAsync(string query, int? limit = null, string? cursor = null, string? order = null, string? descriptor = null, CancellationToken cancellationToken = default)
     {
         var sb = new StringBuilder($"intelligence/search?query={Uri.EscapeDataString(query)}");


### PR DESCRIPTION
## Summary
- support fetching popular threat categories from intelligence API
- add models and example for popular threat categories
- cover popular threat categories endpoint with unit tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689c72d622cc832ea96efbc1228a9143