### PR TITLE
Remove analysisType parameter from SubmitUrlAsync

### DIFF
--- a/VirusTotalAnalyzer.Examples/SubmitUrlExample.cs
+++ b/VirusTotalAnalyzer.Examples/SubmitUrlExample.cs
@@ -12,7 +12,7 @@ public static class SubmitUrlExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
+            var report = await client.SubmitUrlAsync("https://example.com");
             Console.WriteLine(report?.Id);
 
             var simple = await client.SubmitUrlAsync("https://example.org", CancellationToken.None);

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
@@ -230,7 +230,7 @@ public partial class VirusTotalClientTests
         };
         var client = new VirusTotalClient(httpClient);
 
-        var report = await client.SubmitUrlAsync("https://example.com", AnalysisType.Url);
+        var report = await client.SubmitUrlAsync("https://example.com");
 
         Assert.NotNull(report);
         Assert.NotNull(handler.Request);

--- a/VirusTotalAnalyzer/VirusTotalClient.Submissions.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Submissions.cs
@@ -255,7 +255,7 @@ public sealed partial class VirusTotalClient
         return ReanalyzeHashAsync(id, AnalysisType.Url, cancellationToken);
     }
 
-    public async Task<AnalysisReport?> SubmitUrlAsync(string url, AnalysisType analysisType = AnalysisType.Url, CancellationToken cancellationToken = default)
+    public async Task<AnalysisReport?> SubmitUrlAsync(string url, CancellationToken cancellationToken = default)
     {
         if (url is null)
         {
@@ -264,10 +264,6 @@ public sealed partial class VirusTotalClient
         if (url.Length == 0)
         {
             throw new ArgumentException("URL must not be empty.", nameof(url));
-        }
-        if (analysisType != AnalysisType.Url)
-        {
-            throw new ArgumentOutOfRangeException(nameof(analysisType));
         }
         using var content = new FormUrlEncodedContent(new[] { new KeyValuePair<string, string>("url", url) });
         using var response = await _httpClient.PostAsync("urls", content, cancellationToken).ConfigureAwait(false);
@@ -279,18 +275,5 @@ public sealed partial class VirusTotalClient
 #endif
         return await JsonSerializer.DeserializeAsync<AnalysisReport>(stream, _jsonOptions, cancellationToken)
             .ConfigureAwait(false);
-    }
-
-    public Task<AnalysisReport?> SubmitUrlAsync(string url, CancellationToken cancellationToken = default)
-    {
-        if (url is null)
-        {
-            throw new ArgumentNullException(nameof(url));
-        }
-        if (url.Length == 0)
-        {
-            throw new ArgumentException("URL must not be empty.", nameof(url));
-        }
-        return SubmitUrlAsync(url, AnalysisType.Url, cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary
- simplify SubmitUrlAsync by removing unused analysisType parameter
- update example and tests to call SubmitUrlAsync with url only

## Testing
- `/root/.dotnet/dotnet build VirusTotalAnalyzer.sln`
- `/root/.dotnet/dotnet test VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689cf8abc80c832ebaaf4edd78c62053