### PR TITLE
Add URL submission options and query parameter tests

### DIFF
--- a/VirusTotalAnalyzer.Examples/SubmitUrlExample.cs
+++ b/VirusTotalAnalyzer.Examples/SubmitUrlExample.cs
@@ -12,10 +12,11 @@ public static class SubmitUrlExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.SubmitUrlAsync("https://example.com");
+            var report = await client.SubmitUrlAsync("https://example.com", waitForCompletion: true);
             Console.WriteLine(report?.Id);
 
-            var simple = await client.SubmitUrlAsync("https://example.org", CancellationToken.None);
+            var options = new SubmitUrlOptions { WaitForCompletion = true, Analyze = false };
+            var simple = await client.SubmitUrlAsync("https://example.org", options, CancellationToken.None);
             Console.WriteLine(simple?.Id);
         }
         catch (RateLimitExceededException ex)

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
@@ -237,6 +237,7 @@ public partial class VirusTotalClientTests
         var request = handler.Request!;
         Assert.Equal(HttpMethod.Post, request.Method);
         Assert.Equal("/api/v3/urls", request.RequestUri!.AbsolutePath);
+        Assert.Equal(string.Empty, request.RequestUri!.Query);
         Assert.Equal("application/x-www-form-urlencoded", request.Content!.Headers.ContentType!.MediaType);
         Assert.Equal("url=https%3A%2F%2Fexample.com", handler.Content);
     }

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.UrlOptions.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.UrlOptions.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public partial class VirusTotalClientTests
+{
+    [Fact]
+    public async Task SubmitUrlAsync_WaitForCompletion_AddsQueryParameter()
+    {
+        var json = "{\"id\":\"an\",\"type\":\"analysis\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var report = await client.SubmitUrlAsync("https://example.com", waitForCompletion: true);
+
+        Assert.NotNull(report);
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?wait_for_completion=true", handler.Request!.RequestUri!.Query);
+    }
+
+    [Fact]
+    public async Task SubmitUrlAsync_AnalyzeFalse_AddsQueryParameter()
+    {
+        var json = "{\"id\":\"an\",\"type\":\"analysis\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var report = await client.SubmitUrlAsync("https://example.com", waitForCompletion: false, analyze: false);
+
+        Assert.NotNull(report);
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?analyze=false", handler.Request!.RequestUri!.Query);
+    }
+
+    [Fact]
+    public async Task SubmitUrlAsync_WithOptions_BuildsCombinedQuery()
+    {
+        var json = "{\"id\":\"an\",\"type\":\"analysis\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+        var options = new SubmitUrlOptions { WaitForCompletion = true, Analyze = true };
+
+        var report = await client.SubmitUrlAsync("https://example.com", options);
+
+        Assert.NotNull(report);
+        Assert.NotNull(handler.Request);
+        Assert.Equal("?wait_for_completion=true&analyze=true", handler.Request!.RequestUri!.Query);
+    }
+}

--- a/VirusTotalAnalyzer/SubmitUrlOptions.cs
+++ b/VirusTotalAnalyzer/SubmitUrlOptions.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace VirusTotalAnalyzer;
+
+/// <summary>
+/// Options for <see cref="VirusTotalClient.SubmitUrlAsync(string, SubmitUrlOptions?, System.Threading.CancellationToken)"/>.
+/// </summary>
+public sealed class SubmitUrlOptions
+{
+    /// <summary>
+    /// When set to <see langword="true"/>, the request will block until the analysis completes.
+    /// </summary>
+    public bool WaitForCompletion { get; set; }
+
+    /// <summary>
+    /// Controls whether the URL should be analyzed after submission. If <see langword="null"/>,
+    /// the API default is used.
+    /// </summary>
+    public bool? Analyze { get; set; }
+}


### PR DESCRIPTION
## Summary
- extend `SubmitUrlAsync` to accept `SubmitUrlOptions` or inline parameters
- support `wait_for_completion` and `analyze` query parameters
- cover URL submission options with unit tests

## Testing
- `dotnet test VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj -p:TargetFrameworks=net8.0 -p:TargetFramework=net8.0 -p:RestoreTargetFrameworks=net8.0`


------
https://chatgpt.com/codex/tasks/task_e_689d98438df0832eb027c140154b4d9d