### PR TITLE
Add fetchAll option for Yara ruleset listing

### DIFF
--- a/VirusTotalAnalyzer.Examples/ListYaraRulesetsExample.cs
+++ b/VirusTotalAnalyzer.Examples/ListYaraRulesetsExample.cs
@@ -11,14 +11,12 @@ public static class ListYaraRulesetsExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var rulesets = await client.ListYaraRulesetsAsync();
-            if (rulesets != null)
+            var page = await client.ListYaraRulesetsAsync(fetchAll: false);
+            foreach (var rs in page.Data)
             {
-                foreach (var rs in rulesets)
-                {
-                    Console.WriteLine($"{rs.Id}: {rs.Data.Attributes.Name}");
-                }
+                Console.WriteLine($"{rs.Id}: {rs.Data.Attributes.Name}");
             }
+            Console.WriteLine($"Next cursor: {page.NextCursor}");
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.PowerShell/GetVtYaraRulesetCommand.cs
+++ b/VirusTotalAnalyzer.PowerShell/GetVtYaraRulesetCommand.cs
@@ -25,10 +25,14 @@ public sealed class GetVtYaraRulesetCommand : PSCmdlet
         using var client = VirusTotalClient.Create(ApiKey);
         if (string.IsNullOrEmpty(Id))
         {
-            var rulesets = client.ListYaraRulesetsAsync(Limit, Cursor).GetAwaiter().GetResult();
-            if (rulesets != null)
+            var page = client.ListYaraRulesetsAsync(Limit, Cursor, fetchAll: false).GetAwaiter().GetResult();
+            if (page != null)
             {
-                WriteObject(rulesets, true);
+                WriteObject(page.Data, true);
+                if (!string.IsNullOrEmpty(page.NextCursor))
+                {
+                    WriteVerbose($"Next cursor: {page.NextCursor}");
+                }
             }
         }
         else


### PR DESCRIPTION
## Summary
- add fetchAll option to `ListYaraRulesetsAsync` with cursor paging
- update PowerShell and example code for new `Page<YaraRuleset>` return type
- add tests covering multi-page and single-page Yara ruleset listing

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689c8ee11568832e8a20a797bc636edb