### PR TITLE
Add pagination to file relationship methods

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetFileContactedUrlsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileContactedUrlsExample.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetFileContactedUrlsExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var page = await client.GetFileContactedUrlsAsync("44d88612fea8a8f36de82e1278abb02f");
+            foreach (var url in page?.Data ?? new List<UrlSummary>())
+            {
+                Console.WriteLine(url.Data.Attributes.Url);
+            }
+            if (!string.IsNullOrEmpty(page?.NextCursor))
+            {
+                Console.WriteLine($"More URLs available. Next cursor: {page.NextCursor}");
+            }
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.AnalysisRelationships.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.AnalysisRelationships.cs
@@ -14,7 +14,7 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task GetFileContactedUrlsAsync_UsesCorrectPathAndDeserializesResponse()
     {
-        var json = "{\"data\":[{\"id\":\"u1\",\"type\":\"url\",\"data\":{\"attributes\":{\"url\":\"https://example.com\"}}}]}";
+        var json = "{\"data\":[{\"id\":\"u1\",\"type\":\"url\",\"data\":{\"attributes\":{\"url\":\"https://example.com\"}}}],\"meta\":{\"cursor\":\"c1\"}}";
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -31,8 +31,9 @@ public partial class VirusTotalClientTests
         Assert.NotNull(handler.Request);
         Assert.Equal("/api/v3/files/abc/contacted_urls", handler.Request!.RequestUri!.AbsolutePath);
         Assert.NotNull(urls);
-        Assert.Single(urls!);
-        Assert.Equal("https://example.com", urls[0].Data.Attributes.Url);
+        Assert.Single(urls!.Data);
+        Assert.Equal("https://example.com", urls.Data[0].Data.Attributes.Url);
+        Assert.Equal("c1", urls.NextCursor);
     }
 
     [Fact]
@@ -75,8 +76,8 @@ public partial class VirusTotalClientTests
         Assert.NotNull(handler.Request);
         Assert.Equal("/api/v3/files/abc/contacted_domains", handler.Request!.RequestUri!.AbsolutePath);
         Assert.NotNull(domains);
-        Assert.Single(domains!);
-        Assert.Equal("example.com", domains[0].Data.Attributes.Domain);
+        Assert.Single(domains!.Data);
+        Assert.Equal("example.com", domains.Data[0].Data.Attributes.Domain);
     }
 
     [Fact]
@@ -119,8 +120,8 @@ public partial class VirusTotalClientTests
         Assert.NotNull(handler.Request);
         Assert.Equal("/api/v3/files/abc/contacted_ips", handler.Request!.RequestUri!.AbsolutePath);
         Assert.NotNull(ips);
-        Assert.Single(ips!);
-        Assert.Equal("1.2.3.4", ips[0].Data.Attributes.IpAddress);
+        Assert.Single(ips!.Data);
+        Assert.Equal("1.2.3.4", ips.Data[0].Data.Attributes.IpAddress);
     }
 
     [Fact]
@@ -163,8 +164,8 @@ public partial class VirusTotalClientTests
         Assert.NotNull(handler.Request);
         Assert.Equal("/api/v3/files/abc/referrer_files", handler.Request!.RequestUri!.AbsolutePath);
         Assert.NotNull(files);
-        Assert.Single(files!);
-        Assert.Equal("abc", files[0].Attributes.Md5);
+        Assert.Single(files!.Data);
+        Assert.Equal("abc", files.Data[0].Attributes.Md5);
     }
 
     [Fact]
@@ -209,8 +210,8 @@ public partial class VirusTotalClientTests
         Assert.NotNull(handler.Request);
         Assert.Equal("/api/v3/files/abc/downloaded_files", handler.Request!.RequestUri!.AbsolutePath);
         Assert.NotNull(files);
-        Assert.Single(files!);
-        Assert.Equal("abc", files[0].Attributes.Md5);
+        Assert.Single(files!.Data);
+        Assert.Equal("abc", files.Data[0].Attributes.Md5);
     }
 
     [Fact]
@@ -253,8 +254,8 @@ public partial class VirusTotalClientTests
         Assert.NotNull(handler.Request);
         Assert.Equal("/api/v3/files/abc/bundled_files", handler.Request!.RequestUri!.AbsolutePath);
         Assert.NotNull(files);
-        Assert.Single(files!);
-        Assert.Equal("abc", files[0].Attributes.Md5);
+        Assert.Single(files!.Data);
+        Assert.Equal("abc", files.Data[0].Attributes.Md5);
     }
 
     [Fact]
@@ -297,8 +298,8 @@ public partial class VirusTotalClientTests
         Assert.NotNull(handler.Request);
         Assert.Equal("/api/v3/files/abc/dropped_files", handler.Request!.RequestUri!.AbsolutePath);
         Assert.NotNull(files);
-        Assert.Single(files!);
-        Assert.Equal("abc", files[0].Attributes.Md5);
+        Assert.Single(files!.Data);
+        Assert.Equal("abc", files.Data[0].Attributes.Md5);
     }
 
     [Fact]
@@ -341,8 +342,8 @@ public partial class VirusTotalClientTests
         Assert.NotNull(handler.Request);
         Assert.Equal("/api/v3/files/abc/similar_files", handler.Request!.RequestUri!.AbsolutePath);
         Assert.NotNull(files);
-        Assert.Single(files!);
-        Assert.Equal("abc", files[0].Attributes.Md5);
+        Assert.Single(files!.Data);
+        Assert.Equal("abc", files.Data[0].Attributes.Md5);
     }
 
     [Fact]

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
@@ -598,7 +598,7 @@ public partial class VirusTotalClientTests
 
         Assert.NotNull(behavior);
         Assert.NotNull(handler.Request);
-        Assert.Equal("/api/v3/files/abc/behavior", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal("/api/v3/files/abc/behaviour", handler.Request!.RequestUri!.AbsolutePath);
         Assert.Equal("b1", behavior!.Data[0].Id);
         Assert.Equal("proc1", behavior.Data[0].Attributes.Processes[0].Name);
     }
@@ -641,7 +641,7 @@ public partial class VirusTotalClientTests
 
         Assert.NotNull(summary);
         Assert.NotNull(handler.Request);
-        Assert.Equal("/api/v3/files/abc/behavior_summary", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal("/api/v3/files/abc/behaviour_summary", handler.Request!.RequestUri!.AbsolutePath);
         Assert.Contains("network", summary!.Data.Tags);
     }
 

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -83,7 +83,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<FileBehavior?> GetFileBehaviorAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/behavior", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/behaviour", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -96,7 +96,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<FileBehaviorSummary?> GetFileBehaviorSummaryAsync(string id, CancellationToken cancellationToken = default)
     {
-        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/behavior_summary", cancellationToken).ConfigureAwait(false);
+        using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/behaviour_summary", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
         using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -186,7 +186,7 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
-    public async Task<IReadOnlyList<UrlSummary>?> GetFileContactedUrlsAsync(
+    public async Task<PagedResponse<UrlSummary>?> GetFileContactedUrlsAsync(
         string id,
         int? limit = null,
         string? cursor = null,
@@ -210,11 +210,10 @@ public sealed partial class VirusTotalClient
 #else
         await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #endif
-        var result = await JsonSerializer.DeserializeAsync<UrlSummariesResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
-        return result?.Data;
+        return await JsonSerializer.DeserializeAsync<PagedResponse<UrlSummary>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<IReadOnlyList<DomainSummary>?> GetFileContactedDomainsAsync(
+    public async Task<PagedResponse<DomainSummary>?> GetFileContactedDomainsAsync(
         string id,
         int? limit = null,
         string? cursor = null,
@@ -238,11 +237,10 @@ public sealed partial class VirusTotalClient
 #else
         await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #endif
-        var result = await JsonSerializer.DeserializeAsync<DomainSummariesResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
-        return result?.Data;
+        return await JsonSerializer.DeserializeAsync<PagedResponse<DomainSummary>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<IReadOnlyList<IpAddressSummary>?> GetFileContactedIpsAsync(
+    public async Task<PagedResponse<IpAddressSummary>?> GetFileContactedIpsAsync(
         string id,
         int? limit = null,
         string? cursor = null,
@@ -266,11 +264,10 @@ public sealed partial class VirusTotalClient
 #else
         await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #endif
-        var result = await JsonSerializer.DeserializeAsync<IpAddressSummariesResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
-        return result?.Data;
+        return await JsonSerializer.DeserializeAsync<PagedResponse<IpAddressSummary>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<IReadOnlyList<FileReport>?> GetFileReferrerFilesAsync(
+    public async Task<PagedResponse<FileReport>?> GetFileReferrerFilesAsync(
         string id,
         int? limit = null,
         string? cursor = null,
@@ -294,11 +291,10 @@ public sealed partial class VirusTotalClient
 #else
         await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #endif
-        var result = await JsonSerializer.DeserializeAsync<FileReportsResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
-        return result?.Data;
+        return await JsonSerializer.DeserializeAsync<PagedResponse<FileReport>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<IReadOnlyList<FileReport>?> GetFileDownloadedFilesAsync(
+    public async Task<PagedResponse<FileReport>?> GetFileDownloadedFilesAsync(
         string id,
         int? limit = null,
         string? cursor = null,
@@ -322,11 +318,10 @@ public sealed partial class VirusTotalClient
 #else
         await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #endif
-        var result = await JsonSerializer.DeserializeAsync<FileReportsResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
-        return result?.Data;
+        return await JsonSerializer.DeserializeAsync<PagedResponse<FileReport>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<IReadOnlyList<FileReport>?> GetFileBundledFilesAsync(
+    public async Task<PagedResponse<FileReport>?> GetFileBundledFilesAsync(
         string id,
         int? limit = null,
         string? cursor = null,
@@ -350,11 +345,10 @@ public sealed partial class VirusTotalClient
 #else
         await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #endif
-        var result = await JsonSerializer.DeserializeAsync<FileReportsResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
-        return result?.Data;
+        return await JsonSerializer.DeserializeAsync<PagedResponse<FileReport>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<IReadOnlyList<FileReport>?> GetFileDroppedFilesAsync(
+    public async Task<PagedResponse<FileReport>?> GetFileDroppedFilesAsync(
         string id,
         int? limit = null,
         string? cursor = null,
@@ -378,11 +372,10 @@ public sealed partial class VirusTotalClient
 #else
         await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #endif
-        var result = await JsonSerializer.DeserializeAsync<FileReportsResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
-        return result?.Data;
+        return await JsonSerializer.DeserializeAsync<PagedResponse<FileReport>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<IReadOnlyList<FileReport>?> GetFileSimilarFilesAsync(
+    public async Task<PagedResponse<FileReport>?> GetFileSimilarFilesAsync(
         string id,
         int? limit = null,
         string? cursor = null,
@@ -406,8 +399,7 @@ public sealed partial class VirusTotalClient
 #else
         await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #endif
-        var result = await JsonSerializer.DeserializeAsync<FileReportsResponse>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
-        return result?.Data;
+        return await JsonSerializer.DeserializeAsync<PagedResponse<FileReport>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<Uri?> GetFileDownloadUrlAsync(string id, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- return `PagedResponse<T>` for file relationship APIs and surface cursors
- fix file behaviour endpoints to use `/behaviour` paths
- add example for paging through contacted URLs

## Testing
- `dotnet test VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj -p:TargetFrameworks=net8.0`
- `dotnet build VirusTotalAnalyzer.Examples/VirusTotalAnalyzer.Examples.csproj -p:TargetFrameworks=net8.0`


------
https://chatgpt.com/codex/tasks/task_e_689db11bdc0c832e861bb6ffc8626836