### PR TITLE
Add id parameter validation across client

### DIFF
--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.IdValidation.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.IdValidation.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public partial class VirusTotalClientTests
+{
+    public static IEnumerable<object[]> NullIdOperations()
+    {
+        yield return new object[] { new Func<VirusTotalClient, Task>(c => c.GetFileReportAsync(null!)) };
+        yield return new object[] { new Func<VirusTotalClient, Task>(c => c.GetFileContactedUrlsAsync(null!)) };
+        yield return new object[] { new Func<VirusTotalClient, Task>(c => c.GetCommentAsync(null!)) };
+        yield return new object[] { new Func<VirusTotalClient, Task>(c => c.GetGraphAsync(null!)) };
+    }
+
+    public static IEnumerable<object[]> EmptyIdOperations()
+    {
+        yield return new object[] { new Func<VirusTotalClient, Task>(c => c.GetFileReportAsync(string.Empty)) };
+        yield return new object[] { new Func<VirusTotalClient, Task>(c => c.GetFileContactedUrlsAsync(string.Empty)) };
+        yield return new object[] { new Func<VirusTotalClient, Task>(c => c.GetCommentAsync(string.Empty)) };
+        yield return new object[] { new Func<VirusTotalClient, Task>(c => c.GetGraphAsync(string.Empty)) };
+    }
+
+    [Theory]
+    [MemberData(nameof(NullIdOperations))]
+    public async Task IdParameter_Null_Throws(Func<VirusTotalClient, Task> operation)
+    {
+        var client = CreateClient();
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await operation(client));
+    }
+
+    [Theory]
+    [MemberData(nameof(EmptyIdOperations))]
+    public async Task IdParameter_Empty_Throws(Func<VirusTotalClient, Task> operation)
+    {
+        var client = CreateClient();
+        await Assert.ThrowsAsync<ArgumentException>(async () => await operation(client));
+    }
+}
+

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -53,6 +53,7 @@ public sealed partial class VirusTotalClient
         IEnumerable<string>? relationships = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var url = new StringBuilder($"files/{Uri.EscapeDataString(id)}");
         var hasQuery = false;
 
@@ -83,6 +84,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<FileBehavior?> GetFileBehaviorAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/behaviour", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -96,6 +98,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<FileBehaviorSummary?> GetFileBehaviorSummaryAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/behaviour_summary", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -109,6 +112,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<FileNetworkTraffic?> GetFileNetworkTrafficAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/network-traffic", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -122,6 +126,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<FilePeInfo?> GetFilePeInfoAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/pe_info", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -135,6 +140,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<FileClassification?> GetFileClassificationAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/classification", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -148,6 +154,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<string>?> GetFileStringsAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/strings", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -162,6 +169,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<CrowdsourcedYaraResult>?> GetCrowdsourcedYaraResultsAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/crowdsourced_yara_results", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -175,6 +183,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<CrowdsourcedIdsResult>?> GetCrowdsourcedIdsResultsAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/crowdsourced_ids_results", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -192,6 +201,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/contacted_urls");
         var hasQuery = false;
         if (limit.HasValue)
@@ -219,6 +229,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/contacted_domains");
         var hasQuery = false;
         if (limit.HasValue)
@@ -246,6 +257,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/contacted_ips");
         var hasQuery = false;
         if (limit.HasValue)
@@ -273,6 +285,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/referrer_files");
         var hasQuery = false;
         if (limit.HasValue)
@@ -300,6 +313,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/downloaded_files");
         var hasQuery = false;
         if (limit.HasValue)
@@ -327,6 +341,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/bundled_files");
         var hasQuery = false;
         if (limit.HasValue)
@@ -354,6 +369,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/dropped_files");
         var hasQuery = false;
         if (limit.HasValue)
@@ -381,6 +397,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/similar_files");
         var hasQuery = false;
         if (limit.HasValue)
@@ -404,6 +421,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Uri?> GetFileDownloadUrlAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/download_url", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -422,6 +440,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Stream> DownloadFileAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var response = await _httpClient
             .GetAsync($"files/{Uri.EscapeDataString(id)}/download", HttpCompletionOption.ResponseHeadersRead, cancellationToken)
             .ConfigureAwait(false);
@@ -472,6 +491,7 @@ public sealed partial class VirusTotalClient
         IEnumerable<string>? relationships = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var url = new StringBuilder($"urls/{Uri.EscapeDataString(id)}");
         var hasQuery = false;
 
@@ -520,6 +540,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         if (limit == 0)
         {
             return (new List<AnalysisReport>(), cursor);
@@ -577,6 +598,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"urls/{Uri.EscapeDataString(id)}/downloaded_files");
         var hasQuery = false;
         if (limit.HasValue)
@@ -605,6 +627,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"urls/{Uri.EscapeDataString(id)}/referrer_files");
         var hasQuery = false;
         if (limit.HasValue)
@@ -633,6 +656,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"urls/{Uri.EscapeDataString(id)}/redirecting_urls");
         var hasQuery = false;
         if (limit.HasValue)
@@ -661,6 +685,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"urls/{Uri.EscapeDataString(id)}/contacted_ips");
         var hasQuery = false;
         if (limit.HasValue)
@@ -685,6 +710,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IpAddressSummary?> GetUrlLastServingIpAddressAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"urls/{Uri.EscapeDataString(id)}/last_serving_ip_address", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -735,6 +761,7 @@ public sealed partial class VirusTotalClient
         IEnumerable<string>? relationships = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var url = new StringBuilder($"ip_addresses/{Uri.EscapeDataString(id)}");
         var hasQuery = false;
 
@@ -765,6 +792,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IpWhois?> GetIpAddressWhoisAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"ip_addresses/{Uri.EscapeDataString(id)}/whois", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -814,6 +842,7 @@ public sealed partial class VirusTotalClient
         IEnumerable<string>? relationships = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var url = new StringBuilder($"domains/{Uri.EscapeDataString(id)}");
         var hasQuery = false;
 
@@ -844,6 +873,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<DomainWhois?> GetDomainWhoisAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"domains/{Uri.EscapeDataString(id)}/whois", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -889,6 +919,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<AnalysisReport?> GetAnalysisAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"analyses/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -902,6 +933,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<PrivateAnalysis?> GetPrivateAnalysisAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"private/analyses/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -919,6 +951,7 @@ public sealed partial class VirusTotalClient
         TimeSpan? pollingInterval = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var interval = pollingInterval ?? TimeSpan.FromSeconds(1);
         var start = DateTimeOffset.UtcNow;
 

--- a/VirusTotalAnalyzer/VirusTotalClient.Community.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Community.cs
@@ -17,6 +17,7 @@ public sealed partial class VirusTotalClient
 {
     public async Task<Comment?> GetCommentAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.Comment)}/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -30,6 +31,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<CommentsResponse?> GetCommentsAsync(ResourceType resourceType, string id, int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var path = new StringBuilder($"{GetPath(resourceType)}/{Uri.EscapeDataString(id)}/comments");
         var hasQuery = false;
         if (limit.HasValue)
@@ -53,6 +55,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Vote?> GetVoteAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.Vote)}/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -66,6 +69,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<VotesResponse?> GetVotesAsync(ResourceType resourceType, string id, int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var path = new StringBuilder($"{GetPath(resourceType)}/{Uri.EscapeDataString(id)}/votes");
         var hasQuery = false;
         if (limit.HasValue)
@@ -89,6 +93,7 @@ public sealed partial class VirusTotalClient
 
     public Task<Comment?> CreateCommentAsync(ResourceType resourceType, string id, string text, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var request = new CommentRequestBuilder()
             .WithText(text)
             .Build();
@@ -97,6 +102,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Comment?> CreateCommentAsync(ResourceType resourceType, string id, CreateCommentRequest request, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var response = await _httpClient.PostAsync($"{GetPath(resourceType)}/{Uri.EscapeDataString(id)}/comments", content, cancellationToken).ConfigureAwait(false);
@@ -112,6 +118,7 @@ public sealed partial class VirusTotalClient
 
     public Task<Vote?> CreateVoteAsync(ResourceType resourceType, string id, VoteVerdict verdict, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var request = new VoteRequestBuilder()
             .WithVerdict(verdict)
             .Build();
@@ -120,6 +127,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Vote?> CreateVoteAsync(ResourceType resourceType, string id, CreateVoteRequest request, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var response = await _httpClient.PostAsync($"{GetPath(resourceType)}/{Uri.EscapeDataString(id)}/votes", content, cancellationToken).ConfigureAwait(false);
@@ -135,12 +143,14 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteItemAsync(ResourceType resourceType, string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.DeleteAsync($"{GetPath(resourceType)}/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<User?> GetUserAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"users/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -153,6 +163,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<UserPrivileges?> GetUserPrivilegesAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"users/{Uri.EscapeDataString(id)}/privileges", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -165,6 +176,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<UserQuota?> GetUserQuotaAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"users/{Uri.EscapeDataString(id)}/quotas", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472

--- a/VirusTotalAnalyzer/VirusTotalClient.Intelligence.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Intelligence.cs
@@ -18,6 +18,7 @@ public sealed partial class VirusTotalClient
 {
     public async Task<LivehuntNotification?> GetLivehuntNotificationAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.LivehuntNotification)}/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -66,6 +67,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<RetrohuntJob?> GetRetrohuntJobAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.RetrohuntJob)}/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -128,12 +130,14 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteRetrohuntJobAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.DeleteAsync($"intelligence/retrohunt_jobs/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<RetrohuntNotification?> GetRetrohuntNotificationAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.RetrohuntNotification)}/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -181,6 +185,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<MonitorItem?> GetMonitorItemAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.MonitorItem)}/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -234,6 +239,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<YaraRuleset?> GetYaraRulesetAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"intelligence/hunting_rulesets/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -261,6 +267,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<YaraRuleset?> UpdateYaraRulesetAsync(string id, YaraRulesetRequest request, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var message = new HttpRequestMessage(new HttpMethod("PATCH"), $"intelligence/hunting_rulesets/{Uri.EscapeDataString(id)}")
@@ -280,12 +287,14 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteYaraRulesetAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.DeleteAsync($"intelligence/hunting_rulesets/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<YaraWatcher>?> GetYaraRulesetWatchersAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"intelligence/hunting_rulesets/{Uri.EscapeDataString(id)}/watchers", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -299,6 +308,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<YaraWatcher>?> AddYaraRulesetWatchersAsync(string id, YaraWatcherRequest request, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var response = await _httpClient.PostAsync($"intelligence/hunting_rulesets/{Uri.EscapeDataString(id)}/watchers", content, cancellationToken).ConfigureAwait(false);
@@ -314,12 +324,14 @@ public sealed partial class VirusTotalClient
 
     public async Task RemoveYaraRulesetWatcherAsync(string id, string watcherId, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.DeleteAsync($"intelligence/hunting_rulesets/{Uri.EscapeDataString(id)}/watchers/{Uri.EscapeDataString(watcherId)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<Stream> DownloadYaraRulesetAsync(string id, CancellationToken ct = default)
     {
+        ValidateId(id, nameof(id));
         var response = await _httpClient
             .GetAsync($"intelligence/hunting_rulesets/{Uri.EscapeDataString(id)}/download", HttpCompletionOption.ResponseHeadersRead, ct)
             .ConfigureAwait(false);
@@ -334,18 +346,21 @@ public sealed partial class VirusTotalClient
 
     public async Task<Relationship?> GetYaraRulesetOwnerAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var response = await GetRelationshipsAsync(ResourceType.IntelligenceHuntingRuleset, id, "owner", cancellationToken: cancellationToken).ConfigureAwait(false);
         return response?.Data.FirstOrDefault();
     }
 
     public async Task<IReadOnlyList<Relationship>?> GetYaraRulesetEditorsAsync(string id, int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var response = await GetRelationshipsAsync(ResourceType.IntelligenceHuntingRuleset, id, "editors", limit, cursor, cancellationToken).ConfigureAwait(false);
         return response?.Data;
     }
 
     public async Task<RelationshipResponse?> GetRelationshipsAsync(ResourceType resourceType, string id, string relationship, int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var sb = new StringBuilder($"{GetPath(resourceType)}/{Uri.EscapeDataString(id)}/relationships/{Uri.EscapeDataString(relationship)}");
         var hasQuery = false;
         if (limit.HasValue)

--- a/VirusTotalAnalyzer/VirusTotalClient.Monitor.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Monitor.cs
@@ -78,6 +78,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<MonitorItem?> UpdateMonitorItemAsync(string id, UpdateMonitorItemRequest request, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var message = new HttpRequestMessage(new HttpMethod("PATCH"), $"monitor/items/{Uri.EscapeDataString(id)}") { Content = content };
@@ -93,6 +94,7 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteMonitorItemAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.DeleteAsync($"monitor/items/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }

--- a/VirusTotalAnalyzer/VirusTotalClient.Relationships.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Relationships.cs
@@ -30,6 +30,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var relationships = await GetRelationshipsAsync(ResourceType.Url, id, "graphs", limit, cursor, cancellationToken).ConfigureAwait(false);
         if (relationships == null || relationships.Data.Count == 0)
         {
@@ -125,6 +126,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"ip_addresses/{Uri.EscapeDataString(id)}/communicating_files");
         var hasQuery = false;
         if (limit.HasValue)
@@ -153,6 +155,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"ip_addresses/{Uri.EscapeDataString(id)}/downloaded_files");
         var hasQuery = false;
         if (limit.HasValue)
@@ -181,6 +184,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"ip_addresses/{Uri.EscapeDataString(id)}/referrer_files");
         var hasQuery = false;
         if (limit.HasValue)
@@ -209,6 +213,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"ip_addresses/{Uri.EscapeDataString(id)}/urls");
         var hasQuery = false;
         if (limit.HasValue)
@@ -239,6 +244,7 @@ public sealed partial class VirusTotalClient
         string? cursor,
         CancellationToken cancellationToken)
     {
+        ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"domains/{Uri.EscapeDataString(id)}/{Uri.EscapeDataString(relationship)}");
         var hasQuery = false;
         if (limit.HasValue)
@@ -269,6 +275,7 @@ public sealed partial class VirusTotalClient
         string? cursor,
         CancellationToken cancellationToken)
     {
+        ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"{GetPath(resourceType)}/{Uri.EscapeDataString(id)}/resolutions");
         var hasQuery = false;
         if (limit.HasValue)
@@ -298,6 +305,7 @@ public sealed partial class VirusTotalClient
         string? cursor,
         CancellationToken cancellationToken)
     {
+        ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"{GetPath(resourceType)}/{Uri.EscapeDataString(id)}/submissions");
         var hasQuery = false;
         if (limit.HasValue)

--- a/VirusTotalAnalyzer/VirusTotalClient.Resources.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Resources.cs
@@ -40,6 +40,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Graph?> GetGraphAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"graphs/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -66,6 +67,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Graph?> UpdateGraphAsync(string id, UpdateGraphRequest request, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var message = new HttpRequestMessage(new HttpMethod("PATCH"), $"graphs/{Uri.EscapeDataString(id)}") { Content = content };
@@ -81,6 +83,7 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteGraphAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.DeleteAsync($"graphs/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
@@ -125,6 +128,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Collection?> GetCollectionAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"collections/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -151,6 +155,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Collection?> UpdateCollectionAsync(string id, UpdateCollectionRequest request, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var message = new HttpRequestMessage(new HttpMethod("PATCH"), $"collections/{Uri.EscapeDataString(id)}") { Content = content };
@@ -166,12 +171,14 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteCollectionAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.DeleteAsync($"collections/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<PagedResponse<Relationship>?> ListCollectionItemsAsync(string id, int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var path = new StringBuilder($"collections/{Uri.EscapeDataString(id)}/items");
         var hasQuery = false;
         if (limit.HasValue)
@@ -195,6 +202,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<RelationshipResponse?> AddCollectionItemsAsync(string id, AddItemsRequest request, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var response = await _httpClient.PostAsync($"collections/{Uri.EscapeDataString(id)}/items", content, cancellationToken).ConfigureAwait(false);
@@ -209,6 +217,7 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteCollectionItemAsync(string id, string itemId, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.DeleteAsync($"collections/{Uri.EscapeDataString(id)}/items/{Uri.EscapeDataString(itemId)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
@@ -238,6 +247,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Bundle?> GetBundleAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"bundles/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -264,6 +274,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Bundle?> UpdateBundleAsync(string id, UpdateBundleRequest request, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var message = new HttpRequestMessage(new HttpMethod("PATCH"), $"bundles/{Uri.EscapeDataString(id)}") { Content = content };
@@ -279,12 +290,14 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteBundleAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.DeleteAsync($"bundles/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<PagedResponse<Relationship>?> ListBundleItemsAsync(string id, int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var path = new StringBuilder($"bundles/{Uri.EscapeDataString(id)}/items");
         var hasQuery = false;
         if (limit.HasValue)
@@ -308,6 +321,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<RelationshipResponse?> AddBundleItemsAsync(string id, AddItemsRequest request, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var response = await _httpClient.PostAsync($"bundles/{Uri.EscapeDataString(id)}/items", content, cancellationToken).ConfigureAwait(false);
@@ -322,6 +336,7 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteBundleItemAsync(string id, string itemId, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         using var response = await _httpClient.DeleteAsync($"bundles/{Uri.EscapeDataString(id)}/items/{Uri.EscapeDataString(itemId)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -109,6 +109,18 @@ public sealed partial class VirusTotalClient : IDisposable
             _ => throw new ArgumentOutOfRangeException(nameof(type))
         };
 
+    private static void ValidateId(string id, string paramName)
+    {
+        if (id is null)
+        {
+            throw new ArgumentNullException(paramName);
+        }
+        if (id.Length == 0)
+        {
+            throw new ArgumentException("Id must not be empty.", paramName);
+        }
+    }
+
     private async Task EnsureSuccessAsync(HttpResponseMessage response, CancellationToken cancellationToken)
     {
         if (response.IsSuccessStatusCode)
@@ -171,6 +183,7 @@ public sealed partial class VirusTotalClient : IDisposable
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         if (limit == 0)
         {
             return (new List<FileNameInfo>(), cursor);
@@ -224,6 +237,7 @@ public sealed partial class VirusTotalClient : IDisposable
 
     public async Task<Stream> DownloadLivehuntNotificationFileAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var response = await _httpClient.GetAsync($"intelligence/hunting_notification_files/{Uri.EscapeDataString(id)}", HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
 #if NET472
@@ -235,6 +249,7 @@ public sealed partial class VirusTotalClient : IDisposable
 
     public async Task<Stream> DownloadRetrohuntNotificationFileAsync(string id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         var response = await _httpClient
             .GetAsync($"intelligence/retrohunt_notification_files/{Uri.EscapeDataString(id)}", HttpCompletionOption.ResponseHeadersRead, cancellationToken)
             .ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- centralize id validation via `ValidateId`
- guard public methods against null or empty ids
- test id parameter validation

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689db7599728832eb9bd45f219efd214