### PR TITLE
Add batch report retrieval methods

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetFileReportsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileReportsExample.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetFileReportsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var reports = await client.GetFileReportsAsync(new[]
+            {
+                "44d88612fea8a8f36de82e1278abb02f",
+                "275a021bbfb6480f86abdb2d8d0060dd"
+            });
+            foreach (var report in reports ?? Array.Empty<FileReport>())
+            {
+                Console.WriteLine(report.Id);
+            }
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Examples/Program.cs
+++ b/VirusTotalAnalyzer.Examples/Program.cs
@@ -4,6 +4,7 @@ using VirusTotalAnalyzer.Examples;
 // Uncomment the example you want to run.
 
 // await GetFileReportExample.RunAsync();
+// await GetFileReportsExample.RunAsync();
 // await GetUrlReportExample.RunAsync();
 // await GetUrlReportFromUrlExample.RunAsync();
 // await GetUrlRelationshipsExample.RunAsync();

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.MultipleIds.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.MultipleIds.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public partial class VirusTotalClientTests
+{
+    [Fact]
+    public async Task GetFileReportsAsync_ReturnsCombinedResults()
+    {
+        var json = "{\"data\":[{\"id\":\"a\",\"type\":\"file\"},{\"id\":\"b\",\"type\":\"file\"}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var reports = await client.GetFileReportsAsync(new[] { "a", "b" });
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/files", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal("ids=a,b", handler.Request.RequestUri.Query.TrimStart('?'));
+        Assert.NotNull(reports);
+        Assert.Collection(reports!,
+            r => Assert.Equal("a", r.Id),
+            r => Assert.Equal("b", r.Id));
+    }
+
+    [Fact]
+    public async Task GetUrlReportsAsync_ReturnsCombinedResults()
+    {
+        var json = "{\"data\":[{\"id\":\"u1\",\"type\":\"url\"},{\"id\":\"u2\",\"type\":\"url\"}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var reports = await client.GetUrlReportsAsync(new[] { "u1", "u2" });
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/urls", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal("ids=u1,u2", handler.Request.RequestUri.Query.TrimStart('?'));
+        Assert.NotNull(reports);
+        Assert.Collection(reports!,
+            r => Assert.Equal("u1", r.Id),
+            r => Assert.Equal("u2", r.Id));
+    }
+
+    [Fact]
+    public async Task GetIpAddressReportsAsync_ReturnsCombinedResults()
+    {
+        var json = "{\"data\":[{\"id\":\"1.1.1.1\",\"type\":\"ip_address\"},{\"id\":\"8.8.8.8\",\"type\":\"ip_address\"}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var reports = await client.GetIpAddressReportsAsync(new[] { "1.1.1.1", "8.8.8.8" });
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/ip_addresses", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal("ids=1.1.1.1,8.8.8.8", handler.Request.RequestUri.Query.TrimStart('?'));
+        Assert.NotNull(reports);
+        Assert.Collection(reports!,
+            r => Assert.Equal("1.1.1.1", r.Id),
+            r => Assert.Equal("8.8.8.8", r.Id));
+    }
+
+    [Fact]
+    public async Task GetDomainReportsAsync_ReturnsCombinedResults()
+    {
+        var json = "{\"data\":[{\"id\":\"example.com\",\"type\":\"domain\"},{\"id\":\"vt.com\",\"type\":\"domain\"}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var reports = await client.GetDomainReportsAsync(new[] { "example.com", "vt.com" });
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/domains", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal("ids=example.com,vt.com", handler.Request.RequestUri.Query.TrimStart('?'));
+        Assert.NotNull(reports);
+        Assert.Collection(reports!,
+            r => Assert.Equal("example.com", r.Id),
+            r => Assert.Equal("vt.com", r.Id));
+    }
+
+    [Fact]
+    public async Task GetAnalysesAsync_ReturnsCombinedResults()
+    {
+        var json = "{\"data\":[{\"id\":\"a1\",\"type\":\"analysis\",\"data\":{\"attributes\":{}}},{\"id\":\"a2\",\"type\":\"analysis\",\"data\":{\"attributes\":{}}}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var reports = await client.GetAnalysesAsync(new[] { "a1", "a2" });
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/analyses", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal("ids=a1,a2", handler.Request.RequestUri.Query.TrimStart('?'));
+        Assert.NotNull(reports);
+        Assert.Collection(reports!,
+            r => Assert.Equal("a1", r.Id),
+            r => Assert.Equal("a2", r.Id));
+    }
+}

--- a/VirusTotalAnalyzer/Models/DomainReport.cs
+++ b/VirusTotalAnalyzer/Models/DomainReport.cs
@@ -19,6 +19,15 @@ public sealed class DomainReportResponse
     public DomainReport Data { get; set; } = new();
 }
 
+public sealed class DomainReportsResponse
+{
+    [JsonPropertyName("data")]
+    public List<DomainReport> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public PaginationMetadata? Meta { get; set; }
+}
+
 public sealed class DomainAttributes
 {
     [JsonPropertyName("domain")]

--- a/VirusTotalAnalyzer/Models/IpAddressReport.cs
+++ b/VirusTotalAnalyzer/Models/IpAddressReport.cs
@@ -19,6 +19,15 @@ public sealed class IpAddressReportResponse
     public IpAddressReport Data { get; set; } = new();
 }
 
+public sealed class IpAddressReportsResponse
+{
+    [JsonPropertyName("data")]
+    public List<IpAddressReport> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public PaginationMetadata? Meta { get; set; }
+}
+
 public sealed class IpAddressAttributes
 {
     [JsonPropertyName("ip_address")]

--- a/VirusTotalAnalyzer/Models/UrlReport.cs
+++ b/VirusTotalAnalyzer/Models/UrlReport.cs
@@ -19,6 +19,15 @@ public sealed class UrlReportResponse
     public UrlReport Data { get; set; } = new();
 }
 
+public sealed class UrlReportsResponse
+{
+    [JsonPropertyName("data")]
+    public List<UrlReport> Data { get; set; } = new();
+
+    [JsonPropertyName("meta")]
+    public PaginationMetadata? Meta { get; set; }
+}
+
 public sealed class UrlAttributes
 {
     [JsonPropertyName("url")]

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -15,6 +15,38 @@ namespace VirusTotalAnalyzer;
 
 public sealed partial class VirusTotalClient
 {
+    public async Task<IReadOnlyList<FileReport>?> GetFileReportsAsync(
+        IEnumerable<string> ids,
+        IEnumerable<string>? fields = null,
+        IEnumerable<string>? relationships = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (ids == null) throw new ArgumentNullException(nameof(ids));
+        var url = new StringBuilder("files?ids=")
+            .Append(string.Join(",", ids.Select(Uri.EscapeDataString)));
+
+        if (fields != null && fields.Any())
+        {
+            url.Append("&fields=").Append(string.Join(",", fields.Select(Uri.EscapeDataString)));
+        }
+
+        if (relationships != null && relationships.Any())
+        {
+            url.Append("&relationships=").Append(string.Join(",", relationships.Select(Uri.EscapeDataString)));
+        }
+
+        using var response = await _httpClient.GetAsync(url.ToString(), cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<FileReportsResponse>(stream, _jsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+        return result?.Data;
+    }
+
     public async Task<FileReport?> GetFileReportAsync(
         string id,
         IEnumerable<string>? fields = null,
@@ -410,6 +442,38 @@ public sealed partial class VirusTotalClient
         return new StreamWithResponse(response, stream);
     }
 
+    public async Task<IReadOnlyList<UrlReport>?> GetUrlReportsAsync(
+        IEnumerable<string> ids,
+        IEnumerable<string>? fields = null,
+        IEnumerable<string>? relationships = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (ids == null) throw new ArgumentNullException(nameof(ids));
+        var url = new StringBuilder("urls?ids=")
+            .Append(string.Join(",", ids.Select(Uri.EscapeDataString)));
+
+        if (fields != null && fields.Any())
+        {
+            url.Append("&fields=").Append(string.Join(",", fields.Select(Uri.EscapeDataString)));
+        }
+
+        if (relationships != null && relationships.Any())
+        {
+            url.Append("&relationships=").Append(string.Join(",", relationships.Select(Uri.EscapeDataString)));
+        }
+
+        using var response = await _httpClient.GetAsync(url.ToString(), cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<UrlReportsResponse>(stream, _jsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+        return result?.Data;
+    }
+
     public async Task<UrlReport?> GetUrlReportAsync(
         string id,
         IEnumerable<string>? fields = null,
@@ -641,6 +705,38 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
+    public async Task<IReadOnlyList<IpAddressReport>?> GetIpAddressReportsAsync(
+        IEnumerable<string> ids,
+        IEnumerable<string>? fields = null,
+        IEnumerable<string>? relationships = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (ids == null) throw new ArgumentNullException(nameof(ids));
+        var url = new StringBuilder("ip_addresses?ids=")
+            .Append(string.Join(",", ids.Select(Uri.EscapeDataString)));
+
+        if (fields != null && fields.Any())
+        {
+            url.Append("&fields=").Append(string.Join(",", fields.Select(Uri.EscapeDataString)));
+        }
+
+        if (relationships != null && relationships.Any())
+        {
+            url.Append("&relationships=").Append(string.Join(",", relationships.Select(Uri.EscapeDataString)));
+        }
+
+        using var response = await _httpClient.GetAsync(url.ToString(), cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<IpAddressReportsResponse>(stream, _jsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+        return result?.Data;
+    }
+
     public async Task<IpAddressReport?> GetIpAddressReportAsync(
         string id,
         IEnumerable<string>? fields = null,
@@ -688,6 +784,38 @@ public sealed partial class VirusTotalClient
             .ConfigureAwait(false);
     }
 
+    public async Task<IReadOnlyList<DomainReport>?> GetDomainReportsAsync(
+        IEnumerable<string> ids,
+        IEnumerable<string>? fields = null,
+        IEnumerable<string>? relationships = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (ids == null) throw new ArgumentNullException(nameof(ids));
+        var url = new StringBuilder("domains?ids=")
+            .Append(string.Join(",", ids.Select(Uri.EscapeDataString)));
+
+        if (fields != null && fields.Any())
+        {
+            url.Append("&fields=").Append(string.Join(",", fields.Select(Uri.EscapeDataString)));
+        }
+
+        if (relationships != null && relationships.Any())
+        {
+            url.Append("&relationships=").Append(string.Join(",", relationships.Select(Uri.EscapeDataString)));
+        }
+
+        using var response = await _httpClient.GetAsync(url.ToString(), cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<DomainReportsResponse>(stream, _jsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+        return result?.Data;
+    }
+
     public async Task<DomainReport?> GetDomainReportAsync(
         string id,
         IEnumerable<string>? fields = null,
@@ -733,6 +861,38 @@ public sealed partial class VirusTotalClient
 #endif
         return await JsonSerializer.DeserializeAsync<DomainWhois>(stream, _jsonOptions, cancellationToken)
             .ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<AnalysisReport>?> GetAnalysesAsync(
+        IEnumerable<string> ids,
+        IEnumerable<string>? fields = null,
+        IEnumerable<string>? relationships = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (ids == null) throw new ArgumentNullException(nameof(ids));
+        var url = new StringBuilder("analyses?ids=")
+            .Append(string.Join(",", ids.Select(Uri.EscapeDataString)));
+
+        if (fields != null && fields.Any())
+        {
+            url.Append("&fields=").Append(string.Join(",", fields.Select(Uri.EscapeDataString)));
+        }
+
+        if (relationships != null && relationships.Any())
+        {
+            url.Append("&relationships=").Append(string.Join(",", relationships.Select(Uri.EscapeDataString)));
+        }
+
+        using var response = await _httpClient.GetAsync(url.ToString(), cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+#if NET472
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+        var result = await JsonSerializer.DeserializeAsync<AnalysisReportsResponse>(stream, _jsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+        return result?.Data;
     }
 
     public async Task<AnalysisReport?> GetAnalysisAsync(string id, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- support retrieving multiple file reports via `GetFileReportsAsync`
- add batch report methods for URLs, IP addresses, domains, and analyses
- add example and unit tests for multiple ID queries

## Testing
- `dotnet build`
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_689d9853efa8832eb27e48399c35df2b