### PR TITLE
Support monitor event community endpoints

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetMonitorEventCommentsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetMonitorEventCommentsExample.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetMonitorEventCommentsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var comments = await client.GetCommentsAsync(ResourceType.MonitorEvent, "monitor-event-id", limit: 10);
+            Console.WriteLine(comments?.Data.Count);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Examples/GetMonitorEventVotesExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetMonitorEventVotesExample.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetMonitorEventVotesExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var votes = await client.GetVotesAsync(ResourceType.MonitorEvent, "monitor-event-id", limit: 10);
+            Console.WriteLine(votes?.Data.Count);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Examples/GetVotesExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetVotesExample.cs
@@ -13,9 +13,10 @@ public static class GetVotesExample
         {
             var first = await client.GetVotesAsync(ResourceType.File, "file-id", limit: 10);
             Console.WriteLine(first?.Data.Count);
-            if (!string.IsNullOrEmpty(first?.Meta?.Cursor))
+            var cursor = first?.Meta?.Cursor;
+            if (!string.IsNullOrEmpty(cursor))
             {
-                var next = await client.GetVotesAsync(ResourceType.File, "file-id", cursor: first.Meta.Cursor);
+                var next = await client.GetVotesAsync(ResourceType.File, "file-id", cursor: cursor);
                 Console.WriteLine(next?.Data.Count);
             }
         }

--- a/VirusTotalAnalyzer.Tests/MonitorEventTests.cs
+++ b/VirusTotalAnalyzer.Tests/MonitorEventTests.cs
@@ -54,5 +54,87 @@ public class MonitorEventTests
         Assert.Equal("/api/v3/monitor/events", handler.Request.RequestUri!.AbsolutePath);
         Assert.Equal("?filter=type%3Afoo&limit=10&cursor=abc", handler.Request.RequestUri.Query);
     }
+
+    [Fact]
+    public async Task GetCommentsAsync_OnMonitorEvent_UsesMonitorEventsPath()
+    {
+        var json = "{\"data\":[]}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var comments = await client.GetCommentsAsync(ResourceType.MonitorEvent, "e1");
+
+        Assert.NotNull(comments);
+        Assert.Equal("/api/v3/monitor/events/e1/comments", handler.Request!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task CreateCommentAsync_OnMonitorEvent_UsesMonitorEventsPath()
+    {
+        var json = @"{\"data\":{\"id\":\"c1\",\"type\":\"comment\",\"data\":{\"attributes\":{\"date\":1,\"text\":\"hi\"}}}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var comment = await client.CreateCommentAsync(ResourceType.MonitorEvent, "e1", "hi");
+
+        Assert.NotNull(comment);
+        Assert.Equal("/api/v3/monitor/events/e1/comments", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Contains("\"text\":\"hi\"", handler.Content);
+    }
+
+    [Fact]
+    public async Task GetVotesAsync_OnMonitorEvent_UsesMonitorEventsPath()
+    {
+        var json = "{\"data\":[]}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var votes = await client.GetVotesAsync(ResourceType.MonitorEvent, "e1");
+
+        Assert.NotNull(votes);
+        Assert.Equal("/api/v3/monitor/events/e1/votes", handler.Request!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task CreateVoteAsync_OnMonitorEvent_UsesMonitorEventsPath()
+    {
+        var json = @"{\"data\":{\"id\":\"v1\",\"type\":\"vote\",\"data\":{\"attributes\":{\"date\":1,\"verdict\":\"malicious\"}}}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var vote = await client.CreateVoteAsync(ResourceType.MonitorEvent, "e1", VoteVerdict.Malicious);
+
+        Assert.NotNull(vote);
+        Assert.Equal("/api/v3/monitor/events/e1/votes", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Contains("\"verdict\":\"malicious\"", handler.Content);
+    }
 }
 

--- a/VirusTotalAnalyzer.Tests/MonitorEventTests.cs
+++ b/VirusTotalAnalyzer.Tests/MonitorEventTests.cs
@@ -78,7 +78,7 @@ public class MonitorEventTests
     [Fact]
     public async Task CreateCommentAsync_OnMonitorEvent_UsesMonitorEventsPath()
     {
-        var json = @"{\"data\":{\"id\":\"c1\",\"type\":\"comment\",\"data\":{\"attributes\":{\"date\":1,\"text\":\"hi\"}}}}";
+        var json = @"{""data"":{""id"":""c1"",""type"":""comment"",""data"":{""attributes"":{""date"":1,""text"":""hi""}}}}";
         var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -119,7 +119,7 @@ public class MonitorEventTests
     [Fact]
     public async Task CreateVoteAsync_OnMonitorEvent_UsesMonitorEventsPath()
     {
-        var json = @"{\"data\":{\"id\":\"v1\",\"type\":\"vote\",\"data\":{\"attributes\":{\"date\":1,\"verdict\":\"malicious\"}}}}";
+        var json = @"{""data"":{""id"":""v1"",""type"":""vote"",""data"":{""attributes"":{""date"":1,""verdict"":""malicious""}}}}";
         var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -103,6 +103,7 @@ public sealed partial class VirusTotalClient : IDisposable
             ResourceType.RetrohuntJob => "retrohunt_jobs",
             ResourceType.RetrohuntNotification => "retrohunt_notifications",
             ResourceType.MonitorItem => "monitor/items",
+            ResourceType.MonitorEvent => "monitor/events",
             ResourceType.IntelligenceHuntingRuleset => "intelligence/hunting_rulesets",
             ResourceType.FileBehaviour => "file-behaviour",
             _ => throw new ArgumentOutOfRangeException(nameof(type))


### PR DESCRIPTION
## Summary
- map `ResourceType.MonitorEvent` to `monitor/events`
- add tests for commenting and voting on monitor events
- document usage with examples for monitor event comments and votes

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689cdfa3ffdc832e896564a6fd513663