### PR TITLE
Add hashing progress to PowerShell cmdlets

### DIFF
--- a/VirusTotalAnalyzer.PowerShell/CmdletNewVirusScan.cs
+++ b/VirusTotalAnalyzer.PowerShell/CmdletNewVirusScan.cs
@@ -87,15 +87,35 @@ public sealed class CmdletNewVirusScan : AsyncPSCmdlet
                     if (!EnsureFileExists(FileHash!, GetErrorActionPreference()))
                         return;
                     string hash;
-                    using (var sha256 = SHA256.Create())
-                    using (var stream = System.IO.File.OpenRead(FileHash!))
+                    var progress = new ProgressRecord(1, "Hashing file", FileHash!);
+                    WriteProgress(progress);
+                    try
                     {
-                        var bytes = sha256.ComputeHash(stream);
+                        using var sha256 = SHA256.Create();
+                        using var stream = System.IO.File.OpenRead(FileHash!);
+                        var length = stream.Length;
+                        var buffer = new byte[81920];
+                        int read;
+                        long total = 0;
+                        while ((read = await stream.ReadAsync(buffer, 0, buffer.Length, CancelToken).ConfigureAwait(false)) > 0)
+                        {
+                            sha256.TransformBlock(buffer, 0, read, null, 0);
+                            total += read;
+                            progress.PercentComplete = length > 0 ? (int)(total * 100 / length) : 0;
+                            WriteProgress(progress);
+                        }
+                        sha256.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                        var bytes = sha256.Hash!;
 #if NET472
                         hash = BitConverter.ToString(bytes).Replace("-", string.Empty).ToLowerInvariant();
 #else
                         hash = Convert.ToHexString(bytes).ToLowerInvariant();
 #endif
+                    }
+                    finally
+                    {
+                        progress.RecordType = ProgressRecordType.Completed;
+                        WriteProgress(progress);
                     }
                     var fhAnalysis = await client.ReanalyzeFileAsync(hash, CancelToken).ConfigureAwait(false);
                     WriteObject(fhAnalysis);


### PR DESCRIPTION
## Summary
- show progress while hashing files in `Get-VirusReport`
- show progress while hashing files in `New-VirusScan`
- add Pester tests to ensure progress records are emitted

## Testing
- `~/dotnet9/dotnet build`
- `~/dotnet9/dotnet test`
- `pwsh -NoLogo -Command "Invoke-Pester -Script Module/Tests/Cmdlets.Tests.ps1"`


------
https://chatgpt.com/codex/tasks/task_e_68a48fa1854c832ea66f496a5e6df1c9