### PR TITLE
Add optional fetchAll pagination for listing APIs

### DIFF
--- a/VirusTotalAnalyzer.Examples/BundleItemsExample.cs
+++ b/VirusTotalAnalyzer.Examples/BundleItemsExample.cs
@@ -18,7 +18,7 @@ public static class BundleItemsExample
             var added = await client.AddBundleItemsAsync("bundle-id", request);
             Console.WriteLine($"Added {added?.Data.Count ?? 0} items");
 
-            var items = await client.ListBundleItemsAsync("bundle-id", limit: 10);
+            var items = await client.ListBundleItemsAsync("bundle-id", limit: 10, fetchAll: true);
             Console.WriteLine($"Retrieved {items?.Data.Count} items");
 
             await client.DeleteBundleItemAsync("bundle-id", "file-id");

--- a/VirusTotalAnalyzer.Examples/CollectionItemsExample.cs
+++ b/VirusTotalAnalyzer.Examples/CollectionItemsExample.cs
@@ -18,7 +18,7 @@ public static class CollectionItemsExample
             var added = await client.AddCollectionItemsAsync("collection-id", request);
             Console.WriteLine($"Added {added?.Data.Count ?? 0} items");
 
-            var items = await client.ListCollectionItemsAsync("collection-id", limit: 10);
+            var items = await client.ListCollectionItemsAsync("collection-id", limit: 10, fetchAll: true);
             Console.WriteLine($"Retrieved {items?.Data.Count} items");
 
             await client.DeleteCollectionItemAsync("collection-id", "file-id");

--- a/VirusTotalAnalyzer.Examples/CreateMonitorItemExample.cs
+++ b/VirusTotalAnalyzer.Examples/CreateMonitorItemExample.cs
@@ -18,7 +18,7 @@ public static class CreateMonitorItemExample
             var item = await client.CreateMonitorItemAsync(request);
             Console.WriteLine(item?.Id);
 
-            var items = await client.ListMonitorItemsAsync();
+            var items = await client.ListMonitorItemsAsync(fetchAll: true);
             if (items != null)
             {
                 foreach (var i in items.Data)

--- a/VirusTotalAnalyzer.Examples/GetFileContactedUrlsExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileContactedUrlsExample.cs
@@ -12,7 +12,7 @@ public static class GetFileContactedUrlsExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var page = await client.GetFileContactedUrlsAsync("44d88612fea8a8f36de82e1278abb02f");
+            var page = await client.GetFileContactedUrlsAsync("44d88612fea8a8f36de82e1278abb02f", fetchAll: true);
             foreach (var url in page?.Data ?? new List<UrlSummary>())
             {
                 Console.WriteLine(url.Data.Attributes.Url);

--- a/VirusTotalAnalyzer.Examples/ListBundlesExample.cs
+++ b/VirusTotalAnalyzer.Examples/ListBundlesExample.cs
@@ -11,7 +11,7 @@ public static class ListBundlesExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var page = await client.ListBundlesAsync();
+            var page = await client.ListBundlesAsync(fetchAll: true);
             foreach (var bundle in page!.Data)
             {
                 Console.WriteLine(bundle.Id);

--- a/VirusTotalAnalyzer.Examples/ListCollectionsExample.cs
+++ b/VirusTotalAnalyzer.Examples/ListCollectionsExample.cs
@@ -11,7 +11,7 @@ public static class ListCollectionsExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var page = await client.ListCollectionsAsync();
+            var page = await client.ListCollectionsAsync(fetchAll: true);
             foreach (var collection in page!.Data)
             {
                 Console.WriteLine(collection.Id);

--- a/VirusTotalAnalyzer.Examples/ListGraphsExample.cs
+++ b/VirusTotalAnalyzer.Examples/ListGraphsExample.cs
@@ -11,7 +11,7 @@ public static class ListGraphsExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var page = await client.ListGraphsAsync();
+            var page = await client.ListGraphsAsync(fetchAll: true);
             foreach (var graph in page!.Data)
             {
                 Console.WriteLine(graph.Id);

--- a/VirusTotalAnalyzer.Examples/ListMonitorEventsExample.cs
+++ b/VirusTotalAnalyzer.Examples/ListMonitorEventsExample.cs
@@ -11,7 +11,7 @@ public static class ListMonitorEventsExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var events = await client.ListMonitorEventsAsync();
+            var events = await client.ListMonitorEventsAsync(fetchAll: true);
             if (events != null)
             {
                 foreach (var e in events.Data)

--- a/VirusTotalAnalyzer.Tests/GraphCollectionBundleTests.cs
+++ b/VirusTotalAnalyzer.Tests/GraphCollectionBundleTests.cs
@@ -56,6 +56,30 @@ public class GraphCollectionBundleTests
     }
 
     [Fact]
+    public async Task ListGraphsAsync_FetchAll_RetrievesAllPages()
+    {
+        var first = "{\"data\":[{\"id\":\"g1\",\"type\":\"graph\"}],\"meta\":{\"cursor\":\"next\"}}";
+        var second = "{\"data\":[{\"id\":\"g2\",\"type\":\"graph\"}]}";
+        var handler = new QueueHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(first, Encoding.UTF8, "application/json") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(second, Encoding.UTF8, "application/json") }
+        );
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var response = await client.ListGraphsAsync(fetchAll: true);
+
+        Assert.NotNull(response);
+        Assert.Equal(2, response.Data.Count);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(string.Empty, handler.Requests[0].RequestUri!.Query);
+        Assert.Equal("?cursor=next", handler.Requests[1].RequestUri!.Query);
+    }
+
+    [Fact]
     public async Task CreateGraphAsync_PostsGraph()
     {
         var json = "{\"id\":\"g1\",\"type\":\"graph\",\"data\":{\"attributes\":{\"name\":\"demo\"}}}";
@@ -241,6 +265,30 @@ public class GraphCollectionBundleTests
     }
 
     [Fact]
+    public async Task ListCollectionsAsync_FetchAll_RetrievesAllPages()
+    {
+        var first = "{\"data\":[{\"id\":\"c1\",\"type\":\"collection\"}],\"meta\":{\"cursor\":\"next\"}}";
+        var second = "{\"data\":[{\"id\":\"c2\",\"type\":\"collection\"}]}";
+        var handler = new QueueHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(first, Encoding.UTF8, "application/json") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(second, Encoding.UTF8, "application/json") }
+        );
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var response = await client.ListCollectionsAsync(fetchAll: true);
+
+        Assert.NotNull(response);
+        Assert.Equal(2, response.Data.Count);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(string.Empty, handler.Requests[0].RequestUri!.Query);
+        Assert.Equal("?cursor=next", handler.Requests[1].RequestUri!.Query);
+    }
+
+    [Fact]
     public async Task CreateCollectionAsync_PostsCollection()
     {
         var json = "{\"id\":\"c1\",\"type\":\"collection\",\"data\":{\"attributes\":{\"name\":\"demo\"}}}";
@@ -322,6 +370,30 @@ public class GraphCollectionBundleTests
         Assert.Single(response.Data);
         Assert.Equal(HttpMethod.Get, handler.Request!.Method);
         Assert.Equal("/api/v3/collections/c1/items", handler.Request.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task ListCollectionItemsAsync_FetchAll_RetrievesAllPages()
+    {
+        var first = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\"}],\"meta\":{\"cursor\":\"next\"}}";
+        var second = "{\"data\":[{\"id\":\"f2\",\"type\":\"file\"}]}";
+        var handler = new QueueHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(first, Encoding.UTF8, "application/json") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(second, Encoding.UTF8, "application/json") }
+        );
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var response = await client.ListCollectionItemsAsync("c1", fetchAll: true);
+
+        Assert.NotNull(response);
+        Assert.Equal(2, response.Data.Count);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(string.Empty, handler.Requests[0].RequestUri!.Query);
+        Assert.Equal("?cursor=next", handler.Requests[1].RequestUri!.Query);
     }
 
     [Fact]
@@ -412,6 +484,30 @@ public class GraphCollectionBundleTests
     }
 
     [Fact]
+    public async Task ListBundlesAsync_FetchAll_RetrievesAllPages()
+    {
+        var first = "{\"data\":[{\"id\":\"b1\",\"type\":\"bundle\"}],\"meta\":{\"cursor\":\"next\"}}";
+        var second = "{\"data\":[{\"id\":\"b2\",\"type\":\"bundle\"}]}";
+        var handler = new QueueHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(first, Encoding.UTF8, "application/json") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(second, Encoding.UTF8, "application/json") }
+        );
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var response = await client.ListBundlesAsync(fetchAll: true);
+
+        Assert.NotNull(response);
+        Assert.Equal(2, response.Data.Count);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(string.Empty, handler.Requests[0].RequestUri!.Query);
+        Assert.Equal("?cursor=next", handler.Requests[1].RequestUri!.Query);
+    }
+
+    [Fact]
     public async Task CreateBundleAsync_PostsBundle()
     {
         var json = "{\"id\":\"b1\",\"type\":\"bundle\",\"data\":{\"attributes\":{\"name\":\"demo\"}}}";
@@ -496,6 +592,30 @@ public class GraphCollectionBundleTests
         Assert.Single(response.Data);
         Assert.Equal(HttpMethod.Get, handler.Request!.Method);
         Assert.Equal("/api/v3/bundles/b1/items", handler.Request.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task ListBundleItemsAsync_FetchAll_RetrievesAllPages()
+    {
+        var first = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\"}],\"meta\":{\"cursor\":\"next\"}}";
+        var second = "{\"data\":[{\"id\":\"f2\",\"type\":\"file\"}]}";
+        var handler = new QueueHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(first, Encoding.UTF8, "application/json") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(second, Encoding.UTF8, "application/json") }
+        );
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var response = await client.ListBundleItemsAsync("b1", fetchAll: true);
+
+        Assert.NotNull(response);
+        Assert.Equal(2, response.Data.Count);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(string.Empty, handler.Requests[0].RequestUri!.Query);
+        Assert.Equal("?cursor=next", handler.Requests[1].RequestUri!.Query);
     }
 
     [Fact]

--- a/VirusTotalAnalyzer.Tests/MonitorEventTests.cs
+++ b/VirusTotalAnalyzer.Tests/MonitorEventTests.cs
@@ -56,6 +56,30 @@ public class MonitorEventTests
     }
 
     [Fact]
+    public async Task ListMonitorEventsAsync_FetchAll_RetrievesAllPages()
+    {
+        var first = "{\"data\":[{\"id\":\"e1\",\"type\":\"monitor_event\"}],\"meta\":{\"cursor\":\"next\"}}";
+        var second = "{\"data\":[{\"id\":\"e2\",\"type\":\"monitor_event\"}]}";
+        var handler = new QueueHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(first, Encoding.UTF8, "application/json") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(second, Encoding.UTF8, "application/json") }
+        );
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var response = await client.ListMonitorEventsAsync(fetchAll: true);
+
+        Assert.NotNull(response);
+        Assert.Equal(2, response.Data.Count);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(string.Empty, handler.Requests[0].RequestUri!.Query);
+        Assert.Equal("?cursor=next", handler.Requests[1].RequestUri!.Query);
+    }
+
+    [Fact]
     public async Task GetCommentsAsync_OnMonitorEvent_UsesMonitorEventsPath()
     {
         var json = "{\"data\":[]}";

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.AnalysisRelationships.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.AnalysisRelationships.cs
@@ -57,6 +57,30 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetFileContactedUrlsAsync_FetchAll_RetrievesAllPages()
+    {
+        var first = "{\"data\":[{\"id\":\"u1\",\"type\":\"url\"}],\"meta\":{\"cursor\":\"next\"}}";
+        var second = "{\"data\":[{\"id\":\"u2\",\"type\":\"url\"}]}";
+        var handler = new QueueHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(first, Encoding.UTF8, "application/json") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(second, Encoding.UTF8, "application/json") }
+        );
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var urls = await client.GetFileContactedUrlsAsync("abc", fetchAll: true);
+
+        Assert.NotNull(urls);
+        Assert.Equal(2, urls.Data.Count);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(string.Empty, handler.Requests[0].RequestUri!.Query);
+        Assert.Equal("?cursor=next", handler.Requests[1].RequestUri!.Query);
+    }
+
+    [Fact]
     public async Task GetFileContactedDomainsAsync_UsesCorrectPathAndDeserializesResponse()
     {
         var json = "{\"data\":[{\"id\":\"d1\",\"type\":\"domain\",\"data\":{\"attributes\":{\"domain\":\"example.com\"}}}]}";
@@ -98,6 +122,30 @@ public partial class VirusTotalClientTests
 
         Assert.NotNull(handler.Request);
         Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
+    }
+
+    [Fact]
+    public async Task GetFileContactedDomainsAsync_FetchAll_RetrievesAllPages()
+    {
+        var first = "{\"data\":[{\"id\":\"d1\",\"type\":\"domain\"}],\"meta\":{\"cursor\":\"next\"}}";
+        var second = "{\"data\":[{\"id\":\"d2\",\"type\":\"domain\"}]}";
+        var handler = new QueueHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(first, Encoding.UTF8, "application/json") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(second, Encoding.UTF8, "application/json") }
+        );
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var domains = await client.GetFileContactedDomainsAsync("abc", fetchAll: true);
+
+        Assert.NotNull(domains);
+        Assert.Equal(2, domains.Data.Count);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(string.Empty, handler.Requests[0].RequestUri!.Query);
+        Assert.Equal("?cursor=next", handler.Requests[1].RequestUri!.Query);
     }
 
     [Fact]
@@ -145,6 +193,30 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetFileContactedIpsAsync_FetchAll_RetrievesAllPages()
+    {
+        var first = "{\"data\":[{\"id\":\"i1\",\"type\":\"ip_address\"}],\"meta\":{\"cursor\":\"next\"}}";
+        var second = "{\"data\":[{\"id\":\"i2\",\"type\":\"ip_address\"}]}";
+        var handler = new QueueHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(first, Encoding.UTF8, "application/json") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(second, Encoding.UTF8, "application/json") }
+        );
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var ips = await client.GetFileContactedIpsAsync("abc", fetchAll: true);
+
+        Assert.NotNull(ips);
+        Assert.Equal(2, ips.Data.Count);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(string.Empty, handler.Requests[0].RequestUri!.Query);
+        Assert.Equal("?cursor=next", handler.Requests[1].RequestUri!.Query);
+    }
+
+    [Fact]
     public async Task GetFileReferrerFilesAsync_UsesCorrectPathAndDeserializesResponse()
     {
         var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"attributes\":{\"md5\":\"abc\"}}]}";
@@ -186,6 +258,30 @@ public partial class VirusTotalClientTests
 
         Assert.NotNull(handler.Request);
         Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
+    }
+
+    [Fact]
+    public async Task GetFileReferrerFilesAsync_FetchAll_RetrievesAllPages()
+    {
+        var first = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\"}],\"meta\":{\"cursor\":\"next\"}}";
+        var second = "{\"data\":[{\"id\":\"f2\",\"type\":\"file\"}]}";
+        var handler = new QueueHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(first, Encoding.UTF8, "application/json") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(second, Encoding.UTF8, "application/json") }
+        );
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var files = await client.GetFileReferrerFilesAsync("abc", fetchAll: true);
+
+        Assert.NotNull(files);
+        Assert.Equal(2, files.Data.Count);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(string.Empty, handler.Requests[0].RequestUri!.Query);
+        Assert.Equal("?cursor=next", handler.Requests[1].RequestUri!.Query);
     }
 
 
@@ -235,6 +331,30 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetFileDownloadedFilesAsync_FetchAll_RetrievesAllPages()
+    {
+        var first = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\"}],\"meta\":{\"cursor\":\"next\"}}";
+        var second = "{\"data\":[{\"id\":\"f2\",\"type\":\"file\"}]}";
+        var handler = new QueueHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(first, Encoding.UTF8, "application/json") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(second, Encoding.UTF8, "application/json") }
+        );
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var files = await client.GetFileDownloadedFilesAsync("abc", fetchAll: true);
+
+        Assert.NotNull(files);
+        Assert.Equal(2, files.Data.Count);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(string.Empty, handler.Requests[0].RequestUri!.Query);
+        Assert.Equal("?cursor=next", handler.Requests[1].RequestUri!.Query);
+    }
+
+    [Fact]
     public async Task GetFileBundledFilesAsync_UsesCorrectPathAndDeserializesResponse()
     {
         var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"attributes\":{\"md5\":\"abc\"}}]}";
@@ -276,6 +396,30 @@ public partial class VirusTotalClientTests
 
         Assert.NotNull(handler.Request);
         Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
+    }
+
+    [Fact]
+    public async Task GetFileBundledFilesAsync_FetchAll_RetrievesAllPages()
+    {
+        var first = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\"}],\"meta\":{\"cursor\":\"next\"}}";
+        var second = "{\"data\":[{\"id\":\"f2\",\"type\":\"file\"}]}";
+        var handler = new QueueHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(first, Encoding.UTF8, "application/json") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(second, Encoding.UTF8, "application/json") }
+        );
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var files = await client.GetFileBundledFilesAsync("abc", fetchAll: true);
+
+        Assert.NotNull(files);
+        Assert.Equal(2, files.Data.Count);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(string.Empty, handler.Requests[0].RequestUri!.Query);
+        Assert.Equal("?cursor=next", handler.Requests[1].RequestUri!.Query);
     }
 
     [Fact]
@@ -323,6 +467,30 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetFileDroppedFilesAsync_FetchAll_RetrievesAllPages()
+    {
+        var first = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\"}],\"meta\":{\"cursor\":\"next\"}}";
+        var second = "{\"data\":[{\"id\":\"f2\",\"type\":\"file\"}]}";
+        var handler = new QueueHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(first, Encoding.UTF8, "application/json") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(second, Encoding.UTF8, "application/json") }
+        );
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var files = await client.GetFileDroppedFilesAsync("abc", fetchAll: true);
+
+        Assert.NotNull(files);
+        Assert.Equal(2, files.Data.Count);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(string.Empty, handler.Requests[0].RequestUri!.Query);
+        Assert.Equal("?cursor=next", handler.Requests[1].RequestUri!.Query);
+    }
+
+    [Fact]
     public async Task GetFileSimilarFilesAsync_UsesCorrectPathAndDeserializesResponse()
     {
         var json = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\",\"attributes\":{\"md5\":\"abc\"}}]}";
@@ -364,6 +532,30 @@ public partial class VirusTotalClientTests
 
         Assert.NotNull(handler.Request);
         Assert.Equal("?limit=10&cursor=abc", handler.Request!.RequestUri!.Query);
+    }
+
+    [Fact]
+    public async Task GetFileSimilarFilesAsync_FetchAll_RetrievesAllPages()
+    {
+        var first = "{\"data\":[{\"id\":\"f1\",\"type\":\"file\"}],\"meta\":{\"cursor\":\"next\"}}";
+        var second = "{\"data\":[{\"id\":\"f2\",\"type\":\"file\"}]}";
+        var handler = new QueueHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(first, Encoding.UTF8, "application/json") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(second, Encoding.UTF8, "application/json") }
+        );
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var files = await client.GetFileSimilarFilesAsync("abc", fetchAll: true);
+
+        Assert.NotNull(files);
+        Assert.Equal(2, files.Data.Count);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(string.Empty, handler.Requests[0].RequestUri!.Query);
+        Assert.Equal("?cursor=next", handler.Requests[1].RequestUri!.Query);
     }
 
     [Fact]

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -195,228 +195,260 @@ public sealed partial class VirusTotalClient
         return result?.Data;
     }
 
-    public async Task<PagedResponse<UrlSummary>?> GetFileContactedUrlsAsync(
+    public Task<PagedResponse<UrlSummary>?> GetFileContactedUrlsAsync(
         string id,
         int? limit = null,
         string? cursor = null,
+        bool fetchAll = false,
         CancellationToken cancellationToken = default)
     {
         ValidateId(id, nameof(id));
-        var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/contacted_urls");
-        var hasQuery = false;
-        if (limit.HasValue)
+        return GetPagedAsync<UrlSummary>(async (c, token) =>
         {
-            path.Append("?limit=").Append(limit.Value);
-            hasQuery = true;
-        }
-        if (!string.IsNullOrEmpty(cursor))
-        {
-            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
-        }
-        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+            var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/contacted_urls");
+            var hasQuery = false;
+            if (limit.HasValue)
+            {
+                path.Append("?limit=").Append(limit.Value);
+                hasQuery = true;
+            }
+            if (!string.IsNullOrEmpty(c))
+            {
+                path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(c));
+            }
+            using var response = await _httpClient.GetAsync(path.ToString(), token).ConfigureAwait(false);
+            await EnsureSuccessAsync(response, token).ConfigureAwait(false);
 #if NET472
-        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #else
-        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            await using var stream = await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
 #endif
-        return await JsonSerializer.DeserializeAsync<PagedResponse<UrlSummary>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+            return await JsonSerializer.DeserializeAsync<PagedResponse<UrlSummary>>(stream, _jsonOptions, token).ConfigureAwait(false);
+        }, cursor, fetchAll, cancellationToken);
     }
 
-    public async Task<PagedResponse<DomainSummary>?> GetFileContactedDomainsAsync(
+    public Task<PagedResponse<DomainSummary>?> GetFileContactedDomainsAsync(
         string id,
         int? limit = null,
         string? cursor = null,
+        bool fetchAll = false,
         CancellationToken cancellationToken = default)
     {
         ValidateId(id, nameof(id));
-        var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/contacted_domains");
-        var hasQuery = false;
-        if (limit.HasValue)
+        return GetPagedAsync<DomainSummary>(async (c, token) =>
         {
-            path.Append("?limit=").Append(limit.Value);
-            hasQuery = true;
-        }
-        if (!string.IsNullOrEmpty(cursor))
-        {
-            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
-        }
-        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+            var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/contacted_domains");
+            var hasQuery = false;
+            if (limit.HasValue)
+            {
+                path.Append("?limit=").Append(limit.Value);
+                hasQuery = true;
+            }
+            if (!string.IsNullOrEmpty(c))
+            {
+                path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(c));
+            }
+            using var response = await _httpClient.GetAsync(path.ToString(), token).ConfigureAwait(false);
+            await EnsureSuccessAsync(response, token).ConfigureAwait(false);
 #if NET472
-        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #else
-        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            await using var stream = await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
 #endif
-        return await JsonSerializer.DeserializeAsync<PagedResponse<DomainSummary>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+            return await JsonSerializer.DeserializeAsync<PagedResponse<DomainSummary>>(stream, _jsonOptions, token).ConfigureAwait(false);
+        }, cursor, fetchAll, cancellationToken);
     }
 
-    public async Task<PagedResponse<IpAddressSummary>?> GetFileContactedIpsAsync(
+    public Task<PagedResponse<IpAddressSummary>?> GetFileContactedIpsAsync(
         string id,
         int? limit = null,
         string? cursor = null,
+        bool fetchAll = false,
         CancellationToken cancellationToken = default)
     {
         ValidateId(id, nameof(id));
-        var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/contacted_ips");
-        var hasQuery = false;
-        if (limit.HasValue)
+        return GetPagedAsync<IpAddressSummary>(async (c, token) =>
         {
-            path.Append("?limit=").Append(limit.Value);
-            hasQuery = true;
-        }
-        if (!string.IsNullOrEmpty(cursor))
-        {
-            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
-        }
-        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+            var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/contacted_ips");
+            var hasQuery = false;
+            if (limit.HasValue)
+            {
+                path.Append("?limit=").Append(limit.Value);
+                hasQuery = true;
+            }
+            if (!string.IsNullOrEmpty(c))
+            {
+                path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(c));
+            }
+            using var response = await _httpClient.GetAsync(path.ToString(), token).ConfigureAwait(false);
+            await EnsureSuccessAsync(response, token).ConfigureAwait(false);
 #if NET472
-        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #else
-        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            await using var stream = await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
 #endif
-        return await JsonSerializer.DeserializeAsync<PagedResponse<IpAddressSummary>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+            return await JsonSerializer.DeserializeAsync<PagedResponse<IpAddressSummary>>(stream, _jsonOptions, token).ConfigureAwait(false);
+        }, cursor, fetchAll, cancellationToken);
     }
 
-    public async Task<PagedResponse<FileReport>?> GetFileReferrerFilesAsync(
+    public Task<PagedResponse<FileReport>?> GetFileReferrerFilesAsync(
         string id,
         int? limit = null,
         string? cursor = null,
+        bool fetchAll = false,
         CancellationToken cancellationToken = default)
     {
         ValidateId(id, nameof(id));
-        var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/referrer_files");
-        var hasQuery = false;
-        if (limit.HasValue)
+        return GetPagedAsync<FileReport>(async (c, token) =>
         {
-            path.Append("?limit=").Append(limit.Value);
-            hasQuery = true;
-        }
-        if (!string.IsNullOrEmpty(cursor))
-        {
-            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
-        }
-        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+            var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/referrer_files");
+            var hasQuery = false;
+            if (limit.HasValue)
+            {
+                path.Append("?limit=").Append(limit.Value);
+                hasQuery = true;
+            }
+            if (!string.IsNullOrEmpty(c))
+            {
+                path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(c));
+            }
+            using var response = await _httpClient.GetAsync(path.ToString(), token).ConfigureAwait(false);
+            await EnsureSuccessAsync(response, token).ConfigureAwait(false);
 #if NET472
-        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #else
-        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            await using var stream = await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
 #endif
-        return await JsonSerializer.DeserializeAsync<PagedResponse<FileReport>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+            return await JsonSerializer.DeserializeAsync<PagedResponse<FileReport>>(stream, _jsonOptions, token).ConfigureAwait(false);
+        }, cursor, fetchAll, cancellationToken);
     }
 
-    public async Task<PagedResponse<FileReport>?> GetFileDownloadedFilesAsync(
+    public Task<PagedResponse<FileReport>?> GetFileDownloadedFilesAsync(
         string id,
         int? limit = null,
         string? cursor = null,
+        bool fetchAll = false,
         CancellationToken cancellationToken = default)
     {
         ValidateId(id, nameof(id));
-        var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/downloaded_files");
-        var hasQuery = false;
-        if (limit.HasValue)
+        return GetPagedAsync<FileReport>(async (c, token) =>
         {
-            path.Append("?limit=").Append(limit.Value);
-            hasQuery = true;
-        }
-        if (!string.IsNullOrEmpty(cursor))
-        {
-            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
-        }
-        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+            var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/downloaded_files");
+            var hasQuery = false;
+            if (limit.HasValue)
+            {
+                path.Append("?limit=").Append(limit.Value);
+                hasQuery = true;
+            }
+            if (!string.IsNullOrEmpty(c))
+            {
+                path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(c));
+            }
+            using var response = await _httpClient.GetAsync(path.ToString(), token).ConfigureAwait(false);
+            await EnsureSuccessAsync(response, token).ConfigureAwait(false);
 #if NET472
-        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #else
-        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            await using var stream = await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
 #endif
-        return await JsonSerializer.DeserializeAsync<PagedResponse<FileReport>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+            return await JsonSerializer.DeserializeAsync<PagedResponse<FileReport>>(stream, _jsonOptions, token).ConfigureAwait(false);
+        }, cursor, fetchAll, cancellationToken);
     }
 
-    public async Task<PagedResponse<FileReport>?> GetFileBundledFilesAsync(
+    public Task<PagedResponse<FileReport>?> GetFileBundledFilesAsync(
         string id,
         int? limit = null,
         string? cursor = null,
+        bool fetchAll = false,
         CancellationToken cancellationToken = default)
     {
         ValidateId(id, nameof(id));
-        var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/bundled_files");
-        var hasQuery = false;
-        if (limit.HasValue)
+        return GetPagedAsync<FileReport>(async (c, token) =>
         {
-            path.Append("?limit=").Append(limit.Value);
-            hasQuery = true;
-        }
-        if (!string.IsNullOrEmpty(cursor))
-        {
-            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
-        }
-        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+            var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/bundled_files");
+            var hasQuery = false;
+            if (limit.HasValue)
+            {
+                path.Append("?limit=").Append(limit.Value);
+                hasQuery = true;
+            }
+            if (!string.IsNullOrEmpty(c))
+            {
+                path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(c));
+            }
+            using var response = await _httpClient.GetAsync(path.ToString(), token).ConfigureAwait(false);
+            await EnsureSuccessAsync(response, token).ConfigureAwait(false);
 #if NET472
-        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #else
-        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            await using var stream = await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
 #endif
-        return await JsonSerializer.DeserializeAsync<PagedResponse<FileReport>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+            return await JsonSerializer.DeserializeAsync<PagedResponse<FileReport>>(stream, _jsonOptions, token).ConfigureAwait(false);
+        }, cursor, fetchAll, cancellationToken);
     }
 
-    public async Task<PagedResponse<FileReport>?> GetFileDroppedFilesAsync(
+    public Task<PagedResponse<FileReport>?> GetFileDroppedFilesAsync(
         string id,
         int? limit = null,
         string? cursor = null,
+        bool fetchAll = false,
         CancellationToken cancellationToken = default)
     {
         ValidateId(id, nameof(id));
-        var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/dropped_files");
-        var hasQuery = false;
-        if (limit.HasValue)
+        return GetPagedAsync<FileReport>(async (c, token) =>
         {
-            path.Append("?limit=").Append(limit.Value);
-            hasQuery = true;
-        }
-        if (!string.IsNullOrEmpty(cursor))
-        {
-            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
-        }
-        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+            var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/dropped_files");
+            var hasQuery = false;
+            if (limit.HasValue)
+            {
+                path.Append("?limit=").Append(limit.Value);
+                hasQuery = true;
+            }
+            if (!string.IsNullOrEmpty(c))
+            {
+                path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(c));
+            }
+            using var response = await _httpClient.GetAsync(path.ToString(), token).ConfigureAwait(false);
+            await EnsureSuccessAsync(response, token).ConfigureAwait(false);
 #if NET472
-        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #else
-        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            await using var stream = await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
 #endif
-        return await JsonSerializer.DeserializeAsync<PagedResponse<FileReport>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+            return await JsonSerializer.DeserializeAsync<PagedResponse<FileReport>>(stream, _jsonOptions, token).ConfigureAwait(false);
+        }, cursor, fetchAll, cancellationToken);
     }
 
-    public async Task<PagedResponse<FileReport>?> GetFileSimilarFilesAsync(
+    public Task<PagedResponse<FileReport>?> GetFileSimilarFilesAsync(
         string id,
         int? limit = null,
         string? cursor = null,
+        bool fetchAll = false,
         CancellationToken cancellationToken = default)
     {
         ValidateId(id, nameof(id));
-        var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/similar_files");
-        var hasQuery = false;
-        if (limit.HasValue)
+        return GetPagedAsync<FileReport>(async (c, token) =>
         {
-            path.Append("?limit=").Append(limit.Value);
-            hasQuery = true;
-        }
-        if (!string.IsNullOrEmpty(cursor))
-        {
-            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
-        }
-        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+            var path = new System.Text.StringBuilder($"files/{Uri.EscapeDataString(id)}/similar_files");
+            var hasQuery = false;
+            if (limit.HasValue)
+            {
+                path.Append("?limit=").Append(limit.Value);
+                hasQuery = true;
+            }
+            if (!string.IsNullOrEmpty(c))
+            {
+                path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(c));
+            }
+            using var response = await _httpClient.GetAsync(path.ToString(), token).ConfigureAwait(false);
+            await EnsureSuccessAsync(response, token).ConfigureAwait(false);
 #if NET472
-        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #else
-        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            await using var stream = await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
 #endif
-        return await JsonSerializer.DeserializeAsync<PagedResponse<FileReport>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+            return await JsonSerializer.DeserializeAsync<PagedResponse<FileReport>>(stream, _jsonOptions, token).ConfigureAwait(false);
+        }, cursor, fetchAll, cancellationToken);
     }
 
     public async Task<Uri?> GetFileDownloadUrlAsync(string id, CancellationToken cancellationToken = default)

--- a/VirusTotalAnalyzer/VirusTotalClient.Pagination.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Pagination.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer;
+
+public sealed partial class VirusTotalClient
+{
+    private async Task<PagedResponse<T>?> GetPagedAsync<T>(
+        Func<string?, CancellationToken, Task<PagedResponse<T>?>> fetch,
+        string? cursor,
+        bool fetchAll,
+        CancellationToken cancellationToken)
+    {
+        var allData = new List<T>();
+        PagedResponse<T>? page;
+        var nextCursor = cursor;
+        do
+        {
+            page = await fetch(nextCursor, cancellationToken).ConfigureAwait(false);
+            if (page is null)
+            {
+                return null;
+            }
+            allData.AddRange(page.Data);
+            nextCursor = page.Meta?.Cursor;
+        }
+        while (fetchAll && !string.IsNullOrEmpty(nextCursor));
+
+        if (fetchAll)
+        {
+            return new PagedResponse<T>
+            {
+                Data = allData,
+                Meta = page.Meta
+            };
+        }
+
+        return page;
+    }
+}

--- a/VirusTotalAnalyzer/VirusTotalClient.Resources.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Resources.cs
@@ -15,28 +15,29 @@ namespace VirusTotalAnalyzer;
 
 public sealed partial class VirusTotalClient
 {
-    public async Task<PagedResponse<Graph>?> ListGraphsAsync(int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
-    {
-        var path = new StringBuilder("graphs");
-        var hasQuery = false;
-        if (limit.HasValue)
+    public Task<PagedResponse<Graph>?> ListGraphsAsync(int? limit = null, string? cursor = null, bool fetchAll = false, CancellationToken cancellationToken = default)
+        => GetPagedAsync<Graph>(async (c, token) =>
         {
-            path.Append("?limit=").Append(limit.Value);
-            hasQuery = true;
-        }
-        if (!string.IsNullOrEmpty(cursor))
-        {
-            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
-        }
-        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+            var path = new StringBuilder("graphs");
+            var hasQuery = false;
+            if (limit.HasValue)
+            {
+                path.Append("?limit=").Append(limit.Value);
+                hasQuery = true;
+            }
+            if (!string.IsNullOrEmpty(c))
+            {
+                path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(c));
+            }
+            using var response = await _httpClient.GetAsync(path.ToString(), token).ConfigureAwait(false);
+            await EnsureSuccessAsync(response, token).ConfigureAwait(false);
 #if NET472
-        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #else
-        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            await using var stream = await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
 #endif
-        return await JsonSerializer.DeserializeAsync<PagedResponse<Graph>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
-    }
+            return await JsonSerializer.DeserializeAsync<PagedResponse<Graph>>(stream, _jsonOptions, token).ConfigureAwait(false);
+        }, cursor, fetchAll, cancellationToken);
 
     public async Task<Graph?> GetGraphAsync(string id, CancellationToken cancellationToken = default)
     {
@@ -103,28 +104,29 @@ public sealed partial class VirusTotalClient
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<PagedResponse<Collection>?> ListCollectionsAsync(int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
-    {
-        var path = new StringBuilder("collections");
-        var hasQuery = false;
-        if (limit.HasValue)
+    public Task<PagedResponse<Collection>?> ListCollectionsAsync(int? limit = null, string? cursor = null, bool fetchAll = false, CancellationToken cancellationToken = default)
+        => GetPagedAsync<Collection>(async (c, token) =>
         {
-            path.Append("?limit=").Append(limit.Value);
-            hasQuery = true;
-        }
-        if (!string.IsNullOrEmpty(cursor))
-        {
-            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
-        }
-        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+            var path = new StringBuilder("collections");
+            var hasQuery = false;
+            if (limit.HasValue)
+            {
+                path.Append("?limit=").Append(limit.Value);
+                hasQuery = true;
+            }
+            if (!string.IsNullOrEmpty(c))
+            {
+                path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(c));
+            }
+            using var response = await _httpClient.GetAsync(path.ToString(), token).ConfigureAwait(false);
+            await EnsureSuccessAsync(response, token).ConfigureAwait(false);
 #if NET472
-        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #else
-        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            await using var stream = await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
 #endif
-        return await JsonSerializer.DeserializeAsync<PagedResponse<Collection>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
-    }
+            return await JsonSerializer.DeserializeAsync<PagedResponse<Collection>>(stream, _jsonOptions, token).ConfigureAwait(false);
+        }, cursor, fetchAll, cancellationToken);
 
     public async Task<Collection?> GetCollectionAsync(string id, CancellationToken cancellationToken = default)
     {
@@ -176,28 +178,31 @@ public sealed partial class VirusTotalClient
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<PagedResponse<Relationship>?> ListCollectionItemsAsync(string id, int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
+    public Task<PagedResponse<Relationship>?> ListCollectionItemsAsync(string id, int? limit = null, string? cursor = null, bool fetchAll = false, CancellationToken cancellationToken = default)
     {
         ValidateId(id, nameof(id));
-        var path = new StringBuilder($"collections/{Uri.EscapeDataString(id)}/items");
-        var hasQuery = false;
-        if (limit.HasValue)
+        return GetPagedAsync<Relationship>(async (c, token) =>
         {
-            path.Append("?limit=").Append(limit.Value);
-            hasQuery = true;
-        }
-        if (!string.IsNullOrEmpty(cursor))
-        {
-            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
-        }
-        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+            var path = new StringBuilder($"collections/{Uri.EscapeDataString(id)}/items");
+            var hasQuery = false;
+            if (limit.HasValue)
+            {
+                path.Append("?limit=").Append(limit.Value);
+                hasQuery = true;
+            }
+            if (!string.IsNullOrEmpty(c))
+            {
+                path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(c));
+            }
+            using var response = await _httpClient.GetAsync(path.ToString(), token).ConfigureAwait(false);
+            await EnsureSuccessAsync(response, token).ConfigureAwait(false);
 #if NET472
-        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #else
-        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            await using var stream = await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
 #endif
-        return await JsonSerializer.DeserializeAsync<PagedResponse<Relationship>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+            return await JsonSerializer.DeserializeAsync<PagedResponse<Relationship>>(stream, _jsonOptions, token).ConfigureAwait(false);
+        }, cursor, fetchAll, cancellationToken);
     }
 
     public async Task<RelationshipResponse?> AddCollectionItemsAsync(string id, AddItemsRequest request, CancellationToken cancellationToken = default)
@@ -222,28 +227,29 @@ public sealed partial class VirusTotalClient
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<PagedResponse<Bundle>?> ListBundlesAsync(int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
-    {
-        var path = new StringBuilder("bundles");
-        var hasQuery = false;
-        if (limit.HasValue)
+    public Task<PagedResponse<Bundle>?> ListBundlesAsync(int? limit = null, string? cursor = null, bool fetchAll = false, CancellationToken cancellationToken = default)
+        => GetPagedAsync<Bundle>(async (c, token) =>
         {
-            path.Append("?limit=").Append(limit.Value);
-            hasQuery = true;
-        }
-        if (!string.IsNullOrEmpty(cursor))
-        {
-            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
-        }
-        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+            var path = new StringBuilder("bundles");
+            var hasQuery = false;
+            if (limit.HasValue)
+            {
+                path.Append("?limit=").Append(limit.Value);
+                hasQuery = true;
+            }
+            if (!string.IsNullOrEmpty(c))
+            {
+                path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(c));
+            }
+            using var response = await _httpClient.GetAsync(path.ToString(), token).ConfigureAwait(false);
+            await EnsureSuccessAsync(response, token).ConfigureAwait(false);
 #if NET472
-        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #else
-        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            await using var stream = await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
 #endif
-        return await JsonSerializer.DeserializeAsync<PagedResponse<Bundle>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
-    }
+            return await JsonSerializer.DeserializeAsync<PagedResponse<Bundle>>(stream, _jsonOptions, token).ConfigureAwait(false);
+        }, cursor, fetchAll, cancellationToken);
 
     public async Task<Bundle?> GetBundleAsync(string id, CancellationToken cancellationToken = default)
     {
@@ -295,28 +301,31 @@ public sealed partial class VirusTotalClient
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<PagedResponse<Relationship>?> ListBundleItemsAsync(string id, int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
+    public Task<PagedResponse<Relationship>?> ListBundleItemsAsync(string id, int? limit = null, string? cursor = null, bool fetchAll = false, CancellationToken cancellationToken = default)
     {
         ValidateId(id, nameof(id));
-        var path = new StringBuilder($"bundles/{Uri.EscapeDataString(id)}/items");
-        var hasQuery = false;
-        if (limit.HasValue)
+        return GetPagedAsync<Relationship>(async (c, token) =>
         {
-            path.Append("?limit=").Append(limit.Value);
-            hasQuery = true;
-        }
-        if (!string.IsNullOrEmpty(cursor))
-        {
-            path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(cursor));
-        }
-        using var response = await _httpClient.GetAsync(path.ToString(), cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+            var path = new StringBuilder($"bundles/{Uri.EscapeDataString(id)}/items");
+            var hasQuery = false;
+            if (limit.HasValue)
+            {
+                path.Append("?limit=").Append(limit.Value);
+                hasQuery = true;
+            }
+            if (!string.IsNullOrEmpty(c))
+            {
+                path.Append(hasQuery ? '&' : '?').Append("cursor=").Append(Uri.EscapeDataString(c));
+            }
+            using var response = await _httpClient.GetAsync(path.ToString(), token).ConfigureAwait(false);
+            await EnsureSuccessAsync(response, token).ConfigureAwait(false);
 #if NET472
-        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #else
-        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            await using var stream = await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
 #endif
-        return await JsonSerializer.DeserializeAsync<PagedResponse<Relationship>>(stream, _jsonOptions, cancellationToken).ConfigureAwait(false);
+            return await JsonSerializer.DeserializeAsync<PagedResponse<Relationship>>(stream, _jsonOptions, token).ConfigureAwait(false);
+        }, cursor, fetchAll, cancellationToken);
     }
 
     public async Task<RelationshipResponse?> AddBundleItemsAsync(string id, AddItemsRequest request, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- add shared `GetPagedAsync` helper to iterate API pages
- add `fetchAll` option to list APIs such as `ListMonitorEventsAsync` and `ListBundlesAsync`
- extend tests and examples for multi-page retrieval

## Testing
- `dotnet build VirusTotalAnalyzer.sln -p:TargetFrameworks=net8.0`
- `dotnet test VirusTotalAnalyzer.sln -p:TargetFrameworks=net8.0`

------
https://chatgpt.com/codex/tasks/task_e_689dcd0c09dc832e9774ede53cfc1d62