### PR TITLE
Add cmdlets for VirusTotal comments, votes, and users

### DIFF
--- a/Module/Examples/Example-GetVirusComment.ps1
+++ b/Module/Examples/Example-GetVirusComment.ps1
@@ -1,0 +1,6 @@
+Import-Module .\VirusTotalAnalyzer.psd1 -Force
+
+$ApiKey = 'YOUR_API_KEY'
+
+# Get comments for a file by its SHA256 hash
+Get-VirusComment -ApiKey $ApiKey -ResourceType File -Id 'FILE_SHA256'

--- a/Module/Examples/Example-GetVirusUser.ps1
+++ b/Module/Examples/Example-GetVirusUser.ps1
@@ -1,0 +1,6 @@
+Import-Module .\VirusTotalAnalyzer.psd1 -Force
+
+$ApiKey = 'YOUR_API_KEY'
+
+# Retrieve information about a VirusTotal user
+Get-VirusUser -ApiKey $ApiKey -Id 'USERNAME'

--- a/Module/Examples/Example-NewVirusVote.ps1
+++ b/Module/Examples/Example-NewVirusVote.ps1
@@ -1,0 +1,6 @@
+Import-Module .\VirusTotalAnalyzer.psd1 -Force
+
+$ApiKey = 'YOUR_API_KEY'
+
+# Cast a malicious vote for a file
+New-VirusVote -ApiKey $ApiKey -ResourceType File -Id 'FILE_SHA256' -Verdict Malicious

--- a/Module/Tests/Cmdlets.Tests.ps1
+++ b/Module/Tests/Cmdlets.Tests.ps1
@@ -87,3 +87,45 @@ Describe 'New-VirusScan cmdlet' {
         $handler.LastRequest.RequestUri.AbsolutePath | Should -Be "/api/v3/files/$expected/analyse"
     }
 }
+
+Describe 'Get-VirusComment cmdlet' {
+    It 'retrieves comments for a resource' {
+        $json = '{"data":[{"id":"c1","type":"comment"}]}'
+        $handler = [FakeHandler]::new($json)
+        $httpClient = [System.Net.Http.HttpClient]::new($handler)
+        $httpClient.BaseAddress = [Uri]::new('https://www.virustotal.com/api/v3/')
+        $client = [VirusTotalAnalyzer.VirusTotalClient]::new($httpClient)
+
+        $result = @(Get-VirusComment -ApiKey 'x' -ResourceType File -Id 'abc' -Client $client)[0]
+        $result.Id | Should -Be 'c1'
+        $handler.LastRequest.RequestUri.AbsolutePath | Should -Be '/api/v3/files/abc/comments'
+    }
+}
+
+Describe 'New-VirusVote cmdlet' {
+    It 'casts a vote for a resource' {
+        $json = '{"data":{"id":"v1","type":"vote"}}'
+        $handler = [FakeHandler]::new($json)
+        $httpClient = [System.Net.Http.HttpClient]::new($handler)
+        $httpClient.BaseAddress = [Uri]::new('https://www.virustotal.com/api/v3/')
+        $client = [VirusTotalAnalyzer.VirusTotalClient]::new($httpClient)
+
+        $result = New-VirusVote -ApiKey 'x' -ResourceType File -Id 'abc' -Verdict Malicious -Client $client
+        $result.Id | Should -Be 'v1'
+        $handler.LastRequest.RequestUri.AbsolutePath | Should -Be '/api/v3/files/abc/votes'
+    }
+}
+
+Describe 'Get-VirusUser cmdlet' {
+    It 'retrieves user information' {
+        $json = '{"id":"user1","type":"user"}'
+        $handler = [FakeHandler]::new($json)
+        $httpClient = [System.Net.Http.HttpClient]::new($handler)
+        $httpClient.BaseAddress = [Uri]::new('https://www.virustotal.com/api/v3/')
+        $client = [VirusTotalAnalyzer.VirusTotalClient]::new($httpClient)
+
+        $result = Get-VirusUser -ApiKey 'x' -Id 'user1' -Client $client
+        $result.Id | Should -Be 'user1'
+        $handler.LastRequest.RequestUri.AbsolutePath | Should -Be '/api/v3/users/user1'
+    }
+}

--- a/VirusTotalAnalyzer.PowerShell/CmdletGetVirusComment.cs
+++ b/VirusTotalAnalyzer.PowerShell/CmdletGetVirusComment.cs
@@ -1,0 +1,57 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.PowerShell;
+
+/// <summary>Retrieves comments for a specified resource.</summary>
+/// <para>Fetches community comments associated with files, URLs, IP addresses or domains.</para>
+[Cmdlet(VerbsCommon.Get, "VirusComment")]
+public sealed class CmdletGetVirusComment : AsyncPSCmdlet
+{
+    /// <summary>VirusTotal API key.</summary>
+    [Parameter(Mandatory = true)]
+    public string ApiKey { get; set; } = string.Empty;
+
+    /// <summary>Resource type to retrieve comments for.</summary>
+    [Parameter(Mandatory = true)]
+    public ResourceType ResourceType { get; set; }
+
+    /// <summary>Identifier of the resource.</summary>
+    [Parameter(Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Maximum number of comments to return.</summary>
+    [Parameter]
+    public int? Limit { get; set; }
+
+    /// <summary>Pagination cursor.</summary>
+    [Parameter]
+    public string? Cursor { get; set; }
+
+    /// <summary>Existing VirusTotal client to reuse.</summary>
+    [Parameter]
+    public VirusTotalClient? Client { get; set; }
+
+    /// <inheritdoc/>
+    protected override async Task ProcessRecordAsync()
+    {
+        var client = Client ?? VirusTotalClient.Create(ApiKey);
+        try
+        {
+            var comments = await client.GetCommentsAsync(ResourceType, Id, Limit, Cursor, CancelToken).ConfigureAwait(false);
+            if (comments is not null)
+            {
+                WriteObject(comments.Data, true);
+            }
+        }
+        finally
+        {
+            if (Client is null)
+            {
+                client.Dispose();
+            }
+        }
+    }
+}

--- a/VirusTotalAnalyzer.PowerShell/CmdletGetVirusUser.cs
+++ b/VirusTotalAnalyzer.PowerShell/CmdletGetVirusUser.cs
@@ -1,0 +1,45 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.PowerShell;
+
+/// <summary>Retrieves information about a VirusTotal user.</summary>
+/// <para>Fetches public profile data for the specified username.</para>
+[Cmdlet(VerbsCommon.Get, "VirusUser")]
+public sealed class CmdletGetVirusUser : AsyncPSCmdlet
+{
+    /// <summary>VirusTotal API key.</summary>
+    [Parameter(Mandatory = true)]
+    public string ApiKey { get; set; } = string.Empty;
+
+    /// <summary>Identifier of the user to retrieve.</summary>
+    [Parameter(Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Existing VirusTotal client to reuse.</summary>
+    [Parameter]
+    public VirusTotalClient? Client { get; set; }
+
+    /// <inheritdoc/>
+    protected override async Task ProcessRecordAsync()
+    {
+        var client = Client ?? VirusTotalClient.Create(ApiKey);
+        try
+        {
+            var user = await client.GetUserAsync(Id, CancelToken).ConfigureAwait(false);
+            if (user is not null)
+            {
+                WriteObject(user);
+            }
+        }
+        finally
+        {
+            if (Client is null)
+            {
+                client.Dispose();
+            }
+        }
+    }
+}

--- a/VirusTotalAnalyzer.PowerShell/CmdletNewVirusVote.cs
+++ b/VirusTotalAnalyzer.PowerShell/CmdletNewVirusVote.cs
@@ -1,0 +1,50 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer;
+using VirusTotalAnalyzer.Models;
+
+namespace VirusTotalAnalyzer.PowerShell;
+
+/// <summary>Casts a vote for a resource.</summary>
+/// <para>Submits a harmless or malicious verdict for the specified resource.</para>
+[Cmdlet(VerbsCommon.New, "VirusVote")]
+public sealed class CmdletNewVirusVote : AsyncPSCmdlet
+{
+    /// <summary>VirusTotal API key.</summary>
+    [Parameter(Mandatory = true)]
+    public string ApiKey { get; set; } = string.Empty;
+
+    /// <summary>Resource type to vote on.</summary>
+    [Parameter(Mandatory = true)]
+    public ResourceType ResourceType { get; set; }
+
+    /// <summary>Identifier of the resource.</summary>
+    [Parameter(Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Verdict to cast.</summary>
+    [Parameter(Mandatory = true)]
+    public VoteVerdict Verdict { get; set; }
+
+    /// <summary>Existing VirusTotal client to reuse.</summary>
+    [Parameter]
+    public VirusTotalClient? Client { get; set; }
+
+    /// <inheritdoc/>
+    protected override async Task ProcessRecordAsync()
+    {
+        var client = Client ?? VirusTotalClient.Create(ApiKey);
+        try
+        {
+            var vote = await client.CreateVoteAsync(ResourceType, Id, Verdict, CancelToken).ConfigureAwait(false);
+            WriteObject(vote);
+        }
+        finally
+        {
+            if (Client is null)
+            {
+                client.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement PowerShell cmdlets Get-VirusComment, New-VirusVote, and Get-VirusUser
- add usage examples for comments, votes, and user retrieval
- cover cmdlets with Pester tests

## Testing
- `dotnet build`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester Module/Tests/Cmdlets.Tests.ps1"`


------
https://chatgpt.com/codex/tasks/task_e_68a025b3f888832eaeeaa156ab68fb55