### PR TITLE
Add pagination parameters to relationship methods

### DIFF
--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.AnalysisRelationships.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.AnalysisRelationships.cs
@@ -36,6 +36,26 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetFileContactedUrlsAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetFileContactedUrlsAsync("abc", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
+    }
+
+    [Fact]
     public async Task GetFileContactedDomainsAsync_UsesCorrectPathAndDeserializesResponse()
     {
         var json = "{\"data\":[{\"id\":\"d1\",\"type\":\"domain\",\"data\":{\"attributes\":{\"domain\":\"example.com\"}}}]}";
@@ -57,6 +77,26 @@ public partial class VirusTotalClientTests
         Assert.NotNull(domains);
         Assert.Single(domains!);
         Assert.Equal("example.com", domains[0].Data.Attributes.Domain);
+    }
+
+    [Fact]
+    public async Task GetFileContactedDomainsAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetFileContactedDomainsAsync("abc", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
     }
 
     [Fact]
@@ -84,6 +124,26 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetFileContactedIpsAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetFileContactedIpsAsync("abc", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
+    }
+
+    [Fact]
     public async Task GetFileReferrerFilesAsync_UsesCorrectPathAndDeserializesResponse()
     {
         var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"attributes\":{\"md5\":\"abc\"}}]}";
@@ -105,6 +165,26 @@ public partial class VirusTotalClientTests
         Assert.NotNull(files);
         Assert.Single(files!);
         Assert.Equal("abc", files[0].Attributes.Md5);
+    }
+
+    [Fact]
+    public async Task GetFileReferrerFilesAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetFileReferrerFilesAsync("abc", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
     }
 
 
@@ -134,6 +214,26 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetFileDownloadedFilesAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetFileDownloadedFilesAsync("abc", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
+    }
+
+    [Fact]
     public async Task GetFileBundledFilesAsync_UsesCorrectPathAndDeserializesResponse()
     {
         var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"attributes\":{\"md5\":\"abc\"}}]}";
@@ -155,6 +255,26 @@ public partial class VirusTotalClientTests
         Assert.NotNull(files);
         Assert.Single(files!);
         Assert.Equal("abc", files[0].Attributes.Md5);
+    }
+
+    [Fact]
+    public async Task GetFileBundledFilesAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetFileBundledFilesAsync("abc", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
     }
 
     [Fact]
@@ -182,6 +302,26 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetFileDroppedFilesAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetFileDroppedFilesAsync("abc", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
+    }
+
+    [Fact]
     public async Task GetFileSimilarFilesAsync_UsesCorrectPathAndDeserializesResponse()
     {
         var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"attributes\":{\"md5\":\"abc\"}}]}";
@@ -203,6 +343,26 @@ public partial class VirusTotalClientTests
         Assert.NotNull(files);
         Assert.Single(files!);
         Assert.Equal("abc", files[0].Attributes.Md5);
+    }
+
+    [Fact]
+    public async Task GetFileSimilarFilesAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetFileSimilarFilesAsync("abc", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
     }
 
     [Fact]
@@ -230,6 +390,26 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetUrlDownloadedFilesAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetUrlDownloadedFilesAsync("abc", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
+    }
+
+    [Fact]
     public async Task GetUrlReferrerFilesAsync_UsesCorrectPathAndDeserializesResponse()
     {
         var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"attributes\":{\"md5\":\"abc\"}}]}";
@@ -251,6 +431,26 @@ public partial class VirusTotalClientTests
         Assert.NotNull(files);
         Assert.Single(files!);
         Assert.Equal("abc", files[0].Attributes.Md5);
+    }
+
+    [Fact]
+    public async Task GetUrlReferrerFilesAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetUrlReferrerFilesAsync("abc", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
     }
 
     [Fact]
@@ -278,6 +478,26 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetUrlRedirectingUrlsAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetUrlRedirectingUrlsAsync("abc", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
+    }
+
+    [Fact]
     public async Task GetUrlContactedIpsAsync_UsesCorrectPathAndDeserializesResponse()
     {
         var json = "{\"data\":[{\"id\":\"i1\",\"type\":\"ip_address\",\"data\":{\"attributes\":{\"ip_address\":\"1.2.3.4\"}}}]}";
@@ -299,6 +519,26 @@ public partial class VirusTotalClientTests
         Assert.NotNull(ips);
         Assert.Single(ips!);
         Assert.Equal("1.2.3.4", ips[0].Data.Attributes.IpAddress);
+    }
+
+    [Fact]
+    public async Task GetUrlContactedIpsAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetUrlContactedIpsAsync("abc", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
     }
 
     [Fact]

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.DomainRelationships.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.DomainRelationships.cs
@@ -35,6 +35,26 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetDomainSubdomainsAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetDomainSubdomainsAsync("example.com", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
+    }
+
+    [Fact]
     public async Task GetDomainSiblingsAsync_UsesCorrectPathAndDeserializesResponse()
     {
         var json = "{\"data\":[{\"id\":\"d1\",\"type\":\"domain\",\"data\":{\"attributes\":{\"domain\":\"sibling.com\"}}}]}";
@@ -59,6 +79,26 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetDomainSiblingsAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetDomainSiblingsAsync("example.com", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
+    }
+
+    [Fact]
     public async Task GetDomainUrlsAsync_UsesCorrectPathAndDeserializesResponse()
     {
         var json = "{\"data\":[{\"id\":\"u1\",\"type\":\"url\",\"data\":{\"attributes\":{\"url\":\"http://example.com/\"}}}]}";
@@ -80,6 +120,26 @@ public partial class VirusTotalClientTests
         Assert.NotNull(urls);
         Assert.Single(urls!);
         Assert.Equal("http://example.com/", urls[0].Data.Attributes.Url);
+    }
+
+    [Fact]
+    public async Task GetDomainUrlsAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetDomainUrlsAsync("example.com", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
     }
 
     [Fact]
@@ -109,6 +169,26 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetDomainDnsRecordsAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetDomainDnsRecordsAsync("example.com", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
+    }
+
+    [Fact]
     public async Task GetDomainReferrerFilesAsync_UsesCorrectPathAndDeserializesResponse()
     {
         var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"attributes\":{\"md5\":\"abc\"}}]}";
@@ -133,6 +213,26 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetDomainReferrerFilesAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetDomainReferrerFilesAsync("example.com", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
+    }
+
+    [Fact]
     public async Task GetDomainDownloadedFilesAsync_UsesCorrectPathAndDeserializesResponse()
     {
         var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"attributes\":{\"md5\":\"abc\"}}]}";
@@ -154,5 +254,25 @@ public partial class VirusTotalClientTests
         Assert.NotNull(files);
         Assert.Single(files!);
         Assert.Equal("abc", files[0].Attributes.Md5);
+    }
+
+    [Fact]
+    public async Task GetDomainDownloadedFilesAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetDomainDownloadedFilesAsync("example.com", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
     }
 }

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Relationships.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Relationships.cs
@@ -239,6 +239,26 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetIpAddressCommunicatingFilesAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetIpAddressCommunicatingFilesAsync("1.2.3.4", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
+    }
+
+    [Fact]
     public async Task GetIpAddressDownloadedFilesAsync_UsesCorrectPathAndDeserializesResponse()
     {
         var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"attributes\":{\"md5\":\"abc\"}}]}";
@@ -260,6 +280,26 @@ public partial class VirusTotalClientTests
         Assert.NotNull(files);
         Assert.Single(files!);
         Assert.Equal("abc", files[0].Attributes.Md5);
+    }
+
+    [Fact]
+    public async Task GetIpAddressDownloadedFilesAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetIpAddressDownloadedFilesAsync("1.2.3.4", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
     }
 
     [Fact]
@@ -287,6 +327,26 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetIpAddressReferrerFilesAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetIpAddressReferrerFilesAsync("1.2.3.4", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
+    }
+
+    [Fact]
     public async Task GetIpAddressUrlsAsync_UsesCorrectPathAndDeserializesResponse()
     {
         var json = "{\"data\":[{\"id\":\"u1\",\"type\":\"url\",\"data\":{\"attributes\":{\"url\":\"http://example.com/\"}}}]}";
@@ -308,5 +368,25 @@ public partial class VirusTotalClientTests
         Assert.NotNull(urls);
         Assert.Single(urls!);
         Assert.Equal("http://example.com/", urls[0].Data.Attributes.Url);
+    }
+
+    [Fact]
+    public async Task GetIpAddressUrlsAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetIpAddressUrlsAsync("1.2.3.4", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
     }
 }

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.UrlGraphs.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.UrlGraphs.cs
@@ -47,5 +47,27 @@ public partial class VirusTotalClientTests
         Assert.Equal("/api/v3/graphs/g1", handler.Requests[1].RequestUri!.AbsolutePath);
         Assert.Equal("/api/v3/graphs/g2", handler.Requests[2].RequestUri!.AbsolutePath);
     }
+
+    [Fact]
+    public async Task GetUrlGraphsAsync_BuildsQueryWithLimitAndCursor()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"data\":[]}", Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var graphs = await client.GetUrlGraphsAsync("url-id", limit: 10, cursor: "abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
+        Assert.NotNull(graphs);
+        Assert.Empty(graphs);
+    }
 }
 

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -154,9 +154,24 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
-    public async Task<IReadOnlyList<UrlSummary>?> GetFileContactedUrlsAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<UrlSummary>?> GetFileContactedUrlsAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/contacted_urls", cancellationToken).ConfigureAwait(false);
+        var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/contacted_urls");
+        var hasQuery = false;
+        if (limit.HasValue)
+        {
+            path.Append("?limit=").Append(limit.Value);
+            hasQuery = true;
+        }
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -167,9 +182,24 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
-    public async Task<IReadOnlyList<DomainSummary>?> GetFileContactedDomainsAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<DomainSummary>?> GetFileContactedDomainsAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/contacted_domains", cancellationToken).ConfigureAwait(false);
+        var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/contacted_domains");
+        var hasQuery = false;
+        if (limit.HasValue)
+        {
+            path.Append("?limit=").Append(limit.Value);
+            hasQuery = true;
+        }
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -180,9 +210,24 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
-    public async Task<IReadOnlyList<IpAddressSummary>?> GetFileContactedIpsAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<IpAddressSummary>?> GetFileContactedIpsAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/contacted_ips", cancellationToken).ConfigureAwait(false);
+        var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/contacted_ips");
+        var hasQuery = false;
+        if (limit.HasValue)
+        {
+            path.Append("?limit=").Append(limit.Value);
+            hasQuery = true;
+        }
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -193,9 +238,24 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
-    public async Task<IReadOnlyList<FileReport>?> GetFileReferrerFilesAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<FileReport>?> GetFileReferrerFilesAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/referrer_files", cancellationToken).ConfigureAwait(false);
+        var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/referrer_files");
+        var hasQuery = false;
+        if (limit.HasValue)
+        {
+            path.Append("?limit=").Append(limit.Value);
+            hasQuery = true;
+        }
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -206,9 +266,24 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
-    public async Task<IReadOnlyList<FileReport>?> GetFileDownloadedFilesAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<FileReport>?> GetFileDownloadedFilesAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/downloaded_files", cancellationToken).ConfigureAwait(false);
+        var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/downloaded_files");
+        var hasQuery = false;
+        if (limit.HasValue)
+        {
+            path.Append("?limit=").Append(limit.Value);
+            hasQuery = true;
+        }
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -219,9 +294,24 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
-    public async Task<IReadOnlyList<FileReport>?> GetFileBundledFilesAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<FileReport>?> GetFileBundledFilesAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/bundled_files", cancellationToken).ConfigureAwait(false);
+        var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/bundled_files");
+        var hasQuery = false;
+        if (limit.HasValue)
+        {
+            path.Append("?limit=").Append(limit.Value);
+            hasQuery = true;
+        }
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -232,9 +322,24 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
-    public async Task<IReadOnlyList<FileReport>?> GetFileDroppedFilesAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<FileReport>?> GetFileDroppedFilesAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/dropped_files", cancellationToken).ConfigureAwait(false);
+        var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/dropped_files");
+        var hasQuery = false;
+        if (limit.HasValue)
+        {
+            path.Append("?limit=").Append(limit.Value);
+            hasQuery = true;
+        }
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -245,9 +350,24 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
-    public async Task<IReadOnlyList<FileReport>?> GetFileSimilarFilesAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<FileReport>?> GetFileSimilarFilesAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/similar_files", cancellationToken).ConfigureAwait(false);
+        var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/similar_files");
+        var hasQuery = false;
+        if (limit.HasValue)
+        {
+            path.Append("?limit=").Append(limit.Value);
+            hasQuery = true;
+        }
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -395,9 +515,24 @@ public sealed partial class VirusTotalClient
         return (results, nextCursor);
     }
 
-    public async Task<IReadOnlyList<FileReport>?> GetUrlDownloadedFilesAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<FileReport>?> GetUrlDownloadedFilesAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"urls/{Uri.EscapeDataString(id)}/downloaded_files", cancellationToken).ConfigureAwait(false);
+        var path = new System.Text.StringBuilder($"urls/{Uri.EscapeDataString(id)}/downloaded_files");
+        var hasQuery = false;
+        if (limit.HasValue)
+        {
+            path.Append("?limit=").Append(limit.Value);
+            hasQuery = true;
+        }
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -408,9 +543,24 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
-    public async Task<IReadOnlyList<FileReport>?> GetUrlReferrerFilesAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<FileReport>?> GetUrlReferrerFilesAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"urls/{Uri.EscapeDataString(id)}/referrer_files", cancellationToken).ConfigureAwait(false);
+        var path = new System.Text.StringBuilder($"urls/{Uri.EscapeDataString(id)}/referrer_files");
+        var hasQuery = false;
+        if (limit.HasValue)
+        {
+            path.Append("?limit=").Append(limit.Value);
+            hasQuery = true;
+        }
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -421,9 +571,24 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
-    public async Task<IReadOnlyList<UrlSummary>?> GetUrlRedirectingUrlsAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<UrlSummary>?> GetUrlRedirectingUrlsAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"urls/{Uri.EscapeDataString(id)}/redirecting_urls", cancellationToken).ConfigureAwait(false);
+        var path = new System.Text.StringBuilder($"urls/{Uri.EscapeDataString(id)}/redirecting_urls");
+        var hasQuery = false;
+        if (limit.HasValue)
+        {
+            path.Append("?limit=").Append(limit.Value);
+            hasQuery = true;
+        }
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -434,9 +599,24 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
-    public async Task<IReadOnlyList<IpAddressSummary>?> GetUrlContactedIpsAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<IpAddressSummary>?> GetUrlContactedIpsAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"urls/{Uri.EscapeDataString(id)}/contacted_ips", cancellationToken).ConfigureAwait(false);
+        var path = new System.Text.StringBuilder($"urls/{Uri.EscapeDataString(id)}/contacted_ips");
+        var hasQuery = false;
+        if (limit.HasValue)
+        {
+            path.Append("?limit=").Append(limit.Value);
+            hasQuery = true;
+        }
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);

--- a/VirusTotalAnalyzer/VirusTotalClient.Relationships.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Relationships.cs
@@ -24,9 +24,13 @@ public sealed partial class VirusTotalClient
         CancellationToken cancellationToken = default)
         => GetSubmissionsAsync(ResourceType.Url, id, limit, cursor, cancellationToken);
 
-    public async Task<IReadOnlyList<Graph>> GetUrlGraphsAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<Graph>> GetUrlGraphsAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
     {
-        var relationships = await GetRelationshipsAsync(ResourceType.Url, id, "graphs", cancellationToken: cancellationToken).ConfigureAwait(false);
+        var relationships = await GetRelationshipsAsync(ResourceType.Url, id, "graphs", limit, cursor, cancellationToken).ConfigureAwait(false);
         if (relationships == null || relationships.Data.Count == 0)
         {
             return Array.Empty<Graph>();
@@ -59,23 +63,47 @@ public sealed partial class VirusTotalClient
         CancellationToken cancellationToken = default)
         => GetSubmissionsAsync(ResourceType.Domain, id, limit, cursor, cancellationToken);
 
-    public Task<IReadOnlyList<DomainSummary>?> GetDomainSubdomainsAsync(string id, CancellationToken cancellationToken = default)
-        => GetDomainRelationshipsAsync<DomainSubdomainsResponse, DomainSummary>(id, "subdomains", r => r.Data, cancellationToken);
+    public Task<IReadOnlyList<DomainSummary>?> GetDomainSubdomainsAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
+        => GetDomainRelationshipsAsync<DomainSubdomainsResponse, DomainSummary>(id, "subdomains", r => r.Data, limit, cursor, cancellationToken);
 
-    public Task<IReadOnlyList<DomainSummary>?> GetDomainSiblingsAsync(string id, CancellationToken cancellationToken = default)
-        => GetDomainRelationshipsAsync<DomainSiblingsResponse, DomainSummary>(id, "siblings", r => r.Data, cancellationToken);
+    public Task<IReadOnlyList<DomainSummary>?> GetDomainSiblingsAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
+        => GetDomainRelationshipsAsync<DomainSiblingsResponse, DomainSummary>(id, "siblings", r => r.Data, limit, cursor, cancellationToken);
 
-    public Task<IReadOnlyList<UrlSummary>?> GetDomainUrlsAsync(string id, CancellationToken cancellationToken = default)
-        => GetDomainRelationshipsAsync<DomainUrlsResponse, UrlSummary>(id, "urls", r => r.Data, cancellationToken);
+    public Task<IReadOnlyList<UrlSummary>?> GetDomainUrlsAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
+        => GetDomainRelationshipsAsync<DomainUrlsResponse, UrlSummary>(id, "urls", r => r.Data, limit, cursor, cancellationToken);
 
-    public Task<IReadOnlyList<DnsRecord>?> GetDomainDnsRecordsAsync(string id, CancellationToken cancellationToken = default)
-        => GetDomainRelationshipsAsync<DnsRecordsResponse, DnsRecord>(id, "dns_records", r => r.Data, cancellationToken);
+    public Task<IReadOnlyList<DnsRecord>?> GetDomainDnsRecordsAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
+        => GetDomainRelationshipsAsync<DnsRecordsResponse, DnsRecord>(id, "dns_records", r => r.Data, limit, cursor, cancellationToken);
 
-    public Task<IReadOnlyList<FileReport>?> GetDomainReferrerFilesAsync(string id, CancellationToken cancellationToken = default)
-        => GetDomainRelationshipsAsync<FileReportsResponse, FileReport>(id, "referrer_files", r => r.Data, cancellationToken);
+    public Task<IReadOnlyList<FileReport>?> GetDomainReferrerFilesAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
+        => GetDomainRelationshipsAsync<FileReportsResponse, FileReport>(id, "referrer_files", r => r.Data, limit, cursor, cancellationToken);
 
-    public Task<IReadOnlyList<FileReport>?> GetDomainDownloadedFilesAsync(string id, CancellationToken cancellationToken = default)
-        => GetDomainRelationshipsAsync<FileReportsResponse, FileReport>(id, "downloaded_files", r => r.Data, cancellationToken);
+    public Task<IReadOnlyList<FileReport>?> GetDomainDownloadedFilesAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
+        => GetDomainRelationshipsAsync<FileReportsResponse, FileReport>(id, "downloaded_files", r => r.Data, limit, cursor, cancellationToken);
 
     public Task<IReadOnlyList<Resolution>?> GetIpAddressResolutionsAsync(
         string id,
@@ -91,9 +119,24 @@ public sealed partial class VirusTotalClient
         CancellationToken cancellationToken = default)
         => GetSubmissionsAsync(ResourceType.IpAddress, id, limit, cursor, cancellationToken);
 
-    public async Task<IReadOnlyList<FileReport>?> GetIpAddressCommunicatingFilesAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<FileReport>?> GetIpAddressCommunicatingFilesAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"ip_addresses/{Uri.EscapeDataString(id)}/communicating_files", cancellationToken).ConfigureAwait(false);
+        var path = new System.Text.StringBuilder($"ip_addresses/{Uri.EscapeDataString(id)}/communicating_files");
+        var hasQuery = false;
+        if (limit.HasValue)
+        {
+            path.Append("?limit=").Append(limit.Value);
+            hasQuery = true;
+        }
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -104,9 +147,24 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
-    public async Task<IReadOnlyList<FileReport>?> GetIpAddressDownloadedFilesAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<FileReport>?> GetIpAddressDownloadedFilesAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"ip_addresses/{Uri.EscapeDataString(id)}/downloaded_files", cancellationToken).ConfigureAwait(false);
+        var path = new System.Text.StringBuilder($"ip_addresses/{Uri.EscapeDataString(id)}/downloaded_files");
+        var hasQuery = false;
+        if (limit.HasValue)
+        {
+            path.Append("?limit=").Append(limit.Value);
+            hasQuery = true;
+        }
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -117,9 +175,24 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
-    public async Task<IReadOnlyList<FileReport>?> GetIpAddressReferrerFilesAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<FileReport>?> GetIpAddressReferrerFilesAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"ip_addresses/{Uri.EscapeDataString(id)}/referrer_files", cancellationToken).ConfigureAwait(false);
+        var path = new System.Text.StringBuilder($"ip_addresses/{Uri.EscapeDataString(id)}/referrer_files");
+        var hasQuery = false;
+        if (limit.HasValue)
+        {
+            path.Append("?limit=").Append(limit.Value);
+            hasQuery = true;
+        }
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -130,9 +203,24 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
-    public async Task<IReadOnlyList<UrlSummary>?> GetIpAddressUrlsAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<UrlSummary>?> GetIpAddressUrlsAsync(
+        string id,
+        int? limit = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"ip_addresses/{Uri.EscapeDataString(id)}/urls", cancellationToken).ConfigureAwait(false);
+        var path = new System.Text.StringBuilder($"ip_addresses/{Uri.EscapeDataString(id)}/urls");
+        var hasQuery = false;
+        if (limit.HasValue)
+        {
+            path.Append("?limit=").Append(limit.Value);
+            hasQuery = true;
+        }
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -147,9 +235,23 @@ public sealed partial class VirusTotalClient
         string id,
         string relationship,
         Func<TResponse, List<T>> selector,
+        int? limit,
+        string? cursor,
         CancellationToken cancellationToken)
     {
-        using var response = await _httpClient.GetAsync($"domains/{Uri.EscapeDataString(id)}/{Uri.EscapeDataString(relationship)}", cancellationToken).ConfigureAwait(false);
+        var path = new System.Text.StringBuilder($"domains/{Uri.EscapeDataString(id)}/{Uri.EscapeDataString(relationship)}");
+        var hasQuery = false;
+        if (limit.HasValue)
+        {
+            path.Append("?limit=").Append(limit.Value);
+            hasQuery = true;
+        }
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
+        }
+
+        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- support `limit` and `cursor` pagination in domain, IP, file and URL relationship helpers
- implement query-string construction for `GetUrlGraphsAsync` and other relationship calls
- add unit tests validating pagination query generation across relationship APIs

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689d891db5dc832e93993f645fd7da28