### PR TITLE
Escape path parameters and test encoding

### DIFF
--- a/VirusTotalAnalyzer.Tests/PathEncodingTests.cs
+++ b/VirusTotalAnalyzer.Tests/PathEncodingTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public class PathEncodingTests
+{
+    [Fact]
+    public async Task GetUserAsync_EncodesIdInPath()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var id = "user/id?test";
+        await client.GetUserAsync(id);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal($"/api/v3/users/{Uri.EscapeDataString(id)}", handler.Request!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task CreateCommentAsync_EncodesIdInPath()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var id = "file/id#1";
+        var request = new CommentRequestBuilder().WithText("text").Build();
+        await client.CreateCommentAsync(ResourceType.File, id, request);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal($"/api/v3/files/{Uri.EscapeDataString(id)}/comments", handler.Request!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task DeleteGraphCommentAsync_EncodesIdsInPath()
+    {
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK));
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var graphId = "graph/id#1";
+        var commentId = "comment/id?2";
+        await client.DeleteGraphCommentAsync(graphId, commentId);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal($"/api/v3/graphs/{Uri.EscapeDataString(graphId)}/comments/{Uri.EscapeDataString(commentId)}", handler.Request!.RequestUri!.AbsolutePath);
+    }
+}
+

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -17,7 +17,7 @@ public sealed partial class VirusTotalClient
 {
     public async Task<FileReport?> GetFileReportAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -31,7 +31,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<FileBehavior?> GetFileBehaviorAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{id}/behavior", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/behavior", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -44,7 +44,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<FileBehaviorSummary?> GetFileBehaviorSummaryAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{id}/behavior_summary", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/behavior_summary", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -57,7 +57,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<FileNetworkTraffic?> GetFileNetworkTrafficAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{id}/network-traffic", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/network-traffic", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -70,7 +70,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<FilePeInfo?> GetFilePeInfoAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{id}/pe_info", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/pe_info", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -83,7 +83,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<FileClassification?> GetFileClassificationAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{id}/classification", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/classification", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -96,7 +96,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<string>?> GetFileStringsAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{id}/strings", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/strings", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -110,7 +110,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<CrowdsourcedYaraResult>?> GetCrowdsourcedYaraResultsAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{id}/crowdsourced_yara_results", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/crowdsourced_yara_results", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -123,7 +123,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<CrowdsourcedIdsResult>?> GetCrowdsourcedIdsResultsAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{id}/crowdsourced_ids_results", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/crowdsourced_ids_results", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -136,7 +136,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<UrlSummary>?> GetFileContactedUrlsAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{id}/contacted_urls", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/contacted_urls", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -149,7 +149,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<DomainSummary>?> GetFileContactedDomainsAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{id}/contacted_domains", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/contacted_domains", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -162,7 +162,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<IpAddressSummary>?> GetFileContactedIpsAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{id}/contacted_ips", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/contacted_ips", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -175,7 +175,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<FileReport>?> GetFileReferrerFilesAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{id}/referrer_files", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/referrer_files", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -188,7 +188,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<FileReport>?> GetFileDownloadedFilesAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{id}/downloaded_files", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/downloaded_files", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -201,7 +201,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<FileReport>?> GetFileBundledFilesAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{id}/bundled_files", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/bundled_files", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -214,7 +214,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<FileReport>?> GetFileDroppedFilesAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{id}/dropped_files", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/dropped_files", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -227,7 +227,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<FileReport>?> GetFileSimilarFilesAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{id}/similar_files", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/similar_files", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -240,7 +240,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Uri?> GetFileDownloadUrlAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{id}/download_url", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/download_url", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -258,7 +258,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Stream> DownloadFileAsync(string id, CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.GetAsync($"files/{id}/download", HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/download", HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -269,7 +269,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<UrlReport?> GetUrlReportAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"urls/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"urls/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -304,7 +304,7 @@ public sealed partial class VirusTotalClient
 
         do
         {
-            var url = new StringBuilder($"urls/{id}/analyses");
+            var url = new StringBuilder($"urls/{Uri.EscapeDataString(id)}/analyses");
             var hasQuery = false;
             if (remaining.HasValue)
             {
@@ -346,7 +346,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<FileReport>?> GetUrlDownloadedFilesAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"urls/{id}/downloaded_files", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"urls/{Uri.EscapeDataString(id)}/downloaded_files", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -359,7 +359,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<FileReport>?> GetUrlReferrerFilesAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"urls/{id}/referrer_files", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"urls/{Uri.EscapeDataString(id)}/referrer_files", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -372,7 +372,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<UrlSummary>?> GetUrlRedirectingUrlsAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"urls/{id}/redirecting_urls", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"urls/{Uri.EscapeDataString(id)}/redirecting_urls", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -385,7 +385,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<IpAddressSummary>?> GetUrlContactedIpsAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"urls/{id}/contacted_ips", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"urls/{Uri.EscapeDataString(id)}/contacted_ips", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -398,7 +398,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IpAddressSummary?> GetUrlLastServingIpAddressAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"urls/{id}/last_serving_ip_address", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"urls/{Uri.EscapeDataString(id)}/last_serving_ip_address", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -412,7 +412,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IpAddressReport?> GetIpAddressReportAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"ip_addresses/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"ip_addresses/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -426,7 +426,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IpWhois?> GetIpAddressWhoisAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"ip_addresses/{id}/whois", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"ip_addresses/{Uri.EscapeDataString(id)}/whois", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -439,7 +439,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<DomainReport?> GetDomainReportAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"domains/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"domains/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -453,7 +453,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<DomainWhois?> GetDomainWhoisAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"domains/{id}/whois", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"domains/{Uri.EscapeDataString(id)}/whois", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -466,7 +466,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<AnalysisReport?> GetAnalysisAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"analyses/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"analyses/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -479,7 +479,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<PrivateAnalysis?> GetPrivateAnalysisAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"private/analyses/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"private/analyses/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);

--- a/VirusTotalAnalyzer/VirusTotalClient.Community.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Community.cs
@@ -17,7 +17,7 @@ public sealed partial class VirusTotalClient
 {
     public async Task<Comment?> GetCommentAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.Comment)}/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.Comment)}/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -30,7 +30,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<CommentsResponse?> GetCommentsAsync(ResourceType resourceType, string id, int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
     {
-        var path = new StringBuilder($"{GetPath(resourceType)}/{id}/comments");
+        var path = new StringBuilder($"{GetPath(resourceType)}/{Uri.EscapeDataString(id)}/comments");
         var hasQuery = false;
         if (limit.HasValue)
         {
@@ -53,7 +53,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Vote?> GetVoteAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.Vote)}/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.Vote)}/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -66,7 +66,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<VotesResponse?> GetVotesAsync(ResourceType resourceType, string id, int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
     {
-        var path = new StringBuilder($"{GetPath(resourceType)}/{id}/votes");
+        var path = new StringBuilder($"{GetPath(resourceType)}/{Uri.EscapeDataString(id)}/votes");
         var hasQuery = false;
         if (limit.HasValue)
         {
@@ -99,7 +99,7 @@ public sealed partial class VirusTotalClient
     {
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
-        using var response = await _httpClient.PostAsync($"{GetPath(resourceType)}/{id}/comments", content, cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.PostAsync($"{GetPath(resourceType)}/{Uri.EscapeDataString(id)}/comments", content, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -122,7 +122,7 @@ public sealed partial class VirusTotalClient
     {
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
-        using var response = await _httpClient.PostAsync($"{GetPath(resourceType)}/{id}/votes", content, cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.PostAsync($"{GetPath(resourceType)}/{Uri.EscapeDataString(id)}/votes", content, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -135,13 +135,13 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteItemAsync(ResourceType resourceType, string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.DeleteAsync($"{GetPath(resourceType)}/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.DeleteAsync($"{GetPath(resourceType)}/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<User?> GetUserAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"users/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"users/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -153,7 +153,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<UserPrivileges?> GetUserPrivilegesAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"users/{id}/privileges", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"users/{Uri.EscapeDataString(id)}/privileges", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -165,7 +165,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<UserQuota?> GetUserQuotaAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"users/{id}/quotas", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"users/{Uri.EscapeDataString(id)}/quotas", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);

--- a/VirusTotalAnalyzer/VirusTotalClient.Intelligence.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Intelligence.cs
@@ -18,7 +18,7 @@ public sealed partial class VirusTotalClient
 {
     public async Task<LivehuntNotification?> GetLivehuntNotificationAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.LivehuntNotification)}/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.LivehuntNotification)}/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -66,7 +66,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<RetrohuntJob?> GetRetrohuntJobAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.RetrohuntJob)}/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.RetrohuntJob)}/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -128,13 +128,13 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteRetrohuntJobAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.DeleteAsync($"intelligence/retrohunt_jobs/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.DeleteAsync($"intelligence/retrohunt_jobs/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<RetrohuntNotification?> GetRetrohuntNotificationAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.RetrohuntNotification)}/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.RetrohuntNotification)}/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -181,7 +181,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<MonitorItem?> GetMonitorItemAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.MonitorItem)}/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.MonitorItem)}/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -217,7 +217,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<YaraRuleset?> GetYaraRulesetAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"intelligence/hunting_rulesets/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"intelligence/hunting_rulesets/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -246,7 +246,7 @@ public sealed partial class VirusTotalClient
     {
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
-        using var message = new HttpRequestMessage(new HttpMethod("PATCH"), $"intelligence/hunting_rulesets/{id}")
+        using var message = new HttpRequestMessage(new HttpMethod("PATCH"), $"intelligence/hunting_rulesets/{Uri.EscapeDataString(id)}")
         {
             Content = content
         };
@@ -263,7 +263,7 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteYaraRulesetAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.DeleteAsync($"intelligence/hunting_rulesets/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.DeleteAsync($"intelligence/hunting_rulesets/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -281,7 +281,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<RelationshipResponse?> GetRelationshipsAsync(ResourceType resourceType, string id, string relationship, int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
     {
-        var sb = new StringBuilder($"{GetPath(resourceType)}/{id}/relationships/{relationship}");
+        var sb = new StringBuilder($"{GetPath(resourceType)}/{Uri.EscapeDataString(id)}/relationships/{Uri.EscapeDataString(relationship)}");
         var hasQuery = false;
         if (limit.HasValue)
         {

--- a/VirusTotalAnalyzer/VirusTotalClient.Monitor.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Monitor.cs
@@ -80,7 +80,7 @@ public sealed partial class VirusTotalClient
     {
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
-        using var message = new HttpRequestMessage(new HttpMethod("PATCH"), $"monitor/items/{id}") { Content = content };
+        using var message = new HttpRequestMessage(new HttpMethod("PATCH"), $"monitor/items/{Uri.EscapeDataString(id)}") { Content = content };
         using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -93,7 +93,7 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteMonitorItemAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.DeleteAsync($"monitor/items/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.DeleteAsync($"monitor/items/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/VirusTotalAnalyzer/VirusTotalClient.Relationships.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Relationships.cs
@@ -93,7 +93,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<FileReport>?> GetIpAddressCommunicatingFilesAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"ip_addresses/{id}/communicating_files", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"ip_addresses/{Uri.EscapeDataString(id)}/communicating_files", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -106,7 +106,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<FileReport>?> GetIpAddressDownloadedFilesAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"ip_addresses/{id}/downloaded_files", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"ip_addresses/{Uri.EscapeDataString(id)}/downloaded_files", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -119,7 +119,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<FileReport>?> GetIpAddressReferrerFilesAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"ip_addresses/{id}/referrer_files", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"ip_addresses/{Uri.EscapeDataString(id)}/referrer_files", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -132,7 +132,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<UrlSummary>?> GetIpAddressUrlsAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"ip_addresses/{id}/urls", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"ip_addresses/{Uri.EscapeDataString(id)}/urls", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -149,7 +149,7 @@ public sealed partial class VirusTotalClient
         Func<TResponse, List<T>> selector,
         CancellationToken cancellationToken)
     {
-        using var response = await _httpClient.GetAsync($"domains/{id}/{relationship}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"domains/{Uri.EscapeDataString(id)}/{Uri.EscapeDataString(relationship)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -167,7 +167,7 @@ public sealed partial class VirusTotalClient
         string? cursor,
         CancellationToken cancellationToken)
     {
-        var path = new System.Text.StringBuilder($"{GetPath(resourceType)}/{id}/resolutions");
+        var path = new System.Text.StringBuilder($"{GetPath(resourceType)}/{Uri.EscapeDataString(id)}/resolutions");
         var hasQuery = false;
         if (limit.HasValue)
         {
@@ -196,7 +196,7 @@ public sealed partial class VirusTotalClient
         string? cursor,
         CancellationToken cancellationToken)
     {
-        var path = new System.Text.StringBuilder($"{GetPath(resourceType)}/{id}/submissions");
+        var path = new System.Text.StringBuilder($"{GetPath(resourceType)}/{Uri.EscapeDataString(id)}/submissions");
         var hasQuery = false;
         if (limit.HasValue)
         {

--- a/VirusTotalAnalyzer/VirusTotalClient.Resources.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Resources.cs
@@ -40,7 +40,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Graph?> GetGraphAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"graphs/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"graphs/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -68,7 +68,7 @@ public sealed partial class VirusTotalClient
     {
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
-        using var message = new HttpRequestMessage(new HttpMethod("PATCH"), $"graphs/{id}") { Content = content };
+        using var message = new HttpRequestMessage(new HttpMethod("PATCH"), $"graphs/{Uri.EscapeDataString(id)}") { Content = content };
         using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -81,7 +81,7 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteGraphAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.DeleteAsync($"graphs/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.DeleteAsync($"graphs/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -96,7 +96,7 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteGraphCommentAsync(string graphId, string commentId, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.DeleteAsync($"graphs/{graphId}/comments/{commentId}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.DeleteAsync($"graphs/{Uri.EscapeDataString(graphId)}/comments/{Uri.EscapeDataString(commentId)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -125,7 +125,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Collection?> GetCollectionAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"collections/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"collections/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -153,7 +153,7 @@ public sealed partial class VirusTotalClient
     {
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
-        using var message = new HttpRequestMessage(new HttpMethod("PATCH"), $"collections/{id}") { Content = content };
+        using var message = new HttpRequestMessage(new HttpMethod("PATCH"), $"collections/{Uri.EscapeDataString(id)}") { Content = content };
         using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -166,7 +166,7 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteCollectionAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.DeleteAsync($"collections/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.DeleteAsync($"collections/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
@@ -195,7 +195,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Bundle?> GetBundleAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"bundles/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"bundles/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -223,7 +223,7 @@ public sealed partial class VirusTotalClient
     {
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
-        using var message = new HttpRequestMessage(new HttpMethod("PATCH"), $"bundles/{id}") { Content = content };
+        using var message = new HttpRequestMessage(new HttpMethod("PATCH"), $"bundles/{Uri.EscapeDataString(id)}") { Content = content };
         using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -236,7 +236,7 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteBundleAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.DeleteAsync($"bundles/{id}", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.DeleteAsync($"bundles/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/VirusTotalAnalyzer/VirusTotalClient.Submissions.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Submissions.cs
@@ -171,7 +171,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<AnalysisReport?> ReanalyzeHashAsync(string hash, AnalysisType analysisType = AnalysisType.File, CancellationToken cancellationToken = default)
     {
-        var path = $"{GetPath(analysisType)}/{hash}/analyse";
+        var path = $"{GetPath(analysisType)}/{Uri.EscapeDataString(hash)}/analyse";
         using var response = await _httpClient.PostAsync(path, content: null, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -181,7 +181,7 @@ public sealed partial class VirusTotalClient : IDisposable
 
         do
         {
-            var url = new StringBuilder($"files/{id}/names");
+            var url = new StringBuilder($"files/{Uri.EscapeDataString(id)}/names");
             var hasQuery = false;
             if (remaining.HasValue)
             {
@@ -223,7 +223,7 @@ public sealed partial class VirusTotalClient : IDisposable
 
     public async Task<Stream> DownloadLivehuntNotificationFileAsync(string id, CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.GetAsync($"intelligence/hunting_notification_files/{id}", HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        var response = await _httpClient.GetAsync($"intelligence/hunting_notification_files/{Uri.EscapeDataString(id)}", HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -234,7 +234,7 @@ public sealed partial class VirusTotalClient : IDisposable
 
     public async Task<Stream> DownloadRetrohuntNotificationFileAsync(string id, CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.GetAsync($"intelligence/retrohunt_notification_files/{id}", HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        var response = await _httpClient.GetAsync($"intelligence/retrohunt_notification_files/{Uri.EscapeDataString(id)}", HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -245,7 +245,7 @@ public sealed partial class VirusTotalClient : IDisposable
 
     public async Task<Stream> DownloadPcapAsync(string analysisId, CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.GetAsync($"analyses/{analysisId}/pcap", HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        var response = await _httpClient.GetAsync($"analyses/{Uri.EscapeDataString(analysisId)}/pcap", HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- URI-escape identifiers before interpolating into VirusTotal client request paths
- Verify special-character IDs are encoded with new unit tests

## Testing
- `/usr/share/dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689c7d64dd04832e8798c839f7750a32