### PR TITLE
Allow non-time-based FileBehaviour feed

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetFileBehaviorFeedExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileBehaviorFeedExample.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetFileBehaviorFeedExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var feed = await client.GetFeedAsync(ResourceType.FileBehaviour, limit: 10);
+            Console.WriteLine(feed?.Data.Count);
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
@@ -607,6 +607,26 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetFeedAsync_FileBehaviour_BuildsPathWithLimitAndCursor()
+    {
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"data\":[]}", Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetFeedAsync(ResourceType.FileBehaviour, limit: 5, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/feeds/file-behaviour", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal("limit=5&cursor=abc", handler.Request!.RequestUri!.Query.TrimStart('?'));
+    }
+
+    [Fact]
     public async Task GetFeedAsync_DeserializesCursor()
     {
         var json = "{\"data\":[],\"meta\":{\"cursor\":\"next\"}}";

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
@@ -365,6 +365,29 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetFeedAsync_FileBehaviour_DeserializesResponseAndUsesCorrectPath()
+    {
+        var json = "{\"data\":[{\"id\":\"b1\",\"type\":\"file\"}]}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var feed = await client.GetFeedAsync(ResourceType.FileBehaviour);
+
+        Assert.NotNull(feed);
+        Assert.Single(feed!.Data);
+        Assert.Equal("b1", feed.Data[0].Id);
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/feeds/file-behaviour", handler.Request!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
     public async Task GetRelationshipsAsync_DeserializesResponseAndUsesCorrectPath()
     {
         var json = "{\"data\":[{\"id\":\"r1\",\"type\":\"file\"}]}";

--- a/VirusTotalAnalyzer/VirusTotalClient.Intelligence.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Intelligence.cs
@@ -392,7 +392,8 @@ public sealed partial class VirusTotalClient
         if (resourceType != ResourceType.File &&
             resourceType != ResourceType.Url &&
             resourceType != ResourceType.Domain &&
-            resourceType != ResourceType.IpAddress)
+            resourceType != ResourceType.IpAddress &&
+            resourceType != ResourceType.FileBehaviour)
         {
             throw new ArgumentOutOfRangeException(nameof(resourceType));
         }


### PR DESCRIPTION
## Summary
- permit FileBehaviour resource type for non-time-based GetFeedAsync
- cover FileBehaviour feed with tests
- add example demonstrating FileBehaviour feed usage

## Testing
- `dotnet build VirusTotalAnalyzer/VirusTotalAnalyzer.csproj -p:TargetFrameworks=net472`
- `dotnet build VirusTotalAnalyzer.Examples/VirusTotalAnalyzer.Examples.csproj -p:TargetFrameworks=net8.0`
- `dotnet test VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj -p:TargetFrameworks=net8.0`
- `dotnet build VirusTotalAnalyzer.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689ceca51abc832e9ee316c31c7ceb5b