### PR TITLE
feat: add snake case naming policy

### DIFF
--- a/VirusTotalAnalyzer.Tests/AttributeSerializationTests.cs
+++ b/VirusTotalAnalyzer.Tests/AttributeSerializationTests.cs
@@ -12,7 +12,7 @@ public class AttributeSerializationTests
     [Fact]
     public void FileAttributes_Roundtrip()
     {
-        var options = new JsonSerializerOptions();
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = SnakeCaseNamingPolicy.Instance };
         options.Converters.Add(new UnixTimestampConverter());
 
         var report = new FileReport
@@ -53,7 +53,7 @@ public class AttributeSerializationTests
     [Fact]
     public void UrlAttributes_Roundtrip()
     {
-        var options = new JsonSerializerOptions();
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = SnakeCaseNamingPolicy.Instance };
         options.Converters.Add(new UnixTimestampConverter());
 
         var report = new UrlReport
@@ -92,7 +92,7 @@ public class AttributeSerializationTests
     [Fact]
     public void AnalysisAttributes_Roundtrip()
     {
-        var options = new JsonSerializerOptions();
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = SnakeCaseNamingPolicy.Instance };
         options.Converters.Add(new UnixTimestampConverter());
 
         var report = new AnalysisReport
@@ -124,7 +124,7 @@ public class AttributeSerializationTests
     [Fact]
     public void DomainAttributes_Roundtrip()
     {
-        var options = new JsonSerializerOptions();
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = SnakeCaseNamingPolicy.Instance };
         options.Converters.Add(new UnixTimestampConverter());
 
         var report = new DomainReport
@@ -156,7 +156,7 @@ public class AttributeSerializationTests
     [Fact]
     public void IpAddressAttributes_Roundtrip()
     {
-        var options = new JsonSerializerOptions();
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = SnakeCaseNamingPolicy.Instance };
         options.Converters.Add(new UnixTimestampConverter());
 
         var report = new IpAddressReport

--- a/VirusTotalAnalyzer/Models/AddItemsRequest.cs
+++ b/VirusTotalAnalyzer/Models/AddItemsRequest.cs
@@ -1,11 +1,9 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class AddItemsRequest
 {
-    [JsonPropertyName("data")]
     public List<Relationship> Data { get; set; } = new();
 }
 

--- a/VirusTotalAnalyzer/Models/AnalysisReport.cs
+++ b/VirusTotalAnalyzer/Models/AnalysisReport.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -9,7 +8,6 @@ public sealed class AnalysisReport
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
     public AnalysisData Data { get; set; } = new();
 }
@@ -21,27 +19,20 @@ public sealed class AnalysisData
 
 public sealed class AnalysisAttributes
 {
-    [JsonPropertyName("status")]
     public AnalysisStatus Status { get; set; }
 
-    [JsonPropertyName("stats")]
     public AnalysisStats Stats { get; set; } = new();
 
-    [JsonPropertyName("results")]
     public Dictionary<string, AnalysisResult> Results { get; set; } = new();
 
-    [JsonPropertyName("date")]
     public DateTimeOffset Date { get; set; }
 
-    [JsonPropertyName("error")]
     public string? Error { get; set; }
 }
 
 public sealed class AnalysisReportsResponse
 {
-    [JsonPropertyName("data")]
     public List<AnalysisReport> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public PaginationMetadata? Meta { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/AnalysisResult.cs
+++ b/VirusTotalAnalyzer/Models/AnalysisResult.cs
@@ -1,21 +1,16 @@
-using System.Text.Json.Serialization;
+
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class AnalysisResult
 {
-    [JsonPropertyName("category")]
     public string Category { get; set; } = string.Empty;
 
-    [JsonPropertyName("engine_name")]
     public string EngineName { get; set; } = string.Empty;
 
-    [JsonPropertyName("engine_version")]
     public string? EngineVersion { get; set; }
 
-    [JsonPropertyName("method")]
     public string? Method { get; set; }
 
-    [JsonPropertyName("result")]
     public string? Result { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/AnalysisStats.cs
+++ b/VirusTotalAnalyzer/Models/AnalysisStats.cs
@@ -4,11 +4,11 @@ namespace VirusTotalAnalyzer.Models;
 
 public sealed class AnalysisStats
 {
-    [JsonPropertyName("harmless")] public int Harmless { get; set; }
-    [JsonPropertyName("malicious")] public int Malicious { get; set; }
-    [JsonPropertyName("suspicious")] public int Suspicious { get; set; }
-    [JsonPropertyName("undetected")] public int Undetected { get; set; }
-    [JsonPropertyName("timeout")] public int Timeout { get; set; }
-    [JsonPropertyName("failure")] public int Failure { get; set; }
+    public int Harmless { get; set; }
+    public int Malicious { get; set; }
+    public int Suspicious { get; set; }
+    public int Undetected { get; set; }
+    public int Timeout { get; set; }
+    public int Failure { get; set; }
     [JsonPropertyName("type-unsupported")] public int TypeUnsupported { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/Bundle.cs
+++ b/VirusTotalAnalyzer/Models/Bundle.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -8,7 +7,6 @@ public sealed class Bundle
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
     public BundleData Data { get; set; } = new();
 }
@@ -20,66 +18,51 @@ public sealed class BundleData
 
 public sealed class BundleAttributes
 {
-    [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
-    [JsonPropertyName("description")]
     public string? Description { get; set; }
 
-    [JsonPropertyName("files")]
     public List<Relationship> Files { get; set; } = new();
 }
 
 public sealed class CreateBundleRequest
 {
-    [JsonPropertyName("data")]
     public CreateBundleData Data { get; set; } = new();
 }
 
 public sealed class CreateBundleData
 {
-    [JsonPropertyName("type")]
     public string Type { get; set; } = "bundle";
 
-    [JsonPropertyName("attributes")]
     public CreateBundleAttributes Attributes { get; set; } = new();
 }
 
 public sealed class CreateBundleAttributes
 {
-    [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
-    [JsonPropertyName("description")]
     public string? Description { get; set; }
 
-    [JsonPropertyName("files")]
     public List<Relationship> Files { get; set; } = new();
 }
 
 public sealed class UpdateBundleRequest
 {
-    [JsonPropertyName("data")]
     public UpdateBundleData Data { get; set; } = new();
 }
 
 public sealed class UpdateBundleData
 {
-    [JsonPropertyName("type")]
     public string Type { get; set; } = "bundle";
 
-    [JsonPropertyName("attributes")]
     public UpdateBundleAttributes Attributes { get; set; } = new();
 }
 
 public sealed class UpdateBundleAttributes
 {
-    [JsonPropertyName("name")]
     public string? Name { get; set; }
 
-    [JsonPropertyName("description")]
     public string? Description { get; set; }
 
-    [JsonPropertyName("files")]
     public List<Relationship> Files { get; set; } = new();
 }

--- a/VirusTotalAnalyzer/Models/Collection.cs
+++ b/VirusTotalAnalyzer/Models/Collection.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Serialization;
+
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -7,7 +7,6 @@ public sealed class Collection
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
     public CollectionData Data { get; set; } = new();
 }
@@ -19,48 +18,39 @@ public sealed class CollectionData
 
 public sealed class CollectionAttributes
 {
-    [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 }
 
 public sealed class CreateCollectionRequest
 {
-    [JsonPropertyName("data")]
     public CreateCollectionData Data { get; set; } = new();
 }
 
 public sealed class CreateCollectionData
 {
-    [JsonPropertyName("type")]
     public string Type { get; set; } = "collection";
 
-    [JsonPropertyName("attributes")]
     public CreateCollectionAttributes Attributes { get; set; } = new();
 }
 
 public sealed class CreateCollectionAttributes
 {
-    [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 }
 
 public sealed class UpdateCollectionRequest
 {
-    [JsonPropertyName("data")]
     public UpdateCollectionData Data { get; set; } = new();
 }
 
 public sealed class UpdateCollectionData
 {
-    [JsonPropertyName("type")]
     public string Type { get; set; } = "collection";
 
-    [JsonPropertyName("attributes")]
     public UpdateCollectionAttributes Attributes { get; set; } = new();
 }
 
 public sealed class UpdateCollectionAttributes
 {
-    [JsonPropertyName("name")]
     public string? Name { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/Comment.cs
+++ b/VirusTotalAnalyzer/Models/Comment.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -9,7 +8,6 @@ public sealed class Comment
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
     public CommentData Data { get; set; } = new();
 }
@@ -21,45 +19,36 @@ public sealed class CommentData
 
 public sealed class CommentAttributes
 {
-    [JsonPropertyName("date")]
     public DateTimeOffset Date { get; set; }
 
-    [JsonPropertyName("text")]
     public string Text { get; set; } = string.Empty;
 }
 
 public sealed class CommentsResponse
 {
-    [JsonPropertyName("data")]
     public List<Comment> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public PaginationMetadata? Meta { get; set; }
 }
 
 public sealed class CommentResponse
 {
-    [JsonPropertyName("data")]
     public Comment Data { get; set; } = new();
 }
 
 public sealed class CreateCommentRequest
 {
-    [JsonPropertyName("data")]
     public CreateCommentData Data { get; set; } = new();
 }
 
 public sealed class CreateCommentData
 {
-    [JsonPropertyName("type")]
     public string Type { get; set; } = "comment";
 
-    [JsonPropertyName("attributes")]
     public CreateCommentAttributes Attributes { get; set; } = new();
 }
 
 public sealed class CreateCommentAttributes
 {
-    [JsonPropertyName("text")]
     public string Text { get; set; } = string.Empty;
 }

--- a/VirusTotalAnalyzer/Models/CrowdsourcedIdsResult.cs
+++ b/VirusTotalAnalyzer/Models/CrowdsourcedIdsResult.cs
@@ -1,34 +1,25 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class CrowdsourcedIdsResult
 {
-    [JsonPropertyName("rule_name")]
     public string? RuleName { get; set; }
 
-    [JsonPropertyName("rule_id")]
     public string? RuleId { get; set; }
 
-    [JsonPropertyName("ruleset_id")]
     public string? RulesetId { get; set; }
 
-    [JsonPropertyName("ruleset_name")]
     public string? RulesetName { get; set; }
 
-    [JsonPropertyName("source")]
     public string? Source { get; set; }
 
-    [JsonPropertyName("alert_severity")]
     public int AlertSeverity { get; set; }
 
-    [JsonPropertyName("description")]
     public string? Description { get; set; }
 }
 
 public sealed class CrowdsourcedIdsResultsResponse
 {
-    [JsonPropertyName("data")]
     public List<CrowdsourcedIdsResult> Data { get; set; } = new();
 }

--- a/VirusTotalAnalyzer/Models/CrowdsourcedVerdict.cs
+++ b/VirusTotalAnalyzer/Models/CrowdsourcedVerdict.cs
@@ -1,16 +1,12 @@
 using System;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class CrowdsourcedVerdict
 {
-    [JsonPropertyName("source")]
     public string Source { get; set; } = string.Empty;
 
-    [JsonPropertyName("verdict")]
     public Verdict Verdict { get; set; }
 
-    [JsonPropertyName("timestamp")]
     public DateTimeOffset Timestamp { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/CrowdsourcedYaraResult.cs
+++ b/VirusTotalAnalyzer/Models/CrowdsourcedYaraResult.cs
@@ -1,31 +1,23 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class CrowdsourcedYaraResult
 {
-    [JsonPropertyName("rule_name")]
     public string? RuleName { get; set; }
 
-    [JsonPropertyName("ruleset_id")]
     public string? RulesetId { get; set; }
 
-    [JsonPropertyName("ruleset_name")]
     public string? RulesetName { get; set; }
 
-    [JsonPropertyName("source")]
     public string? Source { get; set; }
 
-    [JsonPropertyName("author")]
     public string? Author { get; set; }
 
-    [JsonPropertyName("description")]
     public string? Description { get; set; }
 }
 
 public sealed class CrowdsourcedYaraResultsResponse
 {
-    [JsonPropertyName("data")]
     public List<CrowdsourcedYaraResult> Data { get; set; } = new();
 }

--- a/VirusTotalAnalyzer/Models/DnsRecord.cs
+++ b/VirusTotalAnalyzer/Models/DnsRecord.cs
@@ -20,18 +20,14 @@ public sealed class DnsRecordAttributes
     [JsonPropertyName("type")]
     public string? RecordType { get; set; }
 
-    [JsonPropertyName("value")]
     public string? Value { get; set; }
 
-    [JsonPropertyName("ttl")]
     public int? Ttl { get; set; }
 }
 
 public sealed class DnsRecordsResponse
 {
-    [JsonPropertyName("data")]
     public List<DnsRecord> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public PaginationMetadata? Meta { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/DomainRelationships.cs
+++ b/VirusTotalAnalyzer/Models/DomainRelationships.cs
@@ -1,32 +1,25 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class DomainSubdomainsResponse
 {
-    [JsonPropertyName("data")]
     public List<DomainSummary> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public PaginationMetadata? Meta { get; set; }
 }
 
 public sealed class DomainSiblingsResponse
 {
-    [JsonPropertyName("data")]
     public List<DomainSummary> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public PaginationMetadata? Meta { get; set; }
 }
 
 public sealed class DomainUrlsResponse
 {
-    [JsonPropertyName("data")]
     public List<UrlSummary> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public PaginationMetadata? Meta { get; set; }
 }
 

--- a/VirusTotalAnalyzer/Models/DomainReport.cs
+++ b/VirusTotalAnalyzer/Models/DomainReport.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -9,54 +8,40 @@ public sealed class DomainReport
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
 
-    [JsonPropertyName("attributes")]
     public DomainAttributes Attributes { get; set; } = new();
 }
 
 public sealed class DomainReportResponse
 {
-    [JsonPropertyName("data")]
     public DomainReport Data { get; set; } = new();
 }
 
 public sealed class DomainReportsResponse
 {
-    [JsonPropertyName("data")]
     public List<DomainReport> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public PaginationMetadata? Meta { get; set; }
 }
 
 public sealed class DomainAttributes
 {
-    [JsonPropertyName("domain")]
     public string Domain { get; set; } = string.Empty;
 
-    [JsonPropertyName("reputation")]
     public int Reputation { get; set; }
 
-    [JsonPropertyName("creation_date")]
     public DateTimeOffset CreationDate { get; set; }
 
-    [JsonPropertyName("tags")]
     public List<string> Tags { get; set; } = new();
 
-    [JsonPropertyName("last_analysis_stats")]
     public AnalysisStats LastAnalysisStats { get; set; } = new();
 
-    [JsonPropertyName("last_analysis_results")]
     public Dictionary<string, AnalysisResult> LastAnalysisResults { get; set; } = new();
 
-    [JsonPropertyName("total_votes")]
     public TotalVotes TotalVotes { get; set; } = new();
 
-    [JsonPropertyName("categories")]
     public Dictionary<string, Verdict> Categories { get; set; } = new();
 
-    [JsonPropertyName("last_analysis_date")]
     public DateTimeOffset LastAnalysisDate { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/DomainSummary.cs
+++ b/VirusTotalAnalyzer/Models/DomainSummary.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -8,7 +7,6 @@ public sealed class DomainSummary
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
     public DomainSummaryData Data { get; set; } = new();
 }
@@ -20,22 +18,17 @@ public sealed class DomainSummaryData
 
 public sealed class DomainSummaryAttributes
 {
-    [JsonPropertyName("domain")]
     public string Domain { get; set; } = string.Empty;
 
-    [JsonPropertyName("last_analysis_stats")]
     public AnalysisStats LastAnalysisStats { get; set; } = new();
 
-    [JsonPropertyName("total_votes")]
     public TotalVotes TotalVotes { get; set; } = new();
 }
 
 public sealed class DomainSummariesResponse
 {
-    [JsonPropertyName("data")]
     public List<DomainSummary> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public PaginationMetadata? Meta { get; set; }
 }
 

--- a/VirusTotalAnalyzer/Models/DomainWhois.cs
+++ b/VirusTotalAnalyzer/Models/DomainWhois.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Serialization;
+
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -7,7 +7,6 @@ public sealed class DomainWhois
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
     public DomainWhoisData Data { get; set; } = new();
 }
@@ -19,6 +18,5 @@ public sealed class DomainWhoisData
 
 public sealed class DomainWhoisAttributes
 {
-    [JsonPropertyName("whois")]
     public string Whois { get; set; } = string.Empty;
 }

--- a/VirusTotalAnalyzer/Models/FeedResponse.cs
+++ b/VirusTotalAnalyzer/Models/FeedResponse.cs
@@ -1,25 +1,19 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class FeedResponse
 {
-    [JsonPropertyName("data")]
     public List<FeedItem> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public PaginationMetadata? Meta { get; set; }
 }
 
 public sealed class FeedItem
 {
-    [JsonPropertyName("id")]
     public string Id { get; set; } = string.Empty;
 
-    [JsonPropertyName("type")]
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
 }

--- a/VirusTotalAnalyzer/Models/FileBehavior.cs
+++ b/VirusTotalAnalyzer/Models/FileBehavior.cs
@@ -1,34 +1,27 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class FileBehavior
 {
-    [JsonPropertyName("data")]
     public List<BehaviorEntry> Data { get; set; } = new();
 }
 
 public sealed class BehaviorEntry
 {
-    [JsonPropertyName("id")]
     public string Id { get; set; } = string.Empty;
 
-    [JsonPropertyName("type")]
     public string Type { get; set; } = string.Empty;
 
-    [JsonPropertyName("attributes")]
     public BehaviorAttributes Attributes { get; set; } = new();
 }
 
 public sealed class BehaviorAttributes
 {
-    [JsonPropertyName("processes")]
     public List<BehaviorProcess> Processes { get; set; } = new();
 }
 
 public sealed class BehaviorProcess
 {
-    [JsonPropertyName("name")]
     public string? Name { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/FileBehaviorSummary.cs
+++ b/VirusTotalAnalyzer/Models/FileBehaviorSummary.cs
@@ -1,16 +1,13 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class FileBehaviorSummary
 {
-    [JsonPropertyName("data")]
     public BehaviorSummaryData Data { get; set; } = new();
 }
 
 public sealed class BehaviorSummaryData
 {
-    [JsonPropertyName("tags")]
     public List<string> Tags { get; set; } = new();
 }

--- a/VirusTotalAnalyzer/Models/FileClassification.cs
+++ b/VirusTotalAnalyzer/Models/FileClassification.cs
@@ -1,34 +1,27 @@
-using System.Text.Json.Serialization;
+
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class FileClassification
 {
-    [JsonPropertyName("data")]
     public FileClassificationData Data { get; set; } = new();
 }
 
 public sealed class FileClassificationData
 {
-    [JsonPropertyName("id")]
     public string Id { get; set; } = string.Empty;
 
-    [JsonPropertyName("type")]
     public string Type { get; set; } = string.Empty;
 
-    [JsonPropertyName("attributes")]
     public FileClassificationAttributes Attributes { get; set; } = new();
 }
 
 public sealed class FileClassificationAttributes
 {
-    [JsonPropertyName("popular_threat_name")]
     public string? PopularThreatName { get; set; }
 
-    [JsonPropertyName("popular_threat_category")]
     public string? PopularThreatCategory { get; set; }
 
-    [JsonPropertyName("suggested_threat_label")]
     public string? SuggestedThreatLabel { get; set; }
 }
 

--- a/VirusTotalAnalyzer/Models/FileName.cs
+++ b/VirusTotalAnalyzer/Models/FileName.cs
@@ -1,33 +1,26 @@
 using System;
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class FileNamesResponse
 {
-    [JsonPropertyName("data")]
     public List<FileNameInfo> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public Meta? Meta { get; set; }
 }
 
 public sealed class FileNameInfo
 {
-    [JsonPropertyName("id")]
     public string Id { get; set; } = string.Empty;
 
-    [JsonPropertyName("type")]
     public string Type { get; set; } = string.Empty;
 
-    [JsonPropertyName("attributes")]
     public FileNameAttributes Attributes { get; set; } = new();
 }
 
 public sealed class FileNameAttributes
 {
-    [JsonPropertyName("date")]
     public DateTimeOffset Date { get; set; }
 }
 

--- a/VirusTotalAnalyzer/Models/FileNetworkTraffic.cs
+++ b/VirusTotalAnalyzer/Models/FileNetworkTraffic.cs
@@ -5,13 +5,11 @@ namespace VirusTotalAnalyzer.Models;
 
 public sealed class FileNetworkTraffic
 {
-    [JsonPropertyName("data")]
     public NetworkTrafficData Data { get; set; } = new();
 }
 
 public sealed class NetworkTrafficData
 {
-    [JsonPropertyName("tcp")]
     public List<NetworkTcpEntry> Tcp { get; set; } = new();
 }
 
@@ -20,6 +18,5 @@ public sealed class NetworkTcpEntry
     [JsonPropertyName("dst")]
     public string? Destination { get; set; }
 
-    [JsonPropertyName("port")]
     public int Port { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/FilePeInfo.cs
+++ b/VirusTotalAnalyzer/Models/FilePeInfo.cs
@@ -1,34 +1,27 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class FilePeInfo
 {
-    [JsonPropertyName("data")]
     public PeInfoData Data { get; set; } = new();
 }
 
 public sealed class PeInfoData
 {
-    [JsonPropertyName("attributes")]
     public PeInfoAttributes Attributes { get; set; } = new();
 }
 
 public sealed class PeInfoAttributes
 {
-    [JsonPropertyName("imphash")]
     public string? Imphash { get; set; }
 
-    [JsonPropertyName("machine_type")]
     public string? MachineType { get; set; }
 
-    [JsonPropertyName("sections")]
     public List<PeSection> Sections { get; set; } = new();
 }
 
 public sealed class PeSection
 {
-    [JsonPropertyName("name")]
     public string? Name { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/FileReport.cs
+++ b/VirusTotalAnalyzer/Models/FileReport.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -9,82 +8,59 @@ public sealed class FileReport
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
 
-    [JsonPropertyName("attributes")]
     public FileAttributes Attributes { get; set; } = new();
 }
 
 public sealed class FileReportResponse
 {
-    [JsonPropertyName("data")]
     public FileReport Data { get; set; } = new();
 }
 
 public sealed class FileAttributes
 {
-    [JsonPropertyName("md5")]
     public string Md5 { get; set; } = string.Empty;
 
-    [JsonPropertyName("sha256")]
     public string? Sha256 { get; set; }
 
-    [JsonPropertyName("reputation")]
     public int Reputation { get; set; }
 
-    [JsonPropertyName("creation_date")]
     public DateTimeOffset CreationDate { get; set; }
 
-    [JsonPropertyName("tags")]
     public List<string> Tags { get; set; } = new();
 
-    [JsonPropertyName("size")]
     public long Size { get; set; }
 
-    [JsonPropertyName("first_submission_date")]
     public DateTimeOffset FirstSubmissionDate { get; set; }
 
-    [JsonPropertyName("last_submission_date")]
     public DateTimeOffset LastSubmissionDate { get; set; }
 
-    [JsonPropertyName("last_modification_date")]
     public DateTimeOffset LastModificationDate { get; set; }
 
-    [JsonPropertyName("times_submitted")]
     public int TimesSubmitted { get; set; }
 
-    [JsonPropertyName("meaningful_name")]
     public string? MeaningfulName { get; set; }
 
-    [JsonPropertyName("names")]
     public List<string> Names { get; set; } = new();
 
-    [JsonPropertyName("last_analysis_stats")]
     public AnalysisStats LastAnalysisStats { get; set; } = new();
 
-    [JsonPropertyName("last_analysis_results")]
     public Dictionary<string, AnalysisResult> LastAnalysisResults { get; set; } = new();
 
-    [JsonPropertyName("total_votes")]
     public TotalVotes TotalVotes { get; set; } = new();
 
-    [JsonPropertyName("categories")]
     public Dictionary<string, Verdict> Categories { get; set; } = new();
 
-    [JsonPropertyName("last_analysis_date")]
     public DateTimeOffset LastAnalysisDate { get; set; }
 
-    [JsonPropertyName("crowdsourced_verdicts")]
     public List<CrowdsourcedVerdict> CrowdsourcedVerdicts { get; set; } = new();
 }
 
 public sealed class FileReportsResponse
 {
-    [JsonPropertyName("data")]
     public List<FileReport> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public PaginationMetadata? Meta { get; set; }
 }
 

--- a/VirusTotalAnalyzer/Models/FileStringsResponse.cs
+++ b/VirusTotalAnalyzer/Models/FileStringsResponse.cs
@@ -1,10 +1,8 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class FileStringsResponse
 {
-    [JsonPropertyName("data")]
     public List<string> Data { get; set; } = new();
 }

--- a/VirusTotalAnalyzer/Models/Graph.cs
+++ b/VirusTotalAnalyzer/Models/Graph.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Serialization;
+
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -7,7 +7,6 @@ public sealed class Graph
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
     public GraphData Data { get; set; } = new();
 }
@@ -19,48 +18,39 @@ public sealed class GraphData
 
 public sealed class GraphAttributes
 {
-    [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 }
 
 public sealed class CreateGraphRequest
 {
-    [JsonPropertyName("data")]
     public CreateGraphData Data { get; set; } = new();
 }
 
 public sealed class CreateGraphData
 {
-    [JsonPropertyName("type")]
     public string Type { get; set; } = "graph";
 
-    [JsonPropertyName("attributes")]
     public CreateGraphAttributes Attributes { get; set; } = new();
 }
 
 public sealed class CreateGraphAttributes
 {
-    [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 }
 
 public sealed class UpdateGraphRequest
 {
-    [JsonPropertyName("data")]
     public UpdateGraphData Data { get; set; } = new();
 }
 
 public sealed class UpdateGraphData
 {
-    [JsonPropertyName("type")]
     public string Type { get; set; } = "graph";
 
-    [JsonPropertyName("attributes")]
     public UpdateGraphAttributes Attributes { get; set; } = new();
 }
 
 public sealed class UpdateGraphAttributes
 {
-    [JsonPropertyName("name")]
     public string? Name { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/IocStreamResponse.cs
+++ b/VirusTotalAnalyzer/Models/IocStreamResponse.cs
@@ -1,26 +1,20 @@
 using System.Collections.Generic;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class IocStreamResponse
 {
-    [JsonPropertyName("data")]
     public List<IocStreamItem> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public PaginationMetadata? Meta { get; set; }
 }
 
 public sealed class IocStreamItem
 {
-    [JsonPropertyName("type")]
     public string Type { get; set; } = string.Empty;
 
-    [JsonPropertyName("id")]
     public string Id { get; set; } = string.Empty;
 
-    [JsonPropertyName("attributes")]
     public Dictionary<string, JsonElement>? Attributes { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/IpAddressReport.cs
+++ b/VirusTotalAnalyzer/Models/IpAddressReport.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -9,54 +8,40 @@ public sealed class IpAddressReport
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
 
-    [JsonPropertyName("attributes")]
     public IpAddressAttributes Attributes { get; set; } = new();
 }
 
 public sealed class IpAddressReportResponse
 {
-    [JsonPropertyName("data")]
     public IpAddressReport Data { get; set; } = new();
 }
 
 public sealed class IpAddressReportsResponse
 {
-    [JsonPropertyName("data")]
     public List<IpAddressReport> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public PaginationMetadata? Meta { get; set; }
 }
 
 public sealed class IpAddressAttributes
 {
-    [JsonPropertyName("ip_address")]
     public string IpAddress { get; set; } = string.Empty;
 
-    [JsonPropertyName("reputation")]
     public int Reputation { get; set; }
 
-    [JsonPropertyName("creation_date")]
     public DateTimeOffset CreationDate { get; set; }
 
-    [JsonPropertyName("tags")]
     public List<string> Tags { get; set; } = new();
 
-    [JsonPropertyName("last_analysis_stats")]
     public AnalysisStats LastAnalysisStats { get; set; } = new();
 
-    [JsonPropertyName("last_analysis_results")]
     public Dictionary<string, AnalysisResult> LastAnalysisResults { get; set; } = new();
 
-    [JsonPropertyName("total_votes")]
     public TotalVotes TotalVotes { get; set; } = new();
 
-    [JsonPropertyName("categories")]
     public Dictionary<string, Verdict> Categories { get; set; } = new();
 
-    [JsonPropertyName("last_analysis_date")]
     public DateTimeOffset LastAnalysisDate { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/IpAddressSummary.cs
+++ b/VirusTotalAnalyzer/Models/IpAddressSummary.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -8,14 +7,12 @@ public sealed class IpAddressSummary
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
     public IpAddressSummaryData Data { get; set; } = new();
 }
 
 public sealed class IpAddressSummaryResponse
 {
-    [JsonPropertyName("data")]
     public IpAddressSummary Data { get; set; } = new();
 }
 
@@ -26,22 +23,17 @@ public sealed class IpAddressSummaryData
 
 public sealed class IpAddressSummaryAttributes
 {
-    [JsonPropertyName("ip_address")]
     public string IpAddress { get; set; } = string.Empty;
 
-    [JsonPropertyName("last_analysis_stats")]
     public AnalysisStats LastAnalysisStats { get; set; } = new();
 
-    [JsonPropertyName("total_votes")]
     public TotalVotes TotalVotes { get; set; } = new();
 }
 
 public sealed class IpAddressSummariesResponse
 {
-    [JsonPropertyName("data")]
     public List<IpAddressSummary> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public PaginationMetadata? Meta { get; set; }
 }
 

--- a/VirusTotalAnalyzer/Models/IpWhois.cs
+++ b/VirusTotalAnalyzer/Models/IpWhois.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Serialization;
+
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -7,7 +7,6 @@ public sealed class IpWhois
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
     public IpWhoisData Data { get; set; } = new();
 }
@@ -19,6 +18,5 @@ public sealed class IpWhoisData
 
 public sealed class IpWhoisAttributes
 {
-    [JsonPropertyName("whois")]
     public string Whois { get; set; } = string.Empty;
 }

--- a/VirusTotalAnalyzer/Models/Links.cs
+++ b/VirusTotalAnalyzer/Models/Links.cs
@@ -1,13 +1,10 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class Links
 {
-    [JsonPropertyName("self")]
     public string Self { get; set; } = string.Empty;
 
-    [JsonPropertyName("related")]
     public Dictionary<string, string> Related { get; set; } = new();
 }

--- a/VirusTotalAnalyzer/Models/LivehuntNotification.cs
+++ b/VirusTotalAnalyzer/Models/LivehuntNotification.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -8,30 +7,24 @@ public sealed class LivehuntNotification
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
 
-    [JsonPropertyName("attributes")]
     public LivehuntNotificationAttributes Attributes { get; set; } = new();
 }
 
 public sealed class LivehuntNotificationResponse
 {
-    [JsonPropertyName("data")]
     public LivehuntNotification Data { get; set; } = new();
 }
 
 public sealed class LivehuntNotificationAttributes
 {
-    [JsonPropertyName("rule_name")]
     public string RuleName { get; set; } = string.Empty;
 }
 
 public sealed class LivehuntNotificationsResponse
 {
-    [JsonPropertyName("data")]
     public List<LivehuntNotification> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public Meta? Meta { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/Meta.cs
+++ b/VirusTotalAnalyzer/Models/Meta.cs
@@ -1,10 +1,9 @@
-using System.Text.Json.Serialization;
+
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class Meta
 {
-    [JsonPropertyName("cursor")]
     public string? Cursor { get; set; }
 }
 

--- a/VirusTotalAnalyzer/Models/MonitorEvent.cs
+++ b/VirusTotalAnalyzer/Models/MonitorEvent.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Serialization;
+
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -7,7 +7,6 @@ public sealed class MonitorEvent
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
     public MonitorEventData Data { get; set; } = new();
 }
@@ -19,13 +18,10 @@ public sealed class MonitorEventData
 
 public sealed class MonitorEventAttributes
 {
-    [JsonPropertyName("item_id")]
     public string ItemId { get; set; } = string.Empty;
 
-    [JsonPropertyName("path")]
     public string Path { get; set; } = string.Empty;
 
-    [JsonPropertyName("event_type")]
     public string EventType { get; set; } = string.Empty;
 }
 

--- a/VirusTotalAnalyzer/Models/MonitorItem.cs
+++ b/VirusTotalAnalyzer/Models/MonitorItem.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Serialization;
+
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -7,7 +7,6 @@ public sealed class MonitorItem
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
     public MonitorItemData Data { get; set; } = new();
 }
@@ -19,48 +18,39 @@ public sealed class MonitorItemData
 
 public sealed class MonitorItemAttributes
 {
-    [JsonPropertyName("path")]
     public string Path { get; set; } = string.Empty;
 }
 
 public sealed class CreateMonitorItemRequest
 {
-    [JsonPropertyName("data")]
     public CreateMonitorItemData Data { get; set; } = new();
 }
 
 public sealed class CreateMonitorItemData
 {
-    [JsonPropertyName("type")]
     public string Type { get; set; } = "monitor_item";
 
-    [JsonPropertyName("attributes")]
     public CreateMonitorItemAttributes Attributes { get; set; } = new();
 }
 
 public sealed class CreateMonitorItemAttributes
 {
-    [JsonPropertyName("path")]
     public string Path { get; set; } = string.Empty;
 }
 
 public sealed class UpdateMonitorItemRequest
 {
-    [JsonPropertyName("data")]
     public UpdateMonitorItemData Data { get; set; } = new();
 }
 
 public sealed class UpdateMonitorItemData
 {
-    [JsonPropertyName("type")]
     public string Type { get; set; } = "monitor_item";
 
-    [JsonPropertyName("attributes")]
     public UpdateMonitorItemAttributes Attributes { get; set; } = new();
 }
 
 public sealed class UpdateMonitorItemAttributes
 {
-    [JsonPropertyName("path")]
     public string? Path { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/PagedResponse.cs
+++ b/VirusTotalAnalyzer/Models/PagedResponse.cs
@@ -1,14 +1,11 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class PagedResponse<T>
 {
-    [JsonPropertyName("data")]
     public List<T> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public Meta? Meta { get; set; }
 
     public string? NextCursor => Meta?.Cursor;

--- a/VirusTotalAnalyzer/Models/PaginationMetadata.cs
+++ b/VirusTotalAnalyzer/Models/PaginationMetadata.cs
@@ -1,9 +1,8 @@
-using System.Text.Json.Serialization;
+
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class PaginationMetadata
 {
-    [JsonPropertyName("cursor")]
     public string? Cursor { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/PrivateAnalysis.cs
+++ b/VirusTotalAnalyzer/Models/PrivateAnalysis.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -9,7 +8,6 @@ public sealed class PrivateAnalysis
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
     public PrivateAnalysisData Data { get; set; } = new();
 }
@@ -21,18 +19,13 @@ public sealed class PrivateAnalysisData
 
 public sealed class PrivateAnalysisAttributes
 {
-    [JsonPropertyName("status")]
     public AnalysisStatus Status { get; set; }
 
-    [JsonPropertyName("stats")]
     public AnalysisStats Stats { get; set; } = new();
 
-    [JsonPropertyName("results")]
     public Dictionary<string, AnalysisResult> Results { get; set; } = new();
 
-    [JsonPropertyName("date")]
     public DateTimeOffset Date { get; set; }
 
-    [JsonPropertyName("error")]
     public string? Error { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/Relationship.cs
+++ b/VirusTotalAnalyzer/Models/Relationship.cs
@@ -1,22 +1,17 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class Relationship
 {
-    [JsonPropertyName("id")]
     public string Id { get; set; } = string.Empty;
 
-    [JsonPropertyName("type")]
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
 }
 
 public sealed class RelationshipResponse
 {
-    [JsonPropertyName("data")]
     public List<Relationship> Data { get; set; } = new();
 }

--- a/VirusTotalAnalyzer/Models/Resolution.cs
+++ b/VirusTotalAnalyzer/Models/Resolution.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -18,21 +17,16 @@ public sealed class ResolutionData
 
 public sealed class ResolutionAttributes
 {
-    [JsonPropertyName("date")]
     public DateTimeOffset Date { get; set; }
 
-    [JsonPropertyName("host_name")]
     public string? HostName { get; set; }
 
-    [JsonPropertyName("ip_address")]
     public string? IpAddress { get; set; }
 }
 
 public sealed class ResolutionsResponse
 {
-    [JsonPropertyName("data")]
     public List<Resolution> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public PaginationMetadata? Meta { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/RetrohuntJob.cs
+++ b/VirusTotalAnalyzer/Models/RetrohuntJob.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -8,7 +7,6 @@ public sealed class RetrohuntJob
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
     public RetrohuntJobData Data { get; set; } = new();
 }
@@ -20,21 +18,17 @@ public sealed class RetrohuntJobData
 
 public sealed class RetrohuntJobAttributes
 {
-    [JsonPropertyName("status")]
     public string Status { get; set; } = string.Empty;
 }
 
 public sealed class RetrohuntJobResponse
 {
-    [JsonPropertyName("data")]
     public RetrohuntJob? Data { get; set; }
 }
 
 public sealed class RetrohuntJobsResponse
 {
-    [JsonPropertyName("data")]
     public List<RetrohuntJob> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public Meta? Meta { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/RetrohuntJobRequest.cs
+++ b/VirusTotalAnalyzer/Models/RetrohuntJobRequest.cs
@@ -1,35 +1,27 @@
 using System;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class RetrohuntJobRequest
 {
-    [JsonPropertyName("data")]
     public RetrohuntJobRequestData Data { get; set; } = new();
 }
 
 public sealed class RetrohuntJobRequestData
 {
-    [JsonPropertyName("type")]
     public string Type { get; set; } = "retrohunt_job";
 
-    [JsonPropertyName("attributes")]
     public RetrohuntJobRequestAttributes Attributes { get; set; } = new();
 }
 
 public sealed class RetrohuntJobRequestAttributes
 {
-    [JsonPropertyName("rules")]
     public string Rules { get; set; } = string.Empty;
 
-    [JsonPropertyName("comment")]
     public string? Comment { get; set; }
 
-    [JsonPropertyName("from")]
     public DateTimeOffset? From { get; set; }
 
-    [JsonPropertyName("to")]
     public DateTimeOffset? To { get; set; }
 }
 

--- a/VirusTotalAnalyzer/Models/RetrohuntNotification.cs
+++ b/VirusTotalAnalyzer/Models/RetrohuntNotification.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -8,7 +7,6 @@ public sealed class RetrohuntNotification
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
     public RetrohuntNotificationData Data { get; set; } = new();
 }
@@ -20,15 +18,12 @@ public sealed class RetrohuntNotificationData
 
 public sealed class RetrohuntNotificationAttributes
 {
-    [JsonPropertyName("job_id")]
     public string JobId { get; set; } = string.Empty;
 }
 
 public sealed class RetrohuntNotificationsResponse
 {
-    [JsonPropertyName("data")]
     public List<RetrohuntNotification> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public Meta? Meta { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/SearchResponse.cs
+++ b/VirusTotalAnalyzer/Models/SearchResponse.cs
@@ -1,25 +1,19 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class SearchResponse
 {
-    [JsonPropertyName("data")]
     public List<SearchResult> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public PaginationMetadata? Meta { get; set; }
 }
 
 public sealed class SearchResult
 {
-    [JsonPropertyName("id")]
     public string Id { get; set; } = string.Empty;
 
-    [JsonPropertyName("type")]
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
 }

--- a/VirusTotalAnalyzer/Models/Submission.cs
+++ b/VirusTotalAnalyzer/Models/Submission.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -18,15 +17,12 @@ public sealed class SubmissionData
 
 public sealed class SubmissionAttributes
 {
-    [JsonPropertyName("date")]
     public DateTimeOffset Date { get; set; }
 }
 
 public sealed class SubmissionsResponse
 {
-    [JsonPropertyName("data")]
     public List<Submission> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public PaginationMetadata? Meta { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/ThreatCategory.cs
+++ b/VirusTotalAnalyzer/Models/ThreatCategory.cs
@@ -1,28 +1,22 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class ThreatCategory
 {
-    [JsonPropertyName("id")]
     public string Id { get; set; } = string.Empty;
 
-    [JsonPropertyName("type")]
     public string Type { get; set; } = string.Empty;
 
-    [JsonPropertyName("attributes")]
     public ThreatCategoryAttributes Attributes { get; set; } = new();
 }
 
 public sealed class ThreatCategoryAttributes
 {
-    [JsonPropertyName("count")]
     public long Count { get; set; }
 }
 
 public sealed class ThreatCategoriesResponse
 {
-    [JsonPropertyName("data")]
     public List<ThreatCategory> Data { get; set; } = new();
 }

--- a/VirusTotalAnalyzer/Models/TotalVotes.cs
+++ b/VirusTotalAnalyzer/Models/TotalVotes.cs
@@ -1,9 +1,7 @@
-using System.Text.Json.Serialization;
-
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class TotalVotes
 {
-    [JsonPropertyName("harmless")] public int Harmless { get; set; }
-    [JsonPropertyName("malicious")] public int Malicious { get; set; }
+    public int Harmless { get; set; }
+    public int Malicious { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/UrlReport.cs
+++ b/VirusTotalAnalyzer/Models/UrlReport.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -9,69 +8,50 @@ public sealed class UrlReport
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
 
-    [JsonPropertyName("attributes")]
     public UrlAttributes Attributes { get; set; } = new();
 }
 
 public sealed class UrlReportResponse
 {
-    [JsonPropertyName("data")]
     public UrlReport Data { get; set; } = new();
 }
 
 public sealed class UrlReportsResponse
 {
-    [JsonPropertyName("data")]
     public List<UrlReport> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public PaginationMetadata? Meta { get; set; }
 }
 
 public sealed class UrlAttributes
 {
-    [JsonPropertyName("url")]
     public string Url { get; set; } = string.Empty;
 
-    [JsonPropertyName("reputation")]
     public int Reputation { get; set; }
 
-    [JsonPropertyName("creation_date")]
     public DateTimeOffset CreationDate { get; set; }
 
-    [JsonPropertyName("tags")]
     public List<string> Tags { get; set; } = new();
 
-    [JsonPropertyName("first_submission_date")]
     public DateTimeOffset FirstSubmissionDate { get; set; }
 
-    [JsonPropertyName("last_submission_date")]
     public DateTimeOffset LastSubmissionDate { get; set; }
 
-    [JsonPropertyName("last_modification_date")]
     public DateTimeOffset LastModificationDate { get; set; }
 
-    [JsonPropertyName("times_submitted")]
     public int TimesSubmitted { get; set; }
 
-    [JsonPropertyName("last_analysis_stats")]
     public AnalysisStats LastAnalysisStats { get; set; } = new();
 
-    [JsonPropertyName("last_analysis_results")]
     public Dictionary<string, AnalysisResult> LastAnalysisResults { get; set; } = new();
 
-    [JsonPropertyName("total_votes")]
     public TotalVotes TotalVotes { get; set; } = new();
 
-    [JsonPropertyName("categories")]
     public Dictionary<string, Verdict> Categories { get; set; } = new();
 
-    [JsonPropertyName("last_analysis_date")]
     public DateTimeOffset LastAnalysisDate { get; set; }
 
-    [JsonPropertyName("crowdsourced_verdicts")]
     public List<CrowdsourcedVerdict> CrowdsourcedVerdicts { get; set; } = new();
 }

--- a/VirusTotalAnalyzer/Models/UrlSummary.cs
+++ b/VirusTotalAnalyzer/Models/UrlSummary.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -8,7 +7,6 @@ public sealed class UrlSummary
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
     public UrlSummaryData Data { get; set; } = new();
 }
@@ -20,22 +18,17 @@ public sealed class UrlSummaryData
 
 public sealed class UrlSummaryAttributes
 {
-    [JsonPropertyName("url")]
     public string Url { get; set; } = string.Empty;
 
-    [JsonPropertyName("last_analysis_stats")]
     public AnalysisStats LastAnalysisStats { get; set; } = new();
 
-    [JsonPropertyName("total_votes")]
     public TotalVotes TotalVotes { get; set; } = new();
 }
 
 public sealed class UrlSummariesResponse
 {
-    [JsonPropertyName("data")]
     public List<UrlSummary> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public PaginationMetadata? Meta { get; set; }
 }
 

--- a/VirusTotalAnalyzer/Models/User.cs
+++ b/VirusTotalAnalyzer/Models/User.cs
@@ -1,5 +1,4 @@
 using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -8,7 +7,6 @@ public sealed class User
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
     public UserData Data { get; set; } = new();
 }
@@ -20,10 +18,8 @@ public sealed class UserData
 
 public sealed class UserAttributes
 {
-    [JsonPropertyName("username")]
     public string Username { get; set; } = string.Empty;
 
-    [JsonPropertyName("role")]
     public UserRole Role { get; set; }
 }
 

--- a/VirusTotalAnalyzer/Models/UserPrivileges.cs
+++ b/VirusTotalAnalyzer/Models/UserPrivileges.cs
@@ -1,16 +1,13 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class UserPrivileges
 {
-    [JsonPropertyName("data")]
     public Dictionary<string, PrivilegeData> Data { get; set; } = new();
 }
 
 public sealed class PrivilegeData
 {
-    [JsonPropertyName("allowed")]
     public bool Allowed { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/UserQuota.cs
+++ b/VirusTotalAnalyzer/Models/UserQuota.cs
@@ -1,19 +1,15 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class UserQuota
 {
-    [JsonPropertyName("data")]
     public Dictionary<string, QuotaData> Data { get; set; } = new();
 }
 
 public sealed class QuotaData
 {
-    [JsonPropertyName("allowed")]
     public long Allowed { get; set; }
 
-    [JsonPropertyName("used")]
     public long Used { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/Vote.cs
+++ b/VirusTotalAnalyzer/Models/Vote.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -9,7 +8,6 @@ public sealed class Vote
     public string Id { get; set; } = string.Empty;
     public ResourceType Type { get; set; }
 
-    [JsonPropertyName("links")]
     public Links Links { get; set; } = new();
     public VoteData Data { get; set; } = new();
 }
@@ -21,45 +19,36 @@ public sealed class VoteData
 
 public sealed class VoteAttributes
 {
-    [JsonPropertyName("date")]
     public DateTimeOffset Date { get; set; }
 
-    [JsonPropertyName("verdict")]
     public VoteVerdict Verdict { get; set; }
 }
 
 public sealed class VotesResponse
 {
-    [JsonPropertyName("data")]
     public List<Vote> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public PaginationMetadata? Meta { get; set; }
 }
 
 public sealed class VoteResponse
 {
-    [JsonPropertyName("data")]
     public Vote Data { get; set; } = new();
 }
 
 public sealed class CreateVoteRequest
 {
-    [JsonPropertyName("data")]
     public CreateVoteData Data { get; set; } = new();
 }
 
 public sealed class CreateVoteData
 {
-    [JsonPropertyName("type")]
     public string Type { get; set; } = "vote";
 
-    [JsonPropertyName("attributes")]
     public CreateVoteAttributes Attributes { get; set; } = new();
 }
 
 public sealed class CreateVoteAttributes
 {
-    [JsonPropertyName("verdict")]
     public VoteVerdict Verdict { get; set; }
 }

--- a/VirusTotalAnalyzer/Models/YaraRuleset.cs
+++ b/VirusTotalAnalyzer/Models/YaraRuleset.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
@@ -17,28 +16,22 @@ public sealed class YaraRulesetData
 
 public sealed class YaraRulesetAttributes
 {
-    [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
-    [JsonPropertyName("rules")]
     public string Rules { get; set; } = string.Empty;
 
-    [JsonPropertyName("watchers")]
     public List<YaraWatcher>? Watchers { get; set; }
 }
 
 public sealed class YaraRulesetResponse
 {
-    [JsonPropertyName("data")]
     public YaraRuleset? Data { get; set; }
 }
 
 public sealed class YaraRulesetsResponse
 {
-    [JsonPropertyName("data")]
     public List<YaraRuleset> Data { get; set; } = new();
 
-    [JsonPropertyName("meta")]
     public Meta? Meta { get; set; }
 }
 

--- a/VirusTotalAnalyzer/Models/YaraRulesetRequest.cs
+++ b/VirusTotalAnalyzer/Models/YaraRulesetRequest.cs
@@ -1,32 +1,25 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class YaraRulesetRequest
 {
-    [JsonPropertyName("data")]
     public YaraRulesetRequestData Data { get; set; } = new();
 }
 
 public sealed class YaraRulesetRequestData
 {
-    [JsonPropertyName("type")]
     public string Type { get; set; } = "intelligence_hunting_ruleset";
 
-    [JsonPropertyName("attributes")]
     public YaraRulesetRequestAttributes Attributes { get; set; } = new();
 }
 
 public sealed class YaraRulesetRequestAttributes
 {
-    [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
-    [JsonPropertyName("rules")]
     public string Rules { get; set; } = string.Empty;
 
-    [JsonPropertyName("watchers")]
     public List<YaraWatcher>? Watchers { get; set; }
 }
 

--- a/VirusTotalAnalyzer/Models/YaraWatcher.cs
+++ b/VirusTotalAnalyzer/Models/YaraWatcher.cs
@@ -1,13 +1,11 @@
-using System.Text.Json.Serialization;
+
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class YaraWatcher
 {
-    [JsonPropertyName("id")]
     public string Id { get; set; } = string.Empty;
 
-    [JsonPropertyName("type")]
     public string Type { get; set; } = string.Empty;
 }
 

--- a/VirusTotalAnalyzer/Models/YaraWatcherRequest.cs
+++ b/VirusTotalAnalyzer/Models/YaraWatcherRequest.cs
@@ -1,11 +1,9 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class YaraWatcherRequest
 {
-    [JsonPropertyName("data")]
     public List<YaraWatcher> Data { get; set; } = new();
 }
 

--- a/VirusTotalAnalyzer/Models/YaraWatcherResponse.cs
+++ b/VirusTotalAnalyzer/Models/YaraWatcherResponse.cs
@@ -1,11 +1,9 @@
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 
 namespace VirusTotalAnalyzer.Models;
 
 public sealed class YaraWatcherResponse
 {
-    [JsonPropertyName("data")]
     public List<YaraWatcher> Data { get; set; } = new();
 }
 

--- a/VirusTotalAnalyzer/SnakeCaseNamingPolicy.cs
+++ b/VirusTotalAnalyzer/SnakeCaseNamingPolicy.cs
@@ -1,0 +1,42 @@
+using System.Text;
+using System.Text.Json;
+
+namespace VirusTotalAnalyzer;
+
+/// <summary>
+/// <see cref="JsonNamingPolicy"/> that converts property names to snake_case.
+/// </summary>
+public sealed class SnakeCaseNamingPolicy : JsonNamingPolicy
+{
+    /// <summary>Shared instance of the naming policy.</summary>
+    public static SnakeCaseNamingPolicy Instance { get; } = new();
+
+    /// <inheritdoc />
+    public override string ConvertName(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return name;
+        }
+
+        var builder = new StringBuilder(name.Length + 10);
+        for (var i = 0; i < name.Length; i++)
+        {
+            var c = name[i];
+            if (char.IsUpper(c))
+            {
+                if (i > 0 && (!char.IsUpper(name[i - 1]) || (i + 1 < name.Length && !char.IsUpper(name[i + 1]))))
+                {
+                    builder.Append('_');
+                }
+                builder.Append(char.ToLowerInvariant(c));
+            }
+            else
+            {
+                builder.Append(c);
+            }
+        }
+
+        return builder.ToString();
+    }
+}

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -51,7 +51,7 @@ public sealed partial class VirusTotalClient : IDisposable
         _disposeClient = disposeClient;
         _jsonOptions = new JsonSerializerOptions
         {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            PropertyNamingPolicy = SnakeCaseNamingPolicy.Instance
         };
         _jsonOptions.Converters.Add(new JsonStringEnumMemberConverter());
         _jsonOptions.Converters.Add(new UnixTimestampConverter());


### PR DESCRIPTION
## Summary
- add `SnakeCaseNamingPolicy` to generate snake_case JSON names
- default `VirusTotalClient` serialization to snake_case
- drop redundant `[JsonPropertyName]` attributes and update serialization tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689dd945b440832e9722ee9bdff10c02