### PR TITLE
Add bundle and collection item management

### DIFF
--- a/VirusTotalAnalyzer.Examples/BundleItemsExample.cs
+++ b/VirusTotalAnalyzer.Examples/BundleItemsExample.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class BundleItemsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var request = new AddItemsRequest
+            {
+                Data = { new Relationship { Id = "file-id", Type = ResourceType.File } }
+            };
+            var added = await client.AddBundleItemsAsync("bundle-id", request);
+            Console.WriteLine($"Added {added?.Data.Count ?? 0} items");
+
+            var items = await client.ListBundleItemsAsync("bundle-id", limit: 10);
+            Console.WriteLine($"Retrieved {items?.Data.Count} items");
+
+            await client.DeleteBundleItemAsync("bundle-id", "file-id");
+            Console.WriteLine("Item deleted");
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}
+

--- a/VirusTotalAnalyzer.Examples/CollectionItemsExample.cs
+++ b/VirusTotalAnalyzer.Examples/CollectionItemsExample.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class CollectionItemsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var request = new AddItemsRequest
+            {
+                Data = { new Relationship { Id = "file-id", Type = ResourceType.File } }
+            };
+            var added = await client.AddCollectionItemsAsync("collection-id", request);
+            Console.WriteLine($"Added {added?.Data.Count ?? 0} items");
+
+            var items = await client.ListCollectionItemsAsync("collection-id", limit: 10);
+            Console.WriteLine($"Retrieved {items?.Data.Count} items");
+
+            await client.DeleteCollectionItemAsync("collection-id", "file-id");
+            Console.WriteLine("Item deleted");
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}
+

--- a/VirusTotalAnalyzer.Examples/Program.cs
+++ b/VirusTotalAnalyzer.Examples/Program.cs
@@ -29,6 +29,8 @@ using VirusTotalAnalyzer.Examples;
 // await ListCollectionsExample.RunAsync();
 // await ListBundlesExample.RunAsync();
 // await GraphCommentsExample.RunAsync();
+// await BundleItemsExample.RunAsync();
+// await CollectionItemsExample.RunAsync();
 // await GetRelationshipsExample.RunAsync();
 // await SearchExample.RunAsync();
 // await GetFeedExample.RunAsync();

--- a/VirusTotalAnalyzer.Tests/GraphCollectionBundleTests.cs
+++ b/VirusTotalAnalyzer.Tests/GraphCollectionBundleTests.cs
@@ -303,6 +303,70 @@ public class GraphCollectionBundleTests
     }
 
     [Fact]
+    public async Task ListCollectionItemsAsync_GetsItems()
+    {
+        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\"}]}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var response = await client.ListCollectionItemsAsync("c1");
+
+        Assert.NotNull(response);
+        Assert.Single(response.Data);
+        Assert.Equal(HttpMethod.Get, handler.Request!.Method);
+        Assert.Equal("/api/v3/collections/c1/items", handler.Request.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task AddCollectionItemsAsync_PostsItems()
+    {
+        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\"}]}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var request = new AddItemsRequest
+        {
+            Data = { new Relationship { Id = "f1", Type = ResourceType.File } }
+        };
+        var response = await client.AddCollectionItemsAsync("c1", request);
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpMethod.Post, handler.Request!.Method);
+        Assert.Equal("/api/v3/collections/c1/items", handler.Request.RequestUri!.AbsolutePath);
+        Assert.Contains("\"id\":\"f1\"", handler.Content);
+    }
+
+    [Fact]
+    public async Task DeleteCollectionItemAsync_UsesDelete()
+    {
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.NoContent));
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.DeleteCollectionItemAsync("c1", "f1");
+
+        Assert.Equal(HttpMethod.Delete, handler.Request!.Method);
+        Assert.Equal("/api/v3/collections/c1/items/f1", handler.Request.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
     public async Task ListBundlesAsync_GetsBundles()
     {
         var json = "{\"data\":[{\"id\":\"b1\",\"type\":\"bundle\",\"data\":{\"attributes\":{\"name\":\"demo\"}}}]}";
@@ -410,5 +474,69 @@ public class GraphCollectionBundleTests
 
         Assert.Equal(HttpMethod.Delete, handler.Request!.Method);
         Assert.Equal("/api/v3/bundles/b1", handler.Request.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task ListBundleItemsAsync_GetsItems()
+    {
+        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\"}]}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var response = await client.ListBundleItemsAsync("b1");
+
+        Assert.NotNull(response);
+        Assert.Single(response.Data);
+        Assert.Equal(HttpMethod.Get, handler.Request!.Method);
+        Assert.Equal("/api/v3/bundles/b1/items", handler.Request.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task AddBundleItemsAsync_PostsItems()
+    {
+        var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\"}]}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var request = new AddItemsRequest
+        {
+            Data = { new Relationship { Id = "f1", Type = ResourceType.File } }
+        };
+        var response = await client.AddBundleItemsAsync("b1", request);
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpMethod.Post, handler.Request!.Method);
+        Assert.Equal("/api/v3/bundles/b1/items", handler.Request.RequestUri!.AbsolutePath);
+        Assert.Contains("\"id\":\"f1\"", handler.Content);
+    }
+
+    [Fact]
+    public async Task DeleteBundleItemAsync_UsesDelete()
+    {
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.NoContent));
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.DeleteBundleItemAsync("b1", "f1");
+
+        Assert.Equal(HttpMethod.Delete, handler.Request!.Method);
+        Assert.Equal("/api/v3/bundles/b1/items/f1", handler.Request.RequestUri!.AbsolutePath);
     }
 }

--- a/VirusTotalAnalyzer/Models/AddItemsRequest.cs
+++ b/VirusTotalAnalyzer/Models/AddItemsRequest.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class AddItemsRequest
+{
+    [JsonPropertyName("data")]
+    public List<Relationship> Data { get; set; } = new();
+}
+

--- a/VirusTotalAnalyzer/VirusTotalClient.Resources.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Resources.cs
@@ -170,6 +170,49 @@ public sealed partial class VirusTotalClient
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task<PagedResponse<Relationship>?> ListCollectionItemsAsync(string id, int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
+    {
+        var path = new StringBuilder($"collections/{Uri.EscapeDataString(id)}/items");
+        var hasQuery = false;
+        if (limit.HasValue)
+        {
+            path.Append("?limit=").Append(limit.Value);
+            hasQuery = true;
+        }
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<PagedResponse<Relationship>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<RelationshipResponse?> AddCollectionItemsAsync(string id, AddItemsRequest request, CancellationToken cancellationToken = default)
+    {
+        var json = JsonSerializer.Serialize(request, _jsonOptions);
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var response = await _httpClient.PostAsync($"collections/{Uri.EscapeDataString(id)}/items", content, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<RelationshipResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task DeleteCollectionItemAsync(string id, string itemId, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.DeleteAsync($"collections/{Uri.EscapeDataString(id)}/items/{Uri.EscapeDataString(itemId)}", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task<PagedResponse<Bundle>?> ListBundlesAsync(int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
     {
         var path = new StringBuilder("bundles");
@@ -237,6 +280,49 @@ public sealed partial class VirusTotalClient
     public async Task DeleteBundleAsync(string id, CancellationToken cancellationToken = default)
     {
         using var response = await _httpClient.DeleteAsync($"bundles/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<PagedResponse<Relationship>?> ListBundleItemsAsync(string id, int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
+    {
+        var path = new StringBuilder($"bundles/{Uri.EscapeDataString(id)}/items");
+        var hasQuery = false;
+        if (limit.HasValue)
+        {
+            path.Append("?limit=").Append(limit.Value);
+            hasQuery = true;
+        }
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<PagedResponse<Relationship>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<RelationshipResponse?> AddBundleItemsAsync(string id, AddItemsRequest request, CancellationToken cancellationToken = default)
+    {
+        var json = JsonSerializer.Serialize(request, _jsonOptions);
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var response = await _httpClient.PostAsync($"bundles/{Uri.EscapeDataString(id)}/items", content, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        return await JsonSerializer.DeserializeAsync<RelationshipResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task DeleteBundleItemAsync(string id, string itemId, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.DeleteAsync($"bundles/{Uri.EscapeDataString(id)}/items/{Uri.EscapeDataString(itemId)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
## Summary
- add API client methods to list, add and delete items in bundles and collections
- support item operations via new `AddItemsRequest` model
- include examples and tests for bundle and collection item management

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689c8eef6c84832eb958f0a3b909f4be