### PR TITLE
Add URL ID parsing helper with tests

### DIFF
--- a/VirusTotalAnalyzer.Tests/UrlIdTests.cs
+++ b/VirusTotalAnalyzer.Tests/UrlIdTests.cs
@@ -21,4 +21,34 @@ public class UrlIdTests
             .Replace('/', '_');
         Assert.Equal(expected, id);
     }
+
+    [Theory]
+    [InlineData("HTTP://Virustotal.com", "http://virustotal.com/")]
+    [InlineData("https://virustotal.com:443/#frag", "https://virustotal.com/")]
+    [InlineData("http://virustotal.com:80/path", "http://virustotal.com/path")]
+    [InlineData("http://virustotal.com#fragment", "http://virustotal.com/")]
+    public void TryGetUrlId_CanonicalizesAndEncodes(string url, string canonical)
+    {
+        var result = VirusTotalClientExtensions.TryGetUrlId(url, out var id);
+        var expected = Convert.ToBase64String(Encoding.UTF8.GetBytes(canonical))
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+        Assert.True(result);
+        Assert.Equal(expected, id);
+    }
+
+    [Fact]
+    public void TryGetUrlId_ReturnsFalse_WhenUrlInvalid()
+    {
+        var result = VirusTotalClientExtensions.TryGetUrlId("invalid", out var id);
+        Assert.False(result);
+        Assert.Null(id);
+    }
+
+    [Fact]
+    public void GetUrlId_Throws_WhenUrlInvalid()
+    {
+        Assert.Throws<UriFormatException>(() => VirusTotalClientExtensions.GetUrlId("invalid"));
+    }
 }


### PR DESCRIPTION
## Summary
- add TryGetUrlId helper that returns false when URL parsing fails
- have GetUrlId throw when TryGetUrlId cannot parse the URL
- test success and failure cases for both GetUrlId and TryGetUrlId

## Testing
- `dotnet test VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj -p:TargetFrameworks=net8.0`
- `dotnet build -p:TargetFrameworks=net472`
- `dotnet test VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj -p:TargetFrameworks=net472` *(fails: Cannot open assembly '/usr/lib/dotnet/sdk/8.0.119/Extensions/../TestHostNetFramework/testhost.net472.exe')*

------
https://chatgpt.com/codex/tasks/task_e_68a01c3bdc3c832e8c38194b67c48dde