### PR TITLE
Add directory scanning service

### DIFF
--- a/VirusTotalAnalyzer.Examples/DirectoryScanServiceExample.cs
+++ b/VirusTotalAnalyzer.Examples/DirectoryScanServiceExample.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class DirectoryScanServiceExample
+{
+    public static async Task RunAsync()
+    {
+        var apiKey = Environment.GetEnvironmentVariable("VT_API_KEY");
+        if (string.IsNullOrEmpty(apiKey))
+        {
+            Console.WriteLine("VT_API_KEY environment variable not set.");
+            return;
+        }
+
+        using var client = VirusTotalClient.Create(apiKey);
+        var options = new DirectoryScanOptions
+        {
+            DirectoryPath = "/path/to/watch",
+            ExclusionFilters = new[] { "*.tmp", "*.log" },
+            ScanDelay = TimeSpan.FromSeconds(2)
+        };
+        using var service = new DirectoryScanService(client, options);
+
+        Console.WriteLine($"Watching {options.DirectoryPath}. Press ENTER to exit.");
+        await Task.Run(() => Console.ReadLine());
+    }
+}

--- a/VirusTotalAnalyzer.Examples/Program.cs
+++ b/VirusTotalAnalyzer.Examples/Program.cs
@@ -63,5 +63,6 @@ using VirusTotalAnalyzer.Examples;
 // await ListRetrohuntJobsExample.RunAsync();
 // await StartRetrohuntJobExample.RunAsync();
 // await ListMonitorEventsExample.RunAsync();
+// await DirectoryScanServiceExample.RunAsync();
 
 await Task.CompletedTask;

--- a/VirusTotalAnalyzer.Tests/DirectoryScanServiceTests.cs
+++ b/VirusTotalAnalyzer.Tests/DirectoryScanServiceTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public class DirectoryScanServiceTests
+{
+    private static HttpResponseMessage CreateResponse()
+        => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"id\":\"an\",\"type\":\"analysis\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}", Encoding.UTF8, "application/json")
+        };
+
+    [Fact]
+    public async Task Submits_New_Files()
+    {
+        var tcs = new TaskCompletionSource<HttpRequestMessage>();
+        var handler = new CallbackHandler(req => tcs.TrySetResult(req));
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://www.virustotal.com/api/v3/") };
+        var client = new VirusTotalClient(httpClient);
+
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var options = new DirectoryScanOptions { DirectoryPath = dir };
+            using var service = new DirectoryScanService(client, options);
+
+            var filePath = Path.Combine(dir, "test.bin");
+            await File.WriteAllTextAsync(filePath, "data");
+
+            var completed = await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+            Assert.Same(tcs.Task, completed);
+            var request = await tcs.Task;
+            Assert.Equal("/api/v3/files", request.RequestUri!.AbsolutePath);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public async Task Excludes_Configured_Patterns()
+    {
+        var tcs = new TaskCompletionSource<HttpRequestMessage>();
+        var handler = new CallbackHandler(req => tcs.TrySetResult(req));
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://www.virustotal.com/api/v3/") };
+        var client = new VirusTotalClient(httpClient);
+
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var options = new DirectoryScanOptions
+            {
+                DirectoryPath = dir,
+                ExclusionFilters = new[] { "*.tmp" }
+            };
+            using var service = new DirectoryScanService(client, options);
+
+            var excluded = Path.Combine(dir, "skip.tmp");
+            await File.WriteAllTextAsync(excluded, "data");
+            await Task.Delay(300); // wait to ensure no submission
+            Assert.False(tcs.Task.IsCompleted);
+
+            var included = Path.Combine(dir, "go.bin");
+            await File.WriteAllTextAsync(included, "data");
+
+            var completed = await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+            Assert.Same(tcs.Task, completed);
+            var request = await tcs.Task;
+            Assert.Equal("/api/v3/files", request.RequestUri!.AbsolutePath);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public async Task Waits_For_Scan_Delay()
+    {
+        var tcs = new TaskCompletionSource<DateTime>();
+        var handler = new CallbackHandler(_ => tcs.TrySetResult(DateTime.UtcNow));
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://www.virustotal.com/api/v3/") };
+        var client = new VirusTotalClient(httpClient);
+
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var delay = TimeSpan.FromMilliseconds(300);
+            var options = new DirectoryScanOptions { DirectoryPath = dir, ScanDelay = delay };
+            using var service = new DirectoryScanService(client, options);
+
+            var start = DateTime.UtcNow;
+            var filePath = Path.Combine(dir, "delay.bin");
+            await File.WriteAllTextAsync(filePath, "data");
+
+            var completed = await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+            Assert.Same(tcs.Task, completed);
+            var time = await tcs.Task;
+            var elapsed = time - start;
+            Assert.True(elapsed >= delay, $"elapsed {elapsed} is less than delay {delay}");
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    private sealed class CallbackHandler : HttpMessageHandler
+    {
+        private readonly Action<HttpRequestMessage> _callback;
+
+        public CallbackHandler(Action<HttpRequestMessage> callback) => _callback = callback;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
+        {
+            _callback(request);
+            return Task.FromResult(CreateResponse());
+        }
+    }
+}

--- a/VirusTotalAnalyzer/DirectoryScanOptions.cs
+++ b/VirusTotalAnalyzer/DirectoryScanOptions.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+
+namespace VirusTotalAnalyzer;
+
+/// <summary>
+/// Options for <see cref="DirectoryScanService"/>.
+/// </summary>
+public sealed class DirectoryScanOptions
+{
+    /// <summary>
+    /// Gets or sets the directory path to monitor.
+    /// </summary>
+    public string DirectoryPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets wildcard patterns for files that should be excluded from scanning.
+    /// </summary>
+    public IReadOnlyCollection<string> ExclusionFilters { get; set; }
+        = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets or sets the delay before scanning a new file.
+    /// </summary>
+    public TimeSpan ScanDelay { get; set; } = TimeSpan.Zero;
+}

--- a/VirusTotalAnalyzer/DirectoryScanService.cs
+++ b/VirusTotalAnalyzer/DirectoryScanService.cs
@@ -1,0 +1,90 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VirusTotalAnalyzer;
+
+/// <summary>
+/// Watches a directory and submits newly created files to VirusTotal.
+/// </summary>
+public sealed class DirectoryScanService : IDisposable
+{
+    private readonly VirusTotalClient _client;
+    private readonly DirectoryScanOptions _options;
+    private readonly FileSystemWatcher _watcher;
+    private readonly CancellationTokenSource _cts = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DirectoryScanService"/> class.
+    /// </summary>
+    /// <param name="client">The <see cref="VirusTotalClient"/> used for submissions.</param>
+    /// <param name="options">Configuration options.</param>
+    public DirectoryScanService(VirusTotalClient client, DirectoryScanOptions options)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        if (string.IsNullOrEmpty(options.DirectoryPath))
+        {
+            throw new ArgumentException("Directory path must be specified.", nameof(options));
+        }
+        _watcher = new FileSystemWatcher(options.DirectoryPath)
+        {
+            EnableRaisingEvents = true,
+            IncludeSubdirectories = false
+        };
+        _watcher.Created += OnCreated;
+    }
+
+    private async void OnCreated(object sender, FileSystemEventArgs e)
+    {
+        if (IsExcluded(e.FullPath))
+        {
+            return;
+        }
+
+        try
+        {
+            if (_options.ScanDelay > TimeSpan.Zero)
+            {
+                await Task.Delay(_options.ScanDelay, _cts.Token).ConfigureAwait(false);
+            }
+
+            using var stream = new FileStream(e.FullPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            await _client.SubmitFileAsync(stream, Path.GetFileName(e.FullPath), _cts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch
+        {
+            // Swallow exceptions from scanning individual files.
+        }
+    }
+
+    private bool IsExcluded(string path)
+    {
+        var name = Path.GetFileName(path);
+        return _options.ExclusionFilters.Any(p => WildcardMatch(name, p));
+    }
+
+    private static bool WildcardMatch(string input, string pattern)
+    {
+        var regex = "^" + Regex.Escape(pattern).Replace("\\*", ".*").Replace("\\?", ".") + "$";
+#if NETFRAMEWORK
+        return Regex.IsMatch(input, regex, RegexOptions.IgnoreCase);
+#else
+        return Regex.IsMatch(input, regex, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(100));
+#endif
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _watcher.Dispose();
+        _cts.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- Watch directories for new files and submit them via VirusTotalClient
- Support exclusion filters and configurable scan delay
- Demonstrate usage with new example and tests

## Testing
- `dotnet build VirusTotalAnalyzer.sln`
- `dotnet test VirusTotalAnalyzer.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a025a46ac4832e8a89f8e4ae8504b1