### PR TITLE
Add redirecting URL lookup

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetUrlRedirectingUrlsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetUrlRedirectingUrlsExample.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetUrlRedirectingUrlsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var urls = await client.GetUrlRedirectingUrlsAsync("url-id");
+            foreach (var url in urls ?? Array.Empty<UrlSummary>())
+            {
+                Console.WriteLine(url.Data.Attributes.Url);
+            }
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.AnalysisRelationships.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.AnalysisRelationships.cs
@@ -107,6 +107,8 @@ public partial class VirusTotalClientTests
         Assert.Equal("abc", files[0].Attributes.Md5);
     }
 
+
+
     [Fact]
     public async Task GetFileDownloadedFilesAsync_UsesCorrectPathAndDeserializesResponse()
     {
@@ -249,6 +251,30 @@ public partial class VirusTotalClientTests
         Assert.NotNull(files);
         Assert.Single(files!);
         Assert.Equal("abc", files[0].Attributes.Md5);
+    }
+
+    [Fact]
+    public async Task GetUrlRedirectingUrlsAsync_UsesCorrectPathAndDeserializesResponse()
+    {
+        var json = "{\"data\":[{\"id\":\"u1\",\"type\":\"url\",\"data\":{\"attributes\":{\"url\":\"https://example.com\"}}}]}"; 
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var urls = await client.GetUrlRedirectingUrlsAsync("abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/urls/abc/redirecting_urls", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.NotNull(urls);
+        Assert.Single(urls!);
+        Assert.Equal("https://example.com", urls[0].Data.Attributes.Url);
     }
 
     [Fact]

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -370,6 +370,19 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
+    public async Task<IReadOnlyList<UrlSummary>?> GetUrlRedirectingUrlsAsync(string id, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync($"urls/{id}/redirecting_urls", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<UrlSummariesResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+        return result?.Data;
+    }
+
     public async Task<IReadOnlyList<IpAddressSummary>?> GetUrlContactedIpsAsync(string id, CancellationToken cancellationToken = default)
     {
         using var response = await _httpClient.GetAsync($"urls/{id}/contacted_ips", cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- extend analysis client with `GetUrlRedirectingUrlsAsync`
- cover redirecting URL lookup with unit tests
- add example demonstrating redirecting URL retrieval

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689c72cfcad0832ebbcb0209ec2dca3a