### PR TITLE
feat: support field and relationship filtering

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetDomainReportExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetDomainReportExample.cs
@@ -11,7 +11,10 @@ public static class GetDomainReportExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.GetDomainReportAsync("example.com");
+            var report = await client.GetDomainReportAsync(
+                "example.com",
+                fields: new[] { "last_analysis_stats" },
+                relationships: new[] { "siblings" });
             Console.WriteLine(report?.Id);
         }
         catch (RateLimitExceededException ex)

--- a/VirusTotalAnalyzer.Examples/GetFileReportExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileReportExample.cs
@@ -11,7 +11,10 @@ public static class GetFileReportExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.GetFileReportAsync("44d88612fea8a8f36de82e1278abb02f");
+            var report = await client.GetFileReportAsync(
+                "44d88612fea8a8f36de82e1278abb02f",
+                fields: new[] { "md5", "sha256" },
+                relationships: new[] { "analyses" });
             Console.WriteLine(report?.Id);
             Console.WriteLine(report?.Attributes.CreationDate);
         }

--- a/VirusTotalAnalyzer.Examples/GetIpAddressReportExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetIpAddressReportExample.cs
@@ -11,7 +11,10 @@ public static class GetIpAddressReportExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.GetIpAddressReportAsync("8.8.8.8");
+            var report = await client.GetIpAddressReportAsync(
+                "8.8.8.8",
+                fields: new[] { "last_analysis_stats" },
+                relationships: new[] { "resolutions" });
             Console.WriteLine(report?.Id);
         }
         catch (RateLimitExceededException ex)

--- a/VirusTotalAnalyzer.Examples/GetUrlReportExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetUrlReportExample.cs
@@ -11,7 +11,10 @@ public static class GetUrlReportExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.GetUrlReportAsync("url-id");
+            var report = await client.GetUrlReportAsync(
+                "url-id",
+                fields: new[] { "last_analysis_date" },
+                relationships: new[] { "last_serving_ip_address" });
             Console.WriteLine(report?.Id);
         }
         catch (RateLimitExceededException ex)

--- a/VirusTotalAnalyzer.Examples/GetUrlReportFromUrlExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetUrlReportFromUrlExample.cs
@@ -11,7 +11,10 @@ public static class GetUrlReportFromUrlExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.GetUrlReportAsync(new Uri("https://example.com"));
+            var report = await client.GetUrlReportAsync(
+                new Uri("https://example.com"),
+                fields: new[] { "last_analysis_date" },
+                relationships: new[] { "last_serving_ip_address" });
             Console.WriteLine(report?.Id);
         }
         catch (RateLimitExceededException ex)

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Core.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Core.cs
@@ -49,6 +49,32 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetFileReportAsync_AppendsFieldsAndRelationships()
+    {
+        var json = "{\"data\":{\"id\":\"abc\",\"type\":\"file\"}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetFileReportAsync(
+            "abc",
+            fields: new[] { "reputation", "size" },
+            relationships: new[] { "analyses" });
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/files/abc", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal(
+            "fields=reputation,size&relationships=analyses",
+            handler.Request!.RequestUri!.Query.TrimStart('?'));
+    }
+
+    [Fact]
     public async Task DownloadFileAsync_UsesCorrectPathAndReturnsStream()
     {
         var trackingStream = new TrackingStream(new byte[] { 1, 2, 3 });
@@ -296,6 +322,32 @@ public partial class VirusTotalClientTests
         Assert.Equal("def", report!.Id);
         Assert.Equal(ResourceType.Url, report.Type);
         Assert.Equal("https://example.com", report.Attributes.Url);
+    }
+
+    [Fact]
+    public async Task GetUrlReportAsync_AppendsFieldsAndRelationships()
+    {
+        var json = "{\"data\":{\"id\":\"def\",\"type\":\"url\"}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetUrlReportAsync(
+            "def",
+            fields: new[] { "last_analysis_date" },
+            relationships: new[] { "last_serving_ip_address" });
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/urls/def", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal(
+            "fields=last_analysis_date&relationships=last_serving_ip_address",
+            handler.Request!.RequestUri!.Query.TrimStart('?'));
     }
 
     [Fact]

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
@@ -83,6 +83,32 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetIpAddressReportAsync_AppendsFieldsAndRelationships()
+    {
+        var json = "{\"data\":{\"id\":\"1.1.1.1\",\"type\":\"ip_address\"}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetIpAddressReportAsync(
+            "1.1.1.1",
+            fields: new[] { "last_analysis_stats" },
+            relationships: new[] { "resolutions" });
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/ip_addresses/1.1.1.1", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal(
+            "fields=last_analysis_stats&relationships=resolutions",
+            handler.Request!.RequestUri!.Query.TrimStart('?'));
+    }
+
+    [Fact]
     public async Task GetDomainReportAsync_DeserializesResponseAndUsesCorrectPath()
     {
         var json = "{\"data\":{\"id\":\"example.com\",\"type\":\"domain\",\"attributes\":{\"domain\":\"example.com\"}}}";
@@ -103,6 +129,32 @@ public partial class VirusTotalClientTests
         Assert.Equal(ResourceType.Domain, report.Type);
         Assert.NotNull(handler.Request);
         Assert.Equal("/api/v3/domains/example.com", handler.Request!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task GetDomainReportAsync_AppendsFieldsAndRelationships()
+    {
+        var json = "{\"data\":{\"id\":\"example.com\",\"type\":\"domain\"}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetDomainReportAsync(
+            "example.com",
+            fields: new[] { "last_analysis_stats" },
+            relationships: new[] { "siblings" });
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/domains/example.com", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal(
+            "fields=last_analysis_stats&relationships=siblings",
+            handler.Request!.RequestUri!.Query.TrimStart('?'));
     }
 
     [Fact]

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -15,9 +15,29 @@ namespace VirusTotalAnalyzer;
 
 public sealed partial class VirusTotalClient
 {
-    public async Task<FileReport?> GetFileReportAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<FileReport?> GetFileReportAsync(
+        string id,
+        IEnumerable<string>? fields = null,
+        IEnumerable<string>? relationships = null,
+        CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
+        var url = new StringBuilder($"files/{Uri.EscapeDataString(id)}");
+        var hasQuery = false;
+
+        if (fields != null && fields.Any())
+        {
+            url.Append("?fields=").Append(string.Join(",", fields.Select(Uri.EscapeDataString)));
+            hasQuery = true;
+        }
+
+        if (relationships != null && relationships.Any())
+        {
+            url.Append(hasQuery ? '&' : '?')
+                .Append("relationships=")
+                .Append(string.Join(",", relationships.Select(Uri.EscapeDataString)));
+        }
+
+        using var response = await _httpClient.GetAsync(url.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -270,9 +290,29 @@ public sealed partial class VirusTotalClient
         return new StreamWithResponse(response, stream);
     }
 
-    public async Task<UrlReport?> GetUrlReportAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<UrlReport?> GetUrlReportAsync(
+        string id,
+        IEnumerable<string>? fields = null,
+        IEnumerable<string>? relationships = null,
+        CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"urls/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
+        var url = new StringBuilder($"urls/{Uri.EscapeDataString(id)}");
+        var hasQuery = false;
+
+        if (fields != null && fields.Any())
+        {
+            url.Append("?fields=").Append(string.Join(",", fields.Select(Uri.EscapeDataString)));
+            hasQuery = true;
+        }
+
+        if (relationships != null && relationships.Any())
+        {
+            url.Append(hasQuery ? '&' : '?')
+                .Append("relationships=")
+                .Append(string.Join(",", relationships.Select(Uri.EscapeDataString)));
+        }
+
+        using var response = await _httpClient.GetAsync(url.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -284,10 +324,18 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
-    public Task<UrlReport?> GetUrlReportAsync(Uri url, CancellationToken cancellationToken = default)
+    public Task<UrlReport?> GetUrlReportAsync(
+        Uri url,
+        IEnumerable<string>? fields = null,
+        IEnumerable<string>? relationships = null,
+        CancellationToken cancellationToken = default)
     {
         if (url == null) throw new ArgumentNullException(nameof(url));
-        return GetUrlReportAsync(VirusTotalClientExtensions.GetUrlId(url.ToString()), cancellationToken);
+        return GetUrlReportAsync(
+            VirusTotalClientExtensions.GetUrlId(url.ToString()),
+            fields,
+            relationships,
+            cancellationToken);
     }
 
     public async Task<(List<AnalysisReport> Analyses, string? Cursor)> GetUrlAnalysesAsync(
@@ -413,9 +461,29 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
-    public async Task<IpAddressReport?> GetIpAddressReportAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<IpAddressReport?> GetIpAddressReportAsync(
+        string id,
+        IEnumerable<string>? fields = null,
+        IEnumerable<string>? relationships = null,
+        CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"ip_addresses/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
+        var url = new StringBuilder($"ip_addresses/{Uri.EscapeDataString(id)}");
+        var hasQuery = false;
+
+        if (fields != null && fields.Any())
+        {
+            url.Append("?fields=").Append(string.Join(",", fields.Select(Uri.EscapeDataString)));
+            hasQuery = true;
+        }
+
+        if (relationships != null && relationships.Any())
+        {
+            url.Append(hasQuery ? '&' : '?')
+                .Append("relationships=")
+                .Append(string.Join(",", relationships.Select(Uri.EscapeDataString)));
+        }
+
+        using var response = await _httpClient.GetAsync(url.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -440,9 +508,29 @@ public sealed partial class VirusTotalClient
             .ConfigureAwait(false);
     }
 
-    public async Task<DomainReport?> GetDomainReportAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<DomainReport?> GetDomainReportAsync(
+        string id,
+        IEnumerable<string>? fields = null,
+        IEnumerable<string>? relationships = null,
+        CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"domains/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
+        var url = new StringBuilder($"domains/{Uri.EscapeDataString(id)}");
+        var hasQuery = false;
+
+        if (fields != null && fields.Any())
+        {
+            url.Append("?fields=").Append(string.Join(",", fields.Select(Uri.EscapeDataString)));
+            hasQuery = true;
+        }
+
+        if (relationships != null && relationships.Any())
+        {
+            url.Append(hasQuery ? '&' : '?')
+                .Append("relationships=")
+                .Append(string.Join(",", relationships.Select(Uri.EscapeDataString)));
+        }
+
+        using var response = await _httpClient.GetAsync(url.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- allow selecting specific fields and relationships in `Get*ReportAsync` methods
- document optional filter usage in examples
- test query-string generation for file, URL, IP and domain reports

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689cf8987580832eab2f362ee3460c32