### PR TITLE
refactor: update PowerShell namespace

### DIFF
--- a/VirusTotalAnalyzer.PowerShell/CmdletGetVirusReport.cs
+++ b/VirusTotalAnalyzer.PowerShell/CmdletGetVirusReport.cs
@@ -5,7 +5,7 @@ using System.Security.Cryptography;
 using System.Threading.Tasks;
 using VirusTotalAnalyzer;
 
-namespace ADPlayground.PowerShell;
+namespace VirusTotalAnalyzer.PowerShell;
 
 [Cmdlet(VerbsCommon.Get, "VirusReport", DefaultParameterSetName = "FileInformation")]
 [Alias("Get-VirusScan")]

--- a/VirusTotalAnalyzer.PowerShell/CmdletNewVirusScan.cs
+++ b/VirusTotalAnalyzer.PowerShell/CmdletNewVirusScan.cs
@@ -5,7 +5,7 @@ using System.Security.Cryptography;
 using System.Threading.Tasks;
 using VirusTotalAnalyzer;
 
-namespace ADPlayground.PowerShell;
+namespace VirusTotalAnalyzer.PowerShell;
 
 [Cmdlet(VerbsCommon.New, "VirusScan")]
 public sealed class CmdletNewVirusScan : AsyncPSCmdlet

--- a/VirusTotalAnalyzer.PowerShell/Support/AsyncPSCmdlet.cs
+++ b/VirusTotalAnalyzer.PowerShell/Support/AsyncPSCmdlet.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.IO;
 
-namespace ADPlayground.PowerShell;
+namespace VirusTotalAnalyzer.PowerShell;
 
 /// <summary>
 /// An abstract base class for asynchronous PowerShell cmdlets.


### PR DESCRIPTION
## Summary
- rename PowerShell cmdlet namespaces to `VirusTotalAnalyzer.PowerShell`
- ensure internal warning logger uses `WriteWarning`

## Testing
- `dotnet build VirusTotalAnalyzer.sln`
- `dotnet test VirusTotalAnalyzer.sln`


------
https://chatgpt.com/codex/tasks/task_e_689eef9a4928832e92457a0f9acfc918