### PR TITLE
feat: allow configuring user agent

### DIFF
--- a/VirusTotalAnalyzer.Examples/CustomUserAgentExample.cs
+++ b/VirusTotalAnalyzer.Examples/CustomUserAgentExample.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class CustomUserAgentExample
+{
+    public static async Task RunAsync()
+    {
+        using var client = VirusTotalClient.Create("YOUR_API_KEY", userAgent: "MyApp/1.0");
+
+        // Use the client here.
+        await Task.CompletedTask;
+    }
+}
+

--- a/VirusTotalAnalyzer.Examples/Program.cs
+++ b/VirusTotalAnalyzer.Examples/Program.cs
@@ -49,6 +49,7 @@ using VirusTotalAnalyzer.Examples;
 // await AddCommentExample.RunAsync();
 // await VoteExample.RunAsync();
 // await DeleteExample.RunAsync();
+// await CustomUserAgentExample.RunAsync();
 // await UsingExistingHttpClientExample.RunAsync();
 // await ListLivehuntNotificationsExample.RunAsync();
 // await DownloadLivehuntNotificationFileExample.RunAsync();

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Core.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Core.cs
@@ -26,6 +26,8 @@ public partial class VirusTotalClientTests
         Assert.Equal(new Uri("https://www.virustotal.com/api/v3/"), httpClient.BaseAddress);
         Assert.True(httpClient.DefaultRequestHeaders.TryGetValues("x-apikey", out var values));
         Assert.Equal("demo-key", Assert.Single(values));
+        var expectedAgent = $"{typeof(VirusTotalClient).Assembly.GetName().Name}/{typeof(VirusTotalClient).Assembly.GetName().Version}";
+        Assert.Equal(expectedAgent, httpClient.DefaultRequestHeaders.UserAgent.ToString());
         Assert.True(disposeClient);
     }
 

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.UserAgent.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.UserAgent.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public partial class VirusTotalClientTests
+{
+    [Fact]
+    public async Task GetFileReportAsync_SendsDefaultUserAgent()
+    {
+        var json = "{\"data\":{}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await client.GetFileReportAsync("abc");
+
+        Assert.NotNull(handler.Request);
+        var expected = $"{typeof(VirusTotalClient).Assembly.GetName().Name}/{typeof(VirusTotalClient).Assembly.GetName().Version}";
+        Assert.Equal(expected, handler.Request!.Headers.UserAgent.ToString());
+    }
+
+    [Fact]
+    public async Task GetFileReportAsync_SendsCustomUserAgent()
+    {
+        var json = "{\"data\":{}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient, userAgent: "MyApp/1.0");
+
+        await client.GetFileReportAsync("abc");
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("MyApp/1.0", handler.Request!.Headers.UserAgent.ToString());
+    }
+}
+


### PR DESCRIPTION
## Summary
- allow specifying a custom user agent for VirusTotalClient
- default to library name and version when no user agent supplied
- document user agent customization via example and unit tests

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689dc3bf0098832ea2a3edb5857eeb8e