### PR TITLE
Add concurrent file scanning extension

### DIFF
--- a/VirusTotalAnalyzer.Examples/ScanFilesExample.cs
+++ b/VirusTotalAnalyzer.Examples/ScanFilesExample.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.Examples;
+
+public static class ScanFilesExample
+{
+    public static async Task RunAsync()
+    {
+        var paths = new List<string> { "sample1.txt", "sample2.txt" };
+        foreach (var p in paths)
+        {
+            if (!File.Exists(p))
+            {
+                Console.WriteLine($"File not found: {p}");
+                return;
+            }
+        }
+
+        var client = VirusTotalClient.Create("YOUR_API_KEY");
+        try
+        {
+            var reports = await client.ScanFilesAsync(paths, maxConcurrency: 2);
+            foreach (var report in reports)
+            {
+                Console.WriteLine(report?.Id);
+            }
+        }
+        catch (RateLimitExceededException ex)
+        {
+            Console.WriteLine($"Rate limit exceeded. Retry after: {ex.RetryAfter}, remaining quota: {ex.RemainingQuota}");
+        }
+        catch (ApiException ex)
+        {
+            Console.WriteLine($"API error: {ex.Error?.Message}");
+        }
+    }
+}

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.ScanFilesConcurrency.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.ScanFilesConcurrency.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public partial class VirusTotalClientTests
+{
+    [Fact]
+    public async Task ScanFilesAsync_RespectsMaxConcurrency()
+    {
+        var handler = new MaxConcurrencyHandler();
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        var client = new VirusTotalClient(httpClient);
+
+        var files = new List<string>();
+        for (int i = 0; i < 5; i++)
+        {
+            var path = System.IO.Path.GetTempFileName();
+#if NETFRAMEWORK
+            System.IO.File.WriteAllText(path, "demo");
+#else
+            await System.IO.File.WriteAllTextAsync(path, "demo");
+#endif
+            files.Add(path);
+        }
+
+        try
+        {
+            var reports = await client.ScanFilesAsync(files, maxConcurrency: 2);
+            Assert.Equal(files.Count, reports.Count);
+            Assert.True(handler.MaxConcurrency <= 2);
+        }
+        finally
+        {
+            foreach (var file in files)
+            {
+                System.IO.File.Delete(file);
+            }
+        }
+    }
+
+    private sealed class MaxConcurrencyHandler : HttpMessageHandler
+    {
+        private int _current;
+        public int MaxConcurrency { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var started = Interlocked.Increment(ref _current);
+            UpdateMax(started);
+            try
+            {
+                await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"id\":\"an\",\"type\":\"analysis\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}")
+                };
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _current);
+            }
+        }
+
+        private void UpdateMax(int current)
+        {
+            int initial;
+            do
+            {
+                initial = MaxConcurrency;
+                if (current <= initial)
+                {
+                    return;
+                }
+            }
+            while (Interlocked.CompareExchange(ref MaxConcurrency, current, initial) != initial);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ScanFilesAsync` extension with semaphore-based concurrency control
- provide example for scanning multiple files
- add unit test verifying concurrency limit

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a0259eed7c832eba43b9f018628f09