### PR TITLE
Add disposal guard to VirusTotalClient HTTP APIs

### DIFF
--- a/VirusTotalAnalyzer.Tests/VirusTotalClientDisposeTests.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientDisposeTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net.Http;
 using Xunit;
 
@@ -27,6 +28,34 @@ public class VirusTotalClientDisposeTests
         client.Dispose();
 
         Assert.False(handler.Disposed);
+        httpClient.Dispose();
+    }
+
+    [Fact]
+    public async Task GetFileReportAsync_ThrowsObjectDisposedException_WhenDisposed()
+    {
+        var handler = new TrackingHandler();
+        var httpClient = new HttpClient(handler);
+        var client = new VirusTotalClient(httpClient);
+
+        client.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => client.GetFileReportAsync("file-id"));
+
+        httpClient.Dispose();
+    }
+
+    [Fact]
+    public void GetFileNamesPagedAsync_ThrowsObjectDisposedException_WhenDisposed()
+    {
+        var handler = new TrackingHandler();
+        var httpClient = new HttpClient(handler);
+        var client = new VirusTotalClient(httpClient);
+
+        client.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => client.GetFileNamesPagedAsync("file-id"));
+
         httpClient.Dispose();
     }
 }

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -29,6 +29,7 @@ public sealed partial class VirusTotalClient
         IEnumerable<string>? relationships = null,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         var idArray = ValidateIds(ids, nameof(ids));
         var url = new StringBuilder("files?ids=")
             .Append(string.Join(",", idArray.Select(Uri.EscapeDataString)));
@@ -57,6 +58,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
         IEnumerable<string>? relationships = null,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var url = new StringBuilder($"files/{Uri.EscapeDataString(id)}");
         var hasQuery = false;
@@ -84,6 +86,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
 
     public async Task<FileBehavior?> GetFileBehaviorAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/behaviour", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -94,6 +97,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
 
     public async Task<FileBehaviorSummary?> GetFileBehaviorSummaryAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/behaviour_summary", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -104,6 +108,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
 
     public async Task<FileNetworkTraffic?> GetFileNetworkTrafficAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/network-traffic", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -114,6 +119,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
 
     public async Task<FilePeInfo?> GetFilePeInfoAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/pe_info", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -124,6 +130,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
 
     public async Task<FileClassification?> GetFileClassificationAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/classification", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -134,6 +141,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
 
     public async Task<IReadOnlyList<string>?> GetFileStringsAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/strings", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -145,6 +153,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
 
     public async Task<IReadOnlyList<CrowdsourcedYaraResult>?> GetCrowdsourcedYaraResultsAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/crowdsourced_yara_results", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -155,6 +164,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
 
     public async Task<IReadOnlyList<CrowdsourcedIdsResult>?> GetCrowdsourcedIdsResultsAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/crowdsourced_ids_results", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -170,6 +180,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
         bool fetchAll = false,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         return GetPagedAsync<UrlSummary>(async (c, token) =>
         {
@@ -198,6 +209,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
         bool fetchAll = false,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         return GetPagedAsync<DomainSummary>(async (c, token) =>
         {
@@ -226,6 +238,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
         bool fetchAll = false,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         return GetPagedAsync<IpAddressSummary>(async (c, token) =>
         {
@@ -254,6 +267,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
         bool fetchAll = false,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         return GetPagedAsync<FileReport>(async (c, token) =>
         {
@@ -282,6 +296,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
         bool fetchAll = false,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         return GetPagedAsync<FileReport>(async (c, token) =>
         {
@@ -310,6 +325,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
         bool fetchAll = false,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         return GetPagedAsync<FileReport>(async (c, token) =>
         {
@@ -338,6 +354,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
         bool fetchAll = false,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         return GetPagedAsync<FileReport>(async (c, token) =>
         {
@@ -366,6 +383,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
         bool fetchAll = false,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         return GetPagedAsync<FileReport>(async (c, token) =>
         {
@@ -389,6 +407,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
 
     public async Task<Uri?> GetFileDownloadUrlAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"files/{Uri.EscapeDataString(id)}/download_url", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -404,6 +423,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
 
     public async Task<Stream> DownloadFileAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var response = await _httpClient
             .GetAsync($"files/{Uri.EscapeDataString(id)}/download", HttpCompletionOption.ResponseHeadersRead, cancellationToken)
@@ -427,6 +447,7 @@ var stream = await response.Content.ReadContentStreamAsync(cancellationToken).Co
         IEnumerable<string>? relationships = null,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         var idArray = ValidateIds(ids, nameof(ids));
         var url = new StringBuilder("urls?ids=")
             .Append(string.Join(",", idArray.Select(Uri.EscapeDataString)));
@@ -455,6 +476,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
         IEnumerable<string>? relationships = null,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var url = new StringBuilder($"urls/{Uri.EscapeDataString(id)}");
         var hasQuery = false;
@@ -500,6 +522,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         if (limit == 0)
         {
@@ -554,6 +577,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"urls/{Uri.EscapeDataString(id)}/downloaded_files");
         var hasQuery = false;
@@ -579,6 +603,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"urls/{Uri.EscapeDataString(id)}/referrer_files");
         var hasQuery = false;
@@ -604,6 +629,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"urls/{Uri.EscapeDataString(id)}/redirecting_urls");
         var hasQuery = false;
@@ -629,6 +655,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"urls/{Uri.EscapeDataString(id)}/contacted_ips");
         var hasQuery = false;
@@ -650,6 +677,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
 
     public async Task<IpAddressSummary?> GetUrlLastServingIpAddressAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"urls/{Uri.EscapeDataString(id)}/last_serving_ip_address", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -673,6 +701,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
         IEnumerable<string>? relationships = null,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         var idArray = ValidateIds(ids, nameof(ids));
         var url = new StringBuilder("ip_addresses?ids=")
             .Append(string.Join(",", idArray.Select(Uri.EscapeDataString)));
@@ -701,6 +730,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
         IEnumerable<string>? relationships = null,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var url = new StringBuilder($"ip_addresses/{Uri.EscapeDataString(id)}");
         var hasQuery = false;
@@ -728,6 +758,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
 
     public async Task<IpWhois?> GetIpAddressWhoisAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"ip_addresses/{Uri.EscapeDataString(id)}/whois", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -750,6 +781,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
         IEnumerable<string>? relationships = null,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         var idArray = ValidateIds(ids, nameof(ids));
         var url = new StringBuilder("domains?ids=")
             .Append(string.Join(",", idArray.Select(Uri.EscapeDataString)));
@@ -778,6 +810,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
         IEnumerable<string>? relationships = null,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var url = new StringBuilder($"domains/{Uri.EscapeDataString(id)}");
         var hasQuery = false;
@@ -805,6 +838,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
 
     public async Task<DomainWhois?> GetDomainWhoisAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"domains/{Uri.EscapeDataString(id)}/whois", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -827,6 +861,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
         IEnumerable<string>? relationships = null,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         var idArray = ValidateIds(ids, nameof(ids));
         var url = new StringBuilder("analyses?ids=")
             .Append(string.Join(",", idArray.Select(Uri.EscapeDataString)));
@@ -851,6 +886,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
 
     public async Task<AnalysisReport?> GetAnalysisAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"analyses/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -861,6 +897,7 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
 
     public async Task<PrivateAnalysis?> GetPrivateAnalysisAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"private/analyses/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);

--- a/VirusTotalAnalyzer/VirusTotalClient.Community.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Community.cs
@@ -17,6 +17,7 @@ public sealed partial class VirusTotalClient
 {
     public async Task<Comment?> GetCommentAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.Comment)}/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -27,6 +28,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<CommentsResponse?> GetCommentsAsync(ResourceType resourceType, string id, int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var path = new StringBuilder($"{GetPath(resourceType)}/{Uri.EscapeDataString(id)}/comments");
         var hasQuery = false;
@@ -47,6 +49,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Vote?> GetVoteAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.Vote)}/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -57,6 +60,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<VotesResponse?> GetVotesAsync(ResourceType resourceType, string id, int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var path = new StringBuilder($"{GetPath(resourceType)}/{Uri.EscapeDataString(id)}/votes");
         var hasQuery = false;
@@ -86,6 +90,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Comment?> CreateCommentAsync(ResourceType resourceType, string id, CreateCommentRequest request, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
@@ -107,6 +112,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Vote?> CreateVoteAsync(ResourceType resourceType, string id, CreateVoteRequest request, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
@@ -119,6 +125,7 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteItemAsync(ResourceType resourceType, string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.DeleteAsync($"{GetPath(resourceType)}/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -126,6 +133,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<User?> GetUserAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"users/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -135,6 +143,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<UserPrivileges?> GetUserPrivilegesAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"users/{Uri.EscapeDataString(id)}/privileges", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -144,6 +153,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<UserQuota?> GetUserQuotaAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"users/{Uri.EscapeDataString(id)}/quotas", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);

--- a/VirusTotalAnalyzer/VirusTotalClient.GraphCollaborators.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.GraphCollaborators.cs
@@ -12,6 +12,7 @@ public sealed partial class VirusTotalClient
 {
     public async Task<PagedResponse<User>?> GetGraphCollaboratorsAsync(string id, int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var path = new StringBuilder($"graphs/{Uri.EscapeDataString(id)}/collaborators");
         var hasQuery = false;
@@ -32,6 +33,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<RelationshipResponse?> AddGraphCollaboratorsAsync(string id, AddCollaboratorsRequest request, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
@@ -43,6 +45,7 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteGraphCollaboratorAsync(string graphId, string username, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(graphId, nameof(graphId));
         ValidateId(username, nameof(username));
         using var response = await _httpClient.DeleteAsync($"graphs/{Uri.EscapeDataString(graphId)}/collaborators/{Uri.EscapeDataString(username)}", cancellationToken).ConfigureAwait(false);

--- a/VirusTotalAnalyzer/VirusTotalClient.Intelligence.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Intelligence.cs
@@ -18,6 +18,7 @@ public sealed partial class VirusTotalClient
 {
     public async Task<LivehuntNotification?> GetLivehuntNotificationAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.LivehuntNotification)}/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -28,6 +29,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Page<LivehuntNotification>> ListLivehuntNotificationsAsync(int limit = 10, string? cursor = null, bool fetchAll = true, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         var results = new List<LivehuntNotification>();
         var nextCursor = cursor;
 
@@ -59,6 +61,7 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteLivehuntNotificationAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.DeleteAsync($"intelligence/hunting_notifications/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -66,6 +69,7 @@ public sealed partial class VirusTotalClient
 
     public async Task AcknowledgeLivehuntNotificationAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.PostAsync($"intelligence/hunting_notifications/{Uri.EscapeDataString(id)}/acknowledge", null, cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -73,6 +77,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<RetrohuntJob?> GetRetrohuntJobAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.RetrohuntJob)}/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -82,6 +87,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Page<RetrohuntJob>> ListRetrohuntJobsAsync(int limit = 10, string? cursor = null, bool fetchAll = true, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         var results = new List<RetrohuntJob>();
         var nextCursor = cursor;
 
@@ -113,6 +119,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<RetrohuntJob?> CreateRetrohuntJobAsync(RetrohuntJobRequest request, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var response = await _httpClient.PostAsync("intelligence/retrohunt_jobs", content, cancellationToken).ConfigureAwait(false);
@@ -124,6 +131,7 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteRetrohuntJobAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.DeleteAsync($"intelligence/retrohunt_jobs/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -131,6 +139,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<RetrohuntNotification?> GetRetrohuntNotificationAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.RetrohuntNotification)}/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -140,6 +149,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Page<RetrohuntNotification>> ListRetrohuntNotificationsAsync(int limit = 10, string? cursor = null, bool fetchAll = true, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         var results = new List<RetrohuntNotification>();
         var nextCursor = cursor;
 
@@ -171,6 +181,7 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteRetrohuntNotificationAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.DeleteAsync($"intelligence/retrohunt_notifications/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -178,6 +189,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<MonitorItem?> GetMonitorItemAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"{GetPath(ResourceType.MonitorItem)}/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -187,6 +199,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Page<YaraRuleset>> ListYaraRulesetsAsync(int? limit = null, string? cursor = null, bool fetchAll = true, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         var results = new List<YaraRuleset>();
         var nextCursor = cursor;
 
@@ -224,6 +237,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<YaraRuleset?> GetYaraRulesetAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"intelligence/hunting_rulesets/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -233,6 +247,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<YaraRuleset?> CreateYaraRulesetAsync(YaraRulesetRequest request, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var response = await _httpClient.PostAsync("intelligence/hunting_rulesets", content, cancellationToken).ConfigureAwait(false);
@@ -244,6 +259,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<YaraRuleset?> UpdateYaraRulesetAsync(string id, YaraRulesetRequest request, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
@@ -260,6 +276,7 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteYaraRulesetAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.DeleteAsync($"intelligence/hunting_rulesets/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -267,6 +284,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<YaraWatcher>?> GetYaraRulesetWatchersAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"intelligence/hunting_rulesets/{Uri.EscapeDataString(id)}/watchers", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -277,6 +295,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<YaraWatcher>?> AddYaraRulesetWatchersAsync(string id, YaraWatcherRequest request, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
@@ -289,6 +308,7 @@ public sealed partial class VirusTotalClient
 
     public async Task RemoveYaraRulesetWatcherAsync(string id, string watcherId, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.DeleteAsync($"intelligence/hunting_rulesets/{Uri.EscapeDataString(id)}/watchers/{Uri.EscapeDataString(watcherId)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -321,6 +341,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<RelationshipResponse?> GetRelationshipsAsync(ResourceType resourceType, string id, string relationship, int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var sb = new StringBuilder($"{GetPath(resourceType)}/{Uri.EscapeDataString(id)}/relationships/{Uri.EscapeDataString(relationship)}");
         var hasQuery = false;
@@ -342,6 +363,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IReadOnlyList<ThreatCategory>> GetPopularThreatCategoriesAsync(CancellationToken ct = default)
     {
+        ThrowIfDisposed();
         using var response = await _httpClient.GetAsync("intelligence/popular_threat_categories", ct).ConfigureAwait(false);
         await EnsureSuccessAsync(response, ct).ConfigureAwait(false);
         using var stream = await response.Content.ReadContentStreamAsync(ct).ConfigureAwait(false);
@@ -351,6 +373,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<SearchResponse?> SearchAsync(string query, int? limit = null, string? cursor = null, string? order = null, string? descriptor = null, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         var sb = new StringBuilder($"intelligence/search?query={Uri.EscapeDataString(query)}");
         if (limit.HasValue)
         {
@@ -376,6 +399,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<IocStreamResponse?> GetIocStreamAsync(string filter, int? limit = null, bool descriptorsOnly = false, string? cursor = null, CancellationToken ct = default)
     {
+        ThrowIfDisposed();
         var sb = new StringBuilder($"intelligence/ioc_stream?filter={Uri.EscapeDataString(filter)}");
         if (limit.HasValue)
         {
@@ -397,6 +421,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<FeedResponse?> GetFeedAsync(ResourceType resourceType, int? limit = null, string? cursor = null, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         if (resourceType != ResourceType.File &&
             resourceType != ResourceType.Url &&
             resourceType != ResourceType.Domain &&
@@ -425,6 +450,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<FeedResponse?> GetFeedAsync(ResourceType resourceType, DateTime time, FeedGranularity granularity, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         if (resourceType != ResourceType.File &&
             resourceType != ResourceType.Url &&
             resourceType != ResourceType.Domain &&

--- a/VirusTotalAnalyzer/VirusTotalClient.Monitor.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Monitor.cs
@@ -12,7 +12,9 @@ namespace VirusTotalAnalyzer;
 public sealed partial class VirusTotalClient
 {
     public Task<PagedResponse<MonitorEvent>?> ListMonitorEventsAsync(string? filter = null, int? limit = null, string? cursor = null, bool fetchAll = false, CancellationToken ct = default)
-        => GetPagedAsync<MonitorEvent>(async (c, token) =>
+    {
+        ThrowIfDisposed();
+        return GetPagedAsync<MonitorEvent>(async (c, token) =>
         {
             var path = new StringBuilder("monitor/events");
             var hasQuery = false;
@@ -35,9 +37,12 @@ public sealed partial class VirusTotalClient
             using var stream = await response.Content.ReadContentStreamAsync(token).ConfigureAwait(false);
             return await JsonSerializer.DeserializeAsync<PagedResponse<MonitorEvent>>(stream, _jsonOptions, token).ConfigureAwait(false);
         }, cursor, fetchAll, ct);
+    }
 
     public Task<PagedResponse<MonitorItem>?> ListMonitorItemsAsync(int? limit = null, string? cursor = null, bool fetchAll = false, CancellationToken cancellationToken = default)
-        => GetPagedAsync<MonitorItem>(async (c, token) =>
+    {
+        ThrowIfDisposed();
+        return GetPagedAsync<MonitorItem>(async (c, token) =>
         {
             var path = new StringBuilder("monitor/items");
             var hasQuery = false;
@@ -55,9 +60,11 @@ public sealed partial class VirusTotalClient
             using var stream = await response.Content.ReadContentStreamAsync(token).ConfigureAwait(false);
             return await JsonSerializer.DeserializeAsync<PagedResponse<MonitorItem>>(stream, _jsonOptions, token).ConfigureAwait(false);
         }, cursor, fetchAll, cancellationToken);
+    }
 
     public async Task<MonitorItem?> CreateMonitorItemAsync(CreateMonitorItemRequest request, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var response = await _httpClient.PostAsync("monitor/items", content, cancellationToken).ConfigureAwait(false);
@@ -68,6 +75,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<MonitorItem?> UpdateMonitorItemAsync(string id, UpdateMonitorItemRequest request, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
@@ -80,6 +88,7 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteMonitorItemAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.DeleteAsync($"monitor/items/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);

--- a/VirusTotalAnalyzer/VirusTotalClient.Relationships.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Relationships.cs
@@ -133,6 +133,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"ip_addresses/{Uri.EscapeDataString(id)}/communicating_files");
         var hasQuery = false;
@@ -158,6 +159,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"ip_addresses/{Uri.EscapeDataString(id)}/downloaded_files");
         var hasQuery = false;
@@ -183,6 +185,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"ip_addresses/{Uri.EscapeDataString(id)}/referrer_files");
         var hasQuery = false;
@@ -208,6 +211,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"ip_addresses/{Uri.EscapeDataString(id)}/urls");
         var hasQuery = false;
@@ -233,6 +237,7 @@ public sealed partial class VirusTotalClient
         string? cursor = null,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var path = new System.Text.StringBuilder($"ip_addresses/{Uri.EscapeDataString(id)}/ssl_certificates");
         var hasQuery = false;

--- a/VirusTotalAnalyzer/VirusTotalClient.Resources.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Resources.cs
@@ -16,7 +16,9 @@ namespace VirusTotalAnalyzer;
 public sealed partial class VirusTotalClient
 {
     public Task<PagedResponse<Graph>?> ListGraphsAsync(int? limit = null, string? cursor = null, bool fetchAll = false, CancellationToken cancellationToken = default)
-        => GetPagedAsync<Graph>(async (c, token) =>
+    {
+        ThrowIfDisposed();
+        return GetPagedAsync<Graph>(async (c, token) =>
         {
             var path = new StringBuilder("graphs");
             var hasQuery = false;
@@ -34,9 +36,11 @@ public sealed partial class VirusTotalClient
             using var stream = await response.Content.ReadContentStreamAsync(token).ConfigureAwait(false);
             return await JsonSerializer.DeserializeAsync<PagedResponse<Graph>>(stream, _jsonOptions, token).ConfigureAwait(false);
         }, cursor, fetchAll, cancellationToken);
+    }
 
     public async Task<Graph?> GetGraphAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"graphs/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -46,6 +50,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Graph?> CreateGraphAsync(CreateGraphRequest request, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var response = await _httpClient.PostAsync("graphs", content, cancellationToken).ConfigureAwait(false);
@@ -56,6 +61,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Graph?> UpdateGraphAsync(string id, UpdateGraphRequest request, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
@@ -68,6 +74,7 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteGraphAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.DeleteAsync($"graphs/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -84,12 +91,15 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteGraphCommentAsync(string graphId, string commentId, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         using var response = await _httpClient.DeleteAsync($"graphs/{Uri.EscapeDataString(graphId)}/comments/{Uri.EscapeDataString(commentId)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
     public Task<PagedResponse<Collection>?> ListCollectionsAsync(int? limit = null, string? cursor = null, bool fetchAll = false, CancellationToken cancellationToken = default)
-        => GetPagedAsync<Collection>(async (c, token) =>
+    {
+        ThrowIfDisposed();
+        return GetPagedAsync<Collection>(async (c, token) =>
         {
             var path = new StringBuilder("collections");
             var hasQuery = false;
@@ -107,9 +117,11 @@ public sealed partial class VirusTotalClient
             using var stream = await response.Content.ReadContentStreamAsync(token).ConfigureAwait(false);
             return await JsonSerializer.DeserializeAsync<PagedResponse<Collection>>(stream, _jsonOptions, token).ConfigureAwait(false);
         }, cursor, fetchAll, cancellationToken);
+    }
 
     public async Task<Collection?> GetCollectionAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"collections/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -119,6 +131,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Collection?> CreateCollectionAsync(CreateCollectionRequest request, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var response = await _httpClient.PostAsync("collections", content, cancellationToken).ConfigureAwait(false);
@@ -129,6 +142,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Collection?> UpdateCollectionAsync(string id, UpdateCollectionRequest request, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
@@ -141,6 +155,7 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteCollectionAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.DeleteAsync($"collections/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -148,6 +163,7 @@ public sealed partial class VirusTotalClient
 
     public Task<PagedResponse<Relationship>?> ListCollectionItemsAsync(string id, int? limit = null, string? cursor = null, bool fetchAll = false, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         return GetPagedAsync<Relationship>(async (c, token) =>
         {
@@ -171,6 +187,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<RelationshipResponse?> AddCollectionItemsAsync(string id, AddItemsRequest request, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
@@ -182,13 +199,16 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteCollectionItemAsync(string id, string itemId, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.DeleteAsync($"collections/{Uri.EscapeDataString(id)}/items/{Uri.EscapeDataString(itemId)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
     }
 
     public Task<PagedResponse<Bundle>?> ListBundlesAsync(int? limit = null, string? cursor = null, bool fetchAll = false, CancellationToken cancellationToken = default)
-        => GetPagedAsync<Bundle>(async (c, token) =>
+    {
+        ThrowIfDisposed();
+        return GetPagedAsync<Bundle>(async (c, token) =>
         {
             var path = new StringBuilder("bundles");
             var hasQuery = false;
@@ -206,9 +226,11 @@ public sealed partial class VirusTotalClient
             using var stream = await response.Content.ReadContentStreamAsync(token).ConfigureAwait(false);
             return await JsonSerializer.DeserializeAsync<PagedResponse<Bundle>>(stream, _jsonOptions, token).ConfigureAwait(false);
         }, cursor, fetchAll, cancellationToken);
+    }
 
     public async Task<Bundle?> GetBundleAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"bundles/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -218,6 +240,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Bundle?> CreateBundleAsync(CreateBundleRequest request, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var response = await _httpClient.PostAsync("bundles", content, cancellationToken).ConfigureAwait(false);
@@ -228,6 +251,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<Bundle?> UpdateBundleAsync(string id, UpdateBundleRequest request, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
@@ -240,6 +264,7 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteBundleAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.DeleteAsync($"bundles/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
@@ -247,6 +272,7 @@ public sealed partial class VirusTotalClient
 
     public Task<PagedResponse<Relationship>?> ListBundleItemsAsync(string id, int? limit = null, string? cursor = null, bool fetchAll = false, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         return GetPagedAsync<Relationship>(async (c, token) =>
         {
@@ -270,6 +296,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<RelationshipResponse?> AddBundleItemsAsync(string id, AddItemsRequest request, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var json = JsonSerializer.Serialize(request, _jsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
@@ -281,6 +308,7 @@ public sealed partial class VirusTotalClient
 
     public async Task DeleteBundleItemAsync(string id, string itemId, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.DeleteAsync($"bundles/{Uri.EscapeDataString(id)}/items/{Uri.EscapeDataString(itemId)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);

--- a/VirusTotalAnalyzer/VirusTotalClient.SslCertificates.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.SslCertificates.cs
@@ -11,6 +11,7 @@ public sealed partial class VirusTotalClient
 {
     public async Task<SslCertificate?> GetSslCertificateAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         using var response = await _httpClient.GetAsync($"ssl_certificates/{Uri.EscapeDataString(id)}", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);

--- a/VirusTotalAnalyzer/VirusTotalClient.Submissions.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Submissions.cs
@@ -17,6 +17,7 @@ public sealed partial class VirusTotalClient
 {
     public async Task<Uri?> GetUploadUrlAsync(CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         using var response = await _httpClient.GetAsync("files/upload_url", cancellationToken).ConfigureAwait(false);
         await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
         using var stream = await response.Content.ReadContentStreamAsync(cancellationToken).ConfigureAwait(false);
@@ -39,6 +40,7 @@ public sealed partial class VirusTotalClient
     /// <returns>An <see cref="AnalysisReport"/> for the submitted file or <see langword="null"/> if the response is empty.</returns>
     public async Task<AnalysisReport?> SubmitFileAsync(Stream stream, string fileName, string? password = null, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         if (stream is null)
         {
             throw new ArgumentNullException(nameof(stream));
@@ -161,6 +163,7 @@ public sealed partial class VirusTotalClient
         string? password = null,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         if (stream is null)
         {
             throw new ArgumentNullException(nameof(stream));
@@ -193,6 +196,7 @@ public sealed partial class VirusTotalClient
 
     public async Task<AnalysisReport?> ReanalyzeHashAsync(string hash, AnalysisType analysisType = AnalysisType.File, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         if (hash is null)
         {
             throw new ArgumentNullException(nameof(hash));
@@ -270,6 +274,7 @@ public sealed partial class VirusTotalClient
         SubmitUrlOptions? options,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         if (url is null)
         {
             throw new ArgumentNullException(nameof(url));

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -32,6 +32,14 @@ public sealed partial class VirusTotalClient : IVirusTotalClient
     private readonly bool _disposeClient;
     private bool _disposed;
 
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(VirusTotalClient));
+        }
+    }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="VirusTotalClient"/> class using an existing
     /// <see cref="HttpClient"/>.
@@ -211,6 +219,7 @@ public sealed partial class VirusTotalClient : IVirusTotalClient
         bool fetchAll = false,
         CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         return GetPagedAsync<FileNameInfo>(async (c, token) =>
         {
@@ -310,6 +319,7 @@ public sealed partial class VirusTotalClient : IVirusTotalClient
 
     public async Task<Stream> DownloadLivehuntNotificationFileAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var response = await _httpClient
             .GetAsync($"intelligence/hunting_notification_files/{Uri.EscapeDataString(id)}", HttpCompletionOption.ResponseHeadersRead, cancellationToken)
@@ -321,6 +331,7 @@ public sealed partial class VirusTotalClient : IVirusTotalClient
 
     public async Task<Stream> DownloadRetrohuntNotificationFileAsync(string id, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         ValidateId(id, nameof(id));
         var response = await _httpClient
             .GetAsync($"intelligence/retrohunt_notification_files/{Uri.EscapeDataString(id)}", HttpCompletionOption.ResponseHeadersRead, cancellationToken)
@@ -332,6 +343,7 @@ public sealed partial class VirusTotalClient : IVirusTotalClient
 
     public async Task<Stream> DownloadPcapAsync(string analysisId, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         var response = await _httpClient
             .GetAsync($"analyses/{Uri.EscapeDataString(analysisId)}/pcap", HttpCompletionOption.ResponseHeadersRead, cancellationToken)
             .ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- add a ThrowIfDisposed helper and guard all HTTP-related members across the VirusTotalClient partials
- add unit tests to ensure operations throw ObjectDisposedException when the client has been disposed

## Testing
- dotnet test VirusTotalAnalyzer.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d632ec2910832e9ac71e82128632ae