### PR TITLE
Use generic pagination helper for file names

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetFileNamesPagedExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileNamesPagedExample.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetFileNamesPagedExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var page = await client.GetFileNamesPagedAsync("44d88612fea8a8f36de82e1278abb02f", fetchAll: true);
+            foreach (var name in page!.Data)
+            {
+                Console.WriteLine($"{name.Id} (first seen: {name.Attributes.Date:u})");
+            }
+            Console.WriteLine($"Next cursor: {page.NextCursor}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
@@ -902,4 +902,68 @@ public partial class VirusTotalClientTests
         Assert.Single(handler.Requests);
         Assert.Equal("/api/v3/files/abc/names?limit=1", handler.Requests[0].RequestUri!.PathAndQuery);
     }
+
+    [Fact]
+    public async Task GetFileNamesPagedAsync_DeserializesResponseAndUsesCorrectPath()
+    {
+        var json = "{\"data\":[{\"id\":\"a.exe\",\"type\":\"file_name\",\"attributes\":{\"date\":1672444800}}]}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var page = await client.GetFileNamesPagedAsync("abc");
+
+        Assert.NotNull(page);
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/files/abc/names", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal("a.exe", page!.Data[0].Id);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1672444800), page.Data[0].Attributes.Date);
+    }
+
+    [Fact]
+    public async Task GetFileNamesPagedAsync_ThrowsApiException()
+    {
+        var errorJson = "{\"error\":{\"code\":\"NotFoundError\",\"message\":\"not found\"}}";
+        var response = new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent(errorJson, Encoding.UTF8, "application/json")
+        };
+        var handler = new SingleResponseHandler(response);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        await Assert.ThrowsAsync<ApiException>(() => client.GetFileNamesPagedAsync("abc"));
+    }
+
+    [Fact]
+    public async Task GetFileNamesPagedAsync_PagesThroughResultsWhenFetchAllTrue()
+    {
+        var first = "{\"data\":[{\"id\":\"a.exe\",\"type\":\"file_name\",\"attributes\":{\"date\":1}}],\"meta\":{\"cursor\":\"c1\"}}";
+        var second = "{\"data\":[{\"id\":\"b.exe\",\"type\":\"file_name\",\"attributes\":{\"date\":2}}]}";
+        var handler = new QueueHandler(
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(first, Encoding.UTF8, "application/json") },
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(second, Encoding.UTF8, "application/json") });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var page = await client.GetFileNamesPagedAsync("abc", fetchAll: true);
+
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Collection(page!.Data,
+            n => Assert.Equal("a.exe", n.Id),
+            n => Assert.Equal("b.exe", n.Id));
+        Assert.Null(page.NextCursor);
+    }
 }


### PR DESCRIPTION
## Summary
- add `GetFileNamesPagedAsync` returning `PagedResponse<FileNameInfo>`
- keep existing `GetFileNamesAsync` as wrapper for backward compatibility
- add example and tests for new paged API

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689ddf7376f4832ebc285d3b83c91cd6