### PR TITLE
Ensure download streams dispose responses

### DIFF
--- a/VirusTotalAnalyzer.Tests/TrackingResponseMessage.cs
+++ b/VirusTotalAnalyzer.Tests/TrackingResponseMessage.cs
@@ -1,0 +1,17 @@
+using System.Net.Http;
+
+namespace VirusTotalAnalyzer.Tests;
+
+internal sealed class TrackingResponseMessage : HttpResponseMessage
+{
+    public bool Disposed { get; private set; }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            Disposed = true;
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Core.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Core.cs
@@ -52,8 +52,9 @@ public partial class VirusTotalClientTests
     public async Task DownloadFileAsync_UsesCorrectPathAndReturnsStream()
     {
         var trackingStream = new TrackingStream(new byte[] { 1, 2, 3 });
-        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        var response = new TrackingResponseMessage
         {
+            StatusCode = HttpStatusCode.OK,
             Content = new StreamContent(trackingStream)
         };
         var handler = new SingleResponseHandler(response);
@@ -63,17 +64,25 @@ public partial class VirusTotalClientTests
         };
         var client = new VirusTotalClient(httpClient);
 
-        var stream = await client.DownloadFileAsync("abc");
-
-        Assert.NotNull(handler.Request);
-        Assert.Equal("/api/v3/files/abc/download", handler.Request!.RequestUri!.AbsolutePath);
-        Assert.False(trackingStream.Disposed);
 #if NETFRAMEWORK
-        stream.Dispose();
+        using (var stream = await client.DownloadFileAsync("abc"))
+        {
+            Assert.NotNull(handler.Request);
+            Assert.Equal("/api/v3/files/abc/download", handler.Request!.RequestUri!.AbsolutePath);
+            Assert.False(trackingStream.Disposed);
+            Assert.False(response.Disposed);
+        }
 #else
-        await stream.DisposeAsync();
+        await using (var stream = await client.DownloadFileAsync("abc"))
+        {
+            Assert.NotNull(handler.Request);
+            Assert.Equal("/api/v3/files/abc/download", handler.Request!.RequestUri!.AbsolutePath);
+            Assert.False(trackingStream.Disposed);
+            Assert.False(response.Disposed);
+        }
 #endif
         Assert.True(trackingStream.Disposed);
+        Assert.True(response.Disposed);
     }
 
     [Fact]
@@ -103,8 +112,9 @@ public partial class VirusTotalClientTests
     public async Task DownloadPcapAsync_UsesCorrectPathAndReturnsStream()
     {
         var trackingStream = new TrackingStream(new byte[] { 1, 2, 3 });
-        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        var response = new TrackingResponseMessage
         {
+            StatusCode = HttpStatusCode.OK,
             Content = new StreamContent(trackingStream)
         };
         var handler = new SingleResponseHandler(response);
@@ -114,17 +124,25 @@ public partial class VirusTotalClientTests
         };
         var client = new VirusTotalClient(httpClient);
 
-        var stream = await client.DownloadPcapAsync("abc");
-
-        Assert.NotNull(handler.Request);
-        Assert.Equal("/api/v3/analyses/abc/pcap", handler.Request!.RequestUri!.AbsolutePath);
-        Assert.False(trackingStream.Disposed);
 #if NETFRAMEWORK
-        stream.Dispose();
+        using (var stream = await client.DownloadPcapAsync("abc"))
+        {
+            Assert.NotNull(handler.Request);
+            Assert.Equal("/api/v3/analyses/abc/pcap", handler.Request!.RequestUri!.AbsolutePath);
+            Assert.False(trackingStream.Disposed);
+            Assert.False(response.Disposed);
+        }
 #else
-        await stream.DisposeAsync();
+        await using (var stream = await client.DownloadPcapAsync("abc"))
+        {
+            Assert.NotNull(handler.Request);
+            Assert.Equal("/api/v3/analyses/abc/pcap", handler.Request!.RequestUri!.AbsolutePath);
+            Assert.False(trackingStream.Disposed);
+            Assert.False(response.Disposed);
+        }
 #endif
         Assert.True(trackingStream.Disposed);
+        Assert.True(response.Disposed);
     }
 
     [Fact]
@@ -154,8 +172,9 @@ public partial class VirusTotalClientTests
     public async Task DownloadRetrohuntNotificationFileAsync_UsesCorrectPathAndReturnsStream()
     {
         var trackingStream = new TrackingStream(new byte[] { 1, 2, 3 });
-        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        var response = new TrackingResponseMessage
         {
+            StatusCode = HttpStatusCode.OK,
             Content = new StreamContent(trackingStream)
         };
         var handler = new SingleResponseHandler(response);
@@ -165,17 +184,25 @@ public partial class VirusTotalClientTests
         };
         var client = new VirusTotalClient(httpClient);
 
-        var stream = await client.DownloadRetrohuntNotificationFileAsync("abc");
-
-        Assert.NotNull(handler.Request);
-        Assert.Equal("/api/v3/intelligence/retrohunt_notification_files/abc", handler.Request!.RequestUri!.AbsolutePath);
-        Assert.False(trackingStream.Disposed);
 #if NETFRAMEWORK
-        stream.Dispose();
+        using (var stream = await client.DownloadRetrohuntNotificationFileAsync("abc"))
+        {
+            Assert.NotNull(handler.Request);
+            Assert.Equal("/api/v3/intelligence/retrohunt_notification_files/abc", handler.Request!.RequestUri!.AbsolutePath);
+            Assert.False(trackingStream.Disposed);
+            Assert.False(response.Disposed);
+        }
 #else
-        await stream.DisposeAsync();
+        await using (var stream = await client.DownloadRetrohuntNotificationFileAsync("abc"))
+        {
+            Assert.NotNull(handler.Request);
+            Assert.Equal("/api/v3/intelligence/retrohunt_notification_files/abc", handler.Request!.RequestUri!.AbsolutePath);
+            Assert.False(trackingStream.Disposed);
+            Assert.False(response.Disposed);
+        }
 #endif
         Assert.True(trackingStream.Disposed);
+        Assert.True(response.Disposed);
     }
 
     [Fact]

--- a/VirusTotalAnalyzer/StreamWithResponse.cs
+++ b/VirusTotalAnalyzer/StreamWithResponse.cs
@@ -1,0 +1,66 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VirusTotalAnalyzer;
+
+internal sealed class StreamWithResponse : Stream
+#if !NET472
+    , IAsyncDisposable
+#endif
+{
+    private readonly HttpResponseMessage _response;
+    private readonly Stream _stream;
+
+    public StreamWithResponse(HttpResponseMessage response, Stream stream)
+    {
+        _response = response ?? throw new ArgumentNullException(nameof(response));
+        _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+    }
+
+    public override bool CanRead => _stream.CanRead;
+    public override bool CanSeek => _stream.CanSeek;
+    public override bool CanWrite => _stream.CanWrite;
+    public override long Length => _stream.Length;
+    public override long Position
+    {
+        get => _stream.Position;
+        set => _stream.Position = value;
+    }
+
+    public override void Flush() => _stream.Flush();
+    public override int Read(byte[] buffer, int offset, int count) => _stream.Read(buffer, offset, count);
+    public override long Seek(long offset, SeekOrigin origin) => _stream.Seek(offset, origin);
+    public override void SetLength(long value) => _stream.SetLength(value);
+    public override void Write(byte[] buffer, int offset, int count) => _stream.Write(buffer, offset, count);
+
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+        _stream.ReadAsync(buffer, offset, count, cancellationToken);
+
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+        _stream.WriteAsync(buffer, offset, count, cancellationToken);
+
+#if !NET472
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+        _stream.ReadAsync(buffer, cancellationToken);
+
+    public override ValueTask DisposeAsync()
+    {
+        var dispose = _stream.DisposeAsync();
+        _response.Dispose();
+        return dispose;
+    }
+#endif
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _stream.Dispose();
+            _response.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -258,13 +258,16 @@ public sealed partial class VirusTotalClient
 
     public async Task<Stream> DownloadFileAsync(string id, CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/download", HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        var response = await _httpClient
+            .GetAsync($"files/{Uri.EscapeDataString(id)}/download", HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
-        return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #else
-        return await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #endif
+        return new StreamWithResponse(response, stream);
     }
 
     public async Task<UrlReport?> GetUrlReportAsync(string id, CancellationToken cancellationToken = default)

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -235,24 +235,30 @@ public sealed partial class VirusTotalClient : IDisposable
 
     public async Task<Stream> DownloadRetrohuntNotificationFileAsync(string id, CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.GetAsync($"intelligence/retrohunt_notification_files/{Uri.EscapeDataString(id)}", HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        var response = await _httpClient
+            .GetAsync($"intelligence/retrohunt_notification_files/{Uri.EscapeDataString(id)}", HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
-        return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #else
-        return await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #endif
+        return new StreamWithResponse(response, stream);
     }
 
     public async Task<Stream> DownloadPcapAsync(string analysisId, CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.GetAsync($"analyses/{Uri.EscapeDataString(analysisId)}/pcap", HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        var response = await _httpClient
+            .GetAsync($"analyses/{Uri.EscapeDataString(analysisId)}/pcap", HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
-        return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #else
-        return await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #endif
+        return new StreamWithResponse(response, stream);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- add `StreamWithResponse` to couple a download stream with its `HttpResponseMessage`
- dispose responses when downloading files, retrohunt notification files, and pcaps
- test stream disposal cascades to the underlying HTTP response

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test -p:TargetFrameworks=net8.0`
- `dotnet test -p:TargetFrameworks=net472` *(fails: Could not find 'mono' host)*

------
https://chatgpt.com/codex/tasks/task_e_689ce9836b60832e83bfcf7a1ac64e3a