### PR TITLE
Add link metadata to VirusTotal resource models

### DIFF
--- a/VirusTotalAnalyzer.Tests/AttributeSerializationTests.cs
+++ b/VirusTotalAnalyzer.Tests/AttributeSerializationTests.cs
@@ -19,6 +19,7 @@ public class AttributeSerializationTests
         {
             Id = "file1",
             Type = ResourceType.File,
+            Links = new Links { Self = "https://www.virustotal.com/api/v3/files/file1" },
             Attributes = new FileAttributes
             {
                 Md5 = "md5",
@@ -46,6 +47,7 @@ public class AttributeSerializationTests
         Assert.Equal(100, roundtrip.Attributes.Size);
         Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(10), roundtrip.Attributes.FirstSubmissionDate);
         Assert.Equal(Verdict.Harmless, roundtrip.Attributes.CrowdsourcedVerdicts[0].Verdict);
+        Assert.Equal("https://www.virustotal.com/api/v3/files/file1", roundtrip.Links.Self);
     }
 
     [Fact]
@@ -58,6 +60,7 @@ public class AttributeSerializationTests
         {
             Id = "url1",
             Type = ResourceType.Url,
+            Links = new Links { Self = "https://www.virustotal.com/api/v3/urls/url1" },
             Attributes = new UrlAttributes
             {
                 Url = "https://example.com",
@@ -83,6 +86,7 @@ public class AttributeSerializationTests
         Assert.Equal("malicious", roundtrip.Attributes.LastAnalysisResults["engine"].Category);
         Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(11), roundtrip.Attributes.FirstSubmissionDate);
         Assert.Equal(Verdict.Malicious, roundtrip.Attributes.CrowdsourcedVerdicts[0].Verdict);
+        Assert.Equal("https://www.virustotal.com/api/v3/urls/url1", roundtrip.Links.Self);
     }
 
     [Fact]
@@ -95,6 +99,7 @@ public class AttributeSerializationTests
         {
             Id = "an1",
             Type = ResourceType.Analysis,
+            Links = new Links { Self = "https://www.virustotal.com/api/v3/analyses/an1" },
             Data = new AnalysisData
             {
                 Attributes = new AnalysisAttributes
@@ -113,6 +118,7 @@ public class AttributeSerializationTests
         var roundtrip = JsonSerializer.Deserialize<AnalysisReport>(json, options);
         Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(5), roundtrip!.Data.Attributes.Date);
         Assert.Equal("harmless", roundtrip.Data.Attributes.Results["engine"].Category);
+        Assert.Equal("https://www.virustotal.com/api/v3/analyses/an1", roundtrip.Links.Self);
     }
 
     [Fact]
@@ -125,6 +131,7 @@ public class AttributeSerializationTests
         {
             Id = "domain1",
             Type = ResourceType.Domain,
+            Links = new Links { Self = "https://www.virustotal.com/api/v3/domains/domain1" },
             Attributes = new DomainAttributes
             {
                 Domain = "example.com",
@@ -143,6 +150,7 @@ public class AttributeSerializationTests
         Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(21), roundtrip!.Attributes.CreationDate);
         Assert.Equal("tag", Assert.Single(roundtrip.Attributes.Tags));
         Assert.Equal("suspicious", roundtrip.Attributes.LastAnalysisResults["engine"].Category);
+        Assert.Equal("https://www.virustotal.com/api/v3/domains/domain1", roundtrip.Links.Self);
     }
 
     [Fact]
@@ -155,6 +163,7 @@ public class AttributeSerializationTests
         {
             Id = "ip1",
             Type = ResourceType.IpAddress,
+            Links = new Links { Self = "https://www.virustotal.com/api/v3/ip_addresses/ip1" },
             Attributes = new IpAddressAttributes
             {
                 IpAddress = "1.2.3.4",
@@ -173,5 +182,6 @@ public class AttributeSerializationTests
         Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(63), roundtrip!.Attributes.CreationDate);
         Assert.Equal("tag", Assert.Single(roundtrip.Attributes.Tags));
         Assert.Equal("undetected", roundtrip.Attributes.LastAnalysisResults["engine"].Category);
+        Assert.Equal("https://www.virustotal.com/api/v3/ip_addresses/ip1", roundtrip.Links.Self);
     }
 }

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
@@ -16,7 +16,7 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task GetUserAsync_DeserializesResponse()
     {
-        var json = @"{""id"":""user1"",""type"":""user"",""data"":{""attributes"":{""username"":""demo"",""role"":""admin""}}}";
+        var json = @"{""id"":""user1"",""type"":""user"",""links"":{""self"":""https://www.virustotal.com/api/v3/users/user1""},""data"":{""attributes"":{""username"":""demo"",""role"":""admin""}}}";
         var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
@@ -32,6 +32,7 @@ public partial class VirusTotalClientTests
         Assert.NotNull(user);
         Assert.Equal("demo", user!.Data.Attributes.Username);
         Assert.Equal(UserRole.Admin, user.Data.Attributes.Role);
+        Assert.Equal("https://www.virustotal.com/api/v3/users/user1", user.Links.Self);
         Assert.Equal("/api/v3/users/user1", handler.Request!.RequestUri!.AbsolutePath);
     }
 

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Core.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Core.cs
@@ -32,7 +32,7 @@ public partial class VirusTotalClientTests
     [Fact]
     public async Task GetFileReportAsync_DeserializesResponse()
     {
-        var json = "{\"data\":{\"id\":\"abc\",\"type\":\"file\",\"attributes\":{\"md5\":\"demo\"}}}";
+        var json = "{\"data\":{\"id\":\"abc\",\"type\":\"file\",\"links\":{\"self\":\"https://www.virustotal.com/api/v3/files/abc\"},\"attributes\":{\"md5\":\"demo\"}}}";
         var handler = new StubHandler(json);
         var httpClient = new HttpClient(handler)
         {
@@ -46,6 +46,7 @@ public partial class VirusTotalClientTests
         Assert.Equal("abc", report!.Id);
         Assert.Equal(ResourceType.File, report.Type);
         Assert.Equal("demo", report.Attributes.Md5);
+        Assert.Equal("https://www.virustotal.com/api/v3/files/abc", report.Links.Self);
     }
 
     [Fact]

--- a/VirusTotalAnalyzer/Models/AnalysisReport.cs
+++ b/VirusTotalAnalyzer/Models/AnalysisReport.cs
@@ -8,6 +8,9 @@ public sealed class AnalysisReport
 {
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
+
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
     public AnalysisData Data { get; set; } = new();
 }
 

--- a/VirusTotalAnalyzer/Models/Bundle.cs
+++ b/VirusTotalAnalyzer/Models/Bundle.cs
@@ -7,6 +7,9 @@ public sealed class Bundle
 {
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
+
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
     public BundleData Data { get; set; } = new();
 }
 

--- a/VirusTotalAnalyzer/Models/Collection.cs
+++ b/VirusTotalAnalyzer/Models/Collection.cs
@@ -6,6 +6,9 @@ public sealed class Collection
 {
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
+
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
     public CollectionData Data { get; set; } = new();
 }
 

--- a/VirusTotalAnalyzer/Models/Comment.cs
+++ b/VirusTotalAnalyzer/Models/Comment.cs
@@ -8,6 +8,9 @@ public sealed class Comment
 {
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
+
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
     public CommentData Data { get; set; } = new();
 }
 

--- a/VirusTotalAnalyzer/Models/DomainReport.cs
+++ b/VirusTotalAnalyzer/Models/DomainReport.cs
@@ -9,6 +9,9 @@ public sealed class DomainReport
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
+
     [JsonPropertyName("attributes")]
     public DomainAttributes Attributes { get; set; } = new();
 }

--- a/VirusTotalAnalyzer/Models/DomainSummary.cs
+++ b/VirusTotalAnalyzer/Models/DomainSummary.cs
@@ -7,6 +7,9 @@ public sealed class DomainSummary
 {
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
+
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
     public DomainSummaryData Data { get; set; } = new();
 }
 

--- a/VirusTotalAnalyzer/Models/DomainWhois.cs
+++ b/VirusTotalAnalyzer/Models/DomainWhois.cs
@@ -6,6 +6,9 @@ public sealed class DomainWhois
 {
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
+
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
     public DomainWhoisData Data { get; set; } = new();
 }
 

--- a/VirusTotalAnalyzer/Models/FeedResponse.cs
+++ b/VirusTotalAnalyzer/Models/FeedResponse.cs
@@ -19,4 +19,7 @@ public sealed class FeedItem
 
     [JsonPropertyName("type")]
     public ResourceType Type { get; set; }
+
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
 }

--- a/VirusTotalAnalyzer/Models/FileReport.cs
+++ b/VirusTotalAnalyzer/Models/FileReport.cs
@@ -9,6 +9,9 @@ public sealed class FileReport
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
+
     [JsonPropertyName("attributes")]
     public FileAttributes Attributes { get; set; } = new();
 }

--- a/VirusTotalAnalyzer/Models/Graph.cs
+++ b/VirusTotalAnalyzer/Models/Graph.cs
@@ -6,6 +6,9 @@ public sealed class Graph
 {
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
+
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
     public GraphData Data { get; set; } = new();
 }
 

--- a/VirusTotalAnalyzer/Models/IpAddressReport.cs
+++ b/VirusTotalAnalyzer/Models/IpAddressReport.cs
@@ -9,6 +9,9 @@ public sealed class IpAddressReport
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
+
     [JsonPropertyName("attributes")]
     public IpAddressAttributes Attributes { get; set; } = new();
 }

--- a/VirusTotalAnalyzer/Models/IpAddressSummary.cs
+++ b/VirusTotalAnalyzer/Models/IpAddressSummary.cs
@@ -7,6 +7,9 @@ public sealed class IpAddressSummary
 {
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
+
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
     public IpAddressSummaryData Data { get; set; } = new();
 }
 

--- a/VirusTotalAnalyzer/Models/IpWhois.cs
+++ b/VirusTotalAnalyzer/Models/IpWhois.cs
@@ -6,6 +6,9 @@ public sealed class IpWhois
 {
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
+
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
     public IpWhoisData Data { get; set; } = new();
 }
 

--- a/VirusTotalAnalyzer/Models/Links.cs
+++ b/VirusTotalAnalyzer/Models/Links.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace VirusTotalAnalyzer.Models;
+
+public sealed class Links
+{
+    [JsonPropertyName("self")]
+    public string Self { get; set; } = string.Empty;
+
+    [JsonPropertyName("related")]
+    public Dictionary<string, string> Related { get; set; } = new();
+}

--- a/VirusTotalAnalyzer/Models/LivehuntNotification.cs
+++ b/VirusTotalAnalyzer/Models/LivehuntNotification.cs
@@ -8,6 +8,9 @@ public sealed class LivehuntNotification
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
+
     [JsonPropertyName("attributes")]
     public LivehuntNotificationAttributes Attributes { get; set; } = new();
 }

--- a/VirusTotalAnalyzer/Models/MonitorEvent.cs
+++ b/VirusTotalAnalyzer/Models/MonitorEvent.cs
@@ -6,6 +6,9 @@ public sealed class MonitorEvent
 {
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
+
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
     public MonitorEventData Data { get; set; } = new();
 }
 

--- a/VirusTotalAnalyzer/Models/MonitorItem.cs
+++ b/VirusTotalAnalyzer/Models/MonitorItem.cs
@@ -6,6 +6,9 @@ public sealed class MonitorItem
 {
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
+
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
     public MonitorItemData Data { get; set; } = new();
 }
 

--- a/VirusTotalAnalyzer/Models/PrivateAnalysis.cs
+++ b/VirusTotalAnalyzer/Models/PrivateAnalysis.cs
@@ -8,6 +8,9 @@ public sealed class PrivateAnalysis
 {
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
+
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
     public PrivateAnalysisData Data { get; set; } = new();
 }
 

--- a/VirusTotalAnalyzer/Models/Relationship.cs
+++ b/VirusTotalAnalyzer/Models/Relationship.cs
@@ -10,6 +10,9 @@ public sealed class Relationship
 
     [JsonPropertyName("type")]
     public ResourceType Type { get; set; }
+
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
 }
 
 public sealed class RelationshipResponse

--- a/VirusTotalAnalyzer/Models/RetrohuntJob.cs
+++ b/VirusTotalAnalyzer/Models/RetrohuntJob.cs
@@ -7,6 +7,9 @@ public sealed class RetrohuntJob
 {
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
+
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
     public RetrohuntJobData Data { get; set; } = new();
 }
 

--- a/VirusTotalAnalyzer/Models/RetrohuntNotification.cs
+++ b/VirusTotalAnalyzer/Models/RetrohuntNotification.cs
@@ -7,6 +7,9 @@ public sealed class RetrohuntNotification
 {
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
+
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
     public RetrohuntNotificationData Data { get; set; } = new();
 }
 

--- a/VirusTotalAnalyzer/Models/SearchResponse.cs
+++ b/VirusTotalAnalyzer/Models/SearchResponse.cs
@@ -19,4 +19,7 @@ public sealed class SearchResult
 
     [JsonPropertyName("type")]
     public ResourceType Type { get; set; }
+
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
 }

--- a/VirusTotalAnalyzer/Models/UrlReport.cs
+++ b/VirusTotalAnalyzer/Models/UrlReport.cs
@@ -9,6 +9,9 @@ public sealed class UrlReport
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
+
     [JsonPropertyName("attributes")]
     public UrlAttributes Attributes { get; set; } = new();
 }

--- a/VirusTotalAnalyzer/Models/UrlSummary.cs
+++ b/VirusTotalAnalyzer/Models/UrlSummary.cs
@@ -7,6 +7,9 @@ public sealed class UrlSummary
 {
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
+
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
     public UrlSummaryData Data { get; set; } = new();
 }
 

--- a/VirusTotalAnalyzer/Models/User.cs
+++ b/VirusTotalAnalyzer/Models/User.cs
@@ -7,6 +7,9 @@ public sealed class User
 {
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
+
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
     public UserData Data { get; set; } = new();
 }
 

--- a/VirusTotalAnalyzer/Models/Vote.cs
+++ b/VirusTotalAnalyzer/Models/Vote.cs
@@ -8,6 +8,9 @@ public sealed class Vote
 {
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
+
+    [JsonPropertyName("links")]
+    public Links Links { get; set; } = new();
     public VoteData Data { get; set; } = new();
 }
 


### PR DESCRIPTION
## Summary
- add `Links` model capturing self and related URLs
- expose `Links` property on VirusTotal resource models
- verify link deserialization in unit tests

## Testing
- `~/.dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689dc3c9c8c0832ea2909ddc0757eb2a