### PR TITLE
Validate DownloadPcapAsync ID inputs

### DIFF
--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.IdValidation.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.IdValidation.cs
@@ -14,6 +14,7 @@ public partial class VirusTotalClientTests
         yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.GetFileContactedUrlsAsync(null!)) };
         yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.GetCommentAsync(null!)) };
         yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.GetGraphAsync(null!)) };
+        yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.DownloadPcapAsync(null!)) };
     }
 
     public static IEnumerable<object[]> EmptyIdOperations()
@@ -22,6 +23,7 @@ public partial class VirusTotalClientTests
         yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.GetFileContactedUrlsAsync(string.Empty)) };
         yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.GetCommentAsync(string.Empty)) };
         yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.GetGraphAsync(string.Empty)) };
+        yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.DownloadPcapAsync(string.Empty)) };
     }
 
     [Theory]

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -332,6 +332,7 @@ public sealed partial class VirusTotalClient : IVirusTotalClient
 
     public async Task<Stream> DownloadPcapAsync(string analysisId, CancellationToken cancellationToken = default)
     {
+        ValidateId(analysisId, nameof(analysisId));
         var response = await _httpClient
             .GetAsync($"analyses/{Uri.EscapeDataString(analysisId)}/pcap", HttpCompletionOption.ResponseHeadersRead, cancellationToken)
             .ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- validate the analysis identifier before downloading PCAP content
- extend the shared ID validation tests to cover DownloadPcapAsync

## Testing
- dotnet test VirusTotalAnalyzer/VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj -f net8.0 *(fails: dotnet CLI is unavailable in the execution environment)*


------
https://chatgpt.com/codex/tasks/task_e_68d632e6f5c8832ebca94cabfc43e294