### PR TITLE
Generate cmdlet help during build

### DIFF
--- a/Module/Build/Manage-VirusTotal.ps1
+++ b/Module/Build/Manage-VirusTotal.ps1
@@ -104,4 +104,13 @@ Build-Module -ModuleName 'VirusTotalAnalyzer' {
     # global options for publishing to github/psgallery
     #New-ConfigurationPublish -Type PowerShellGallery -FilePath 'C:\Support\Important\PowerShellGalleryAPI.txt' -Enabled:$true
     #New-ConfigurationPublish -Type GitHub -FilePath 'C:\Support\Important\GitHubAPI.txt' -UserName 'EvotecIT' -Enabled:$true
+} 
+
+# Ensure help files are copied alongside the module assembly
+$binRoot = Join-Path $PSScriptRoot '..' '..' 'VirusTotalAnalyzer.PowerShell' 'bin'
+$helpFiles = Get-ChildItem -Path $binRoot -Recurse -Filter '*.psm1-Help.xml' -ErrorAction SilentlyContinue
+if ($helpFiles) {
+    $dest = Join-Path $PSScriptRoot '..' 'en-US'
+    New-Item -ItemType Directory -Path $dest -Force | Out-Null
+    Copy-Item -Path $helpFiles.FullName -Destination $dest -Force
 }

--- a/Module/Tests/Cmdlets.Tests.ps1
+++ b/Module/Tests/Cmdlets.Tests.ps1
@@ -180,3 +180,21 @@ Describe 'Get-VirusUser cmdlet' {
         $handler.LastRequest.RequestUri.AbsolutePath | Should -Be '/api/v3/users/user1'
     }
 }
+
+Describe 'Cmdlet help content' {
+    It 'includes examples for Get-VirusReport' {
+        (Get-Help Get-VirusReport -Examples).Examples | Should -Not -BeNullOrEmpty
+    }
+    It 'includes examples for New-VirusScan' {
+        (Get-Help New-VirusScan -Examples).Examples | Should -Not -BeNullOrEmpty
+    }
+    It 'includes examples for Get-VirusComment' {
+        (Get-Help Get-VirusComment -Examples).Examples | Should -Not -BeNullOrEmpty
+    }
+    It 'includes examples for New-VirusVote' {
+        (Get-Help New-VirusVote -Examples).Examples | Should -Not -BeNullOrEmpty
+    }
+    It 'includes examples for Get-VirusUser' {
+        (Get-Help Get-VirusUser -Examples).Examples | Should -Not -BeNullOrEmpty
+    }
+}

--- a/VirusTotalAnalyzer.PowerShell/CmdletGetVirusComment.cs
+++ b/VirusTotalAnalyzer.PowerShell/CmdletGetVirusComment.cs
@@ -7,6 +7,12 @@ namespace VirusTotalAnalyzer.PowerShell;
 
 /// <summary>Retrieves comments for a specified resource.</summary>
 /// <para>Fetches community comments associated with files, URLs, IP addresses or domains.</para>
+/// <example>
+///   <code>
+///     <para><prefix>PS&gt; </prefix>Get-VirusComment -ApiKey $ApiKey -ResourceType File -Id 'abc'</para>
+///   </code>
+///   <para>Displays community feedback for the file with the given hash.</para>
+/// </example>
 [Cmdlet(VerbsCommon.Get, "VirusComment")]
 public sealed class CmdletGetVirusComment : AsyncPSCmdlet
 {

--- a/VirusTotalAnalyzer.PowerShell/CmdletGetVirusUser.cs
+++ b/VirusTotalAnalyzer.PowerShell/CmdletGetVirusUser.cs
@@ -7,6 +7,12 @@ namespace VirusTotalAnalyzer.PowerShell;
 
 /// <summary>Retrieves information about a VirusTotal user.</summary>
 /// <para>Fetches public profile data for the specified username.</para>
+/// <example>
+///   <code>
+///     <para><prefix>PS&gt; </prefix>Get-VirusUser -ApiKey $ApiKey -Id 'user1'</para>
+///   </code>
+///   <para>Returns details for the given user identifier.</para>
+/// </example>
 [Cmdlet(VerbsCommon.Get, "VirusUser")]
 public sealed class CmdletGetVirusUser : AsyncPSCmdlet
 {

--- a/VirusTotalAnalyzer.PowerShell/CmdletNewVirusVote.cs
+++ b/VirusTotalAnalyzer.PowerShell/CmdletNewVirusVote.cs
@@ -7,6 +7,12 @@ namespace VirusTotalAnalyzer.PowerShell;
 
 /// <summary>Casts a vote for a resource.</summary>
 /// <para>Submits a harmless or malicious verdict for the specified resource.</para>
+/// <example>
+///   <code>
+///     <para><prefix>PS&gt; </prefix>New-VirusVote -ApiKey $ApiKey -ResourceType File -Id 'abc' -Verdict Malicious</para>
+///   </code>
+///   <para>Marks the file identified by the given hash as malicious.</para>
+/// </example>
 [Cmdlet(VerbsCommon.New, "VirusVote")]
 public sealed class CmdletNewVirusVote : AsyncPSCmdlet
 {

--- a/VirusTotalAnalyzer.PowerShell/VirusTotalAnalyzer.PowerShell.csproj
+++ b/VirusTotalAnalyzer.PowerShell/VirusTotalAnalyzer.PowerShell.csproj
@@ -5,11 +5,11 @@
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='net8.0'">
+  <PropertyGroup Condition="'$(TargetFramework)'!='net9.0'">
     <XmlDoc2CmdletDocArguments>-strict</XmlDoc2CmdletDocArguments>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.7.0" Condition="'$(TargetFramework)'=='net8.0'">
+    <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.7.0" Condition="'$(TargetFramework)'!='net9.0'">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -17,4 +17,19 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" />
   </ItemGroup>
+  <Target Name="MoveHelpToCulture" AfterTargets="XmlDoc2CmdletDoc">
+    <ItemGroup>
+      <HelpFile Include="$(TargetPath)-Help.xml" />
+    </ItemGroup>
+    <MakeDir Directories="$(TargetDir)en-US" />
+    <Copy SourceFiles="@(HelpFile)" DestinationFiles="$(TargetDir)en-US/$(TargetName).dll-Help.xml" Condition="Exists('%(HelpFile.Identity)')" />
+    <Copy SourceFiles="@(HelpFile)" DestinationFiles="$(TargetDir)en-US/$(TargetName).psm1-Help.xml" Condition="Exists('%(HelpFile.Identity)')" />
+  </Target>
+  <Target Name="CopyHelpFromNet8" AfterTargets="Build" Condition="'$(TargetFramework)'=='net9.0'">
+    <ItemGroup>
+      <Net8Help Include="$(OutputPath)..\net8.0\en-US\$(TargetName).psm1-Help.xml" />
+    </ItemGroup>
+    <MakeDir Directories="$(TargetDir)en-US" />
+    <Copy SourceFiles="@(Net8Help)" DestinationFolder="$(TargetDir)en-US" Condition="Exists('%(Net8Help.Identity)')" />
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary
- run XmlDoc2CmdletDoc when building PowerShell module and copy help into culture folders
- include cmdlet help in module build output
- document PowerShell cmdlets with examples and add tests validating help availability

## Testing
- `dotnet build -c Debug`
- `dotnet test`
- `pwsh -NoLogo -Command "Invoke-Pester -Path Module/Tests/Cmdlets.Tests.ps1 -EnableExit"`


------
https://chatgpt.com/codex/tasks/task_e_68a4a69ca454832e99daf1debb3dd26b