### PR TITLE
Add async enumerable support for file name API

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetFileNamesAsyncEnumerableExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileNamesAsyncEnumerableExample.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class GetFileNamesAsyncEnumerableExample
+{
+    public static async Task RunAsync()
+    {
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            await foreach (var name in client.GetFileNamesAsyncEnumerable("44d88612fea8a8f36de82e1278abb02f"))
+            {
+                Console.WriteLine($"{name.Id} (first seen: {name.Attributes.Date:u})");
+            }
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer/VirusTotalAnalyzer.csproj
+++ b/VirusTotalAnalyzer/VirusTotalAnalyzer.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />


### PR DESCRIPTION
## Summary
- stream paginated responses with new `GetPagedAsyncEnumerable<T>` helper
- expose `GetFileNamesAsyncEnumerable` wrapper returning `IAsyncEnumerable`
- cover async enumerable behavior with tests and examples

## Testing
- `dotnet build -v minimal`
- `dotnet test -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_689f81a66fe0832e9630be4c53b0c7cf