### PR TITLE
Add ReanalyzeUrlAsync overload

### DIFF
--- a/VirusTotalAnalyzer.Examples/ReanalyzeUrlExample.cs
+++ b/VirusTotalAnalyzer.Examples/ReanalyzeUrlExample.cs
@@ -11,7 +11,7 @@ public static class ReanalyzeUrlExample
         var client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.ReanalyzeUrlAsync("url-id");
+            var report = await client.ReanalyzeUrlAsync("https://www.example.com");
             Console.WriteLine(report?.Id);
         }
         catch (RateLimitExceededException ex)

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
@@ -518,11 +518,13 @@ public partial class VirusTotalClientTests
         };
         var client = new VirusTotalClient(httpClient);
 
-        var report = await client.ReanalyzeUrlAsync("def");
+        const string url = "https://example.com";
+        var id = VirusTotalClientExtensions.GetUrlId(url);
+        var report = await client.ReanalyzeUrlAsync(url);
 
         Assert.NotNull(report);
         Assert.NotNull(handler.Request);
-        Assert.Equal("/api/v3/urls/def/analyse", handler.Request!.RequestUri!.AbsolutePath);
+        Assert.Equal($"/api/v3/urls/{id}/analyse", handler.Request!.RequestUri!.AbsolutePath);
     }
 
     [Fact]

--- a/VirusTotalAnalyzer/VirusTotalClient.Submissions.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Submissions.cs
@@ -255,6 +255,19 @@ public sealed partial class VirusTotalClient
         return ReanalyzeHashAsync(id, AnalysisType.Url, cancellationToken);
     }
 
+    public Task<AnalysisReport?> ReanalyzeUrlAsync(string url)
+    {
+        if (url is null)
+        {
+            throw new ArgumentNullException(nameof(url));
+        }
+        if (url.Length == 0)
+        {
+            throw new ArgumentException("Url must not be empty.", nameof(url));
+        }
+        return ReanalyzeUrlAsync(VirusTotalClientExtensions.GetUrlId(url), cancellationToken: default);
+    }
+
     public Task<AnalysisReport?> SubmitUrlAsync(string url, CancellationToken cancellationToken = default)
         => SubmitUrlAsync(url, options: null, cancellationToken);
 


### PR DESCRIPTION
## Summary
- add `ReanalyzeUrlAsync` overload accepting URL strings
- update example to call URL-based reanalyze
- test URL overload generates expected request path

## Testing
- `dotnet build VirusTotalAnalyzer.Examples/VirusTotalAnalyzer.Examples.csproj -p:TargetFramework=net8.0 -p:TargetFrameworks=net8.0`
- `dotnet test VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj -p:TargetFramework=net8.0 -p:TargetFrameworks=net8.0`


------
https://chatgpt.com/codex/tasks/task_e_689ddf78f3bc832ebf45fe100d785988