### PR TITLE
Add support for time-based VirusTotal feeds

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetTimeBasedFeedExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetTimeBasedFeedExample.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetTimeBasedFeedExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var feed = await client.GetFeedAsync(ResourceType.FileBehaviour, DateTime.UtcNow.AddHours(-1), FeedGranularity.Hourly);
+            Console.WriteLine(feed?.Data.Count);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
@@ -636,6 +636,76 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetFeedAsync_ByTime_DailyBuildsPath()
+    {
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"data\":[]}", Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetFeedAsync(ResourceType.File, new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc), FeedGranularity.Daily);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/feeds/files/20240102", handler.Request!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task GetFeedAsync_ByTime_HourlyBuildsPath()
+    {
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"data\":[]}", Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetFeedAsync(ResourceType.Url, new DateTime(2024, 1, 2, 3, 0, 0, DateTimeKind.Utc), FeedGranularity.Hourly);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/feeds/urls/2024010203", handler.Request!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task GetFeedAsync_ByTime_FileBehaviourBuildsPath()
+    {
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"data\":[]}", Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetFeedAsync(ResourceType.FileBehaviour, new DateTime(2024, 1, 2, 3, 0, 0, DateTimeKind.Utc), FeedGranularity.Hourly);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/feeds/file-behaviour/2024010203", handler.Request!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task GetFeedAsync_ByTime_ThrowsForUnsupportedResourceType()
+    {
+        var handler = new StubHandler("{\"data\":[]}");
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => client.GetFeedAsync(ResourceType.Analysis, DateTime.UtcNow, FeedGranularity.Daily));
+    }
+
+    [Fact]
     public async Task GetIocStreamAsync_BuildsQuery()
     {
         var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)

--- a/VirusTotalAnalyzer/FeedGranularity.cs
+++ b/VirusTotalAnalyzer/FeedGranularity.cs
@@ -1,0 +1,7 @@
+namespace VirusTotalAnalyzer;
+
+public enum FeedGranularity
+{
+    Daily,
+    Hourly
+}

--- a/VirusTotalAnalyzer/ResourceType.cs
+++ b/VirusTotalAnalyzer/ResourceType.cs
@@ -68,5 +68,8 @@ public enum ResourceType
     MonitorEvent,
 
     [EnumMember(Value = "intelligence_hunting_ruleset")]
-    IntelligenceHuntingRuleset
+    IntelligenceHuntingRuleset,
+
+    [EnumMember(Value = "file-behaviour")]
+    FileBehaviour
 }

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -104,6 +104,7 @@ public sealed partial class VirusTotalClient : IDisposable
             ResourceType.RetrohuntNotification => "retrohunt_notifications",
             ResourceType.MonitorItem => "monitor/items",
             ResourceType.IntelligenceHuntingRuleset => "intelligence/hunting_rulesets",
+            ResourceType.FileBehaviour => "file-behaviour",
             _ => throw new ArgumentOutOfRangeException(nameof(type))
         };
 


### PR DESCRIPTION
## Summary
- support daily/hourly feed retrieval including file-behaviour dataset
- expose `FeedGranularity` enum and new `GetFeedAsync` overload
- cover time-based feed API with unit tests and example

## Testing
- `dotnet build VirusTotalAnalyzer.sln`
- `dotnet test VirusTotalAnalyzer.sln`


------
https://chatgpt.com/codex/tasks/task_e_689c783ebc28832ea9bf907accbf75cf