### PR TITLE
Add 20 minute timeout to CI jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
   test-windows:
     name: 'Windows'
     runs-on: windows-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -63,6 +64,7 @@ jobs:
   test-ubuntu:
     name: 'Ubuntu'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -103,6 +105,7 @@ jobs:
   test-macos:
     name: 'macOS'
     runs-on: macos-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- add 20-minute timeout to Windows, Ubuntu, and macOS test jobs

## Testing
- `dotnet restore VirusTotalAnalyzer.sln`
- `dotnet build VirusTotalAnalyzer.sln --configuration Release --no-restore`
- `dotnet test VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj --configuration Release --no-build --verbosity normal --logger trx`


------
https://chatgpt.com/codex/tasks/task_e_68a0462e4b20832e9ac8460148e8af7f