### PR TITLE
Handle invalid URIs returned by VirusTotal API

### DIFF
--- a/VirusTotalAnalyzer.Examples/GetFileDownloadUrlExample.cs
+++ b/VirusTotalAnalyzer.Examples/GetFileDownloadUrlExample.cs
@@ -12,7 +12,14 @@ public static class GetFileDownloadUrlExample
         try
         {
             var url = await client.GetFileDownloadUrlAsync("44d88612fea8a8f36de82e1278abb02f");
-            Console.WriteLine(url);
+            if (url is null)
+            {
+                Console.WriteLine("Download URL was not provided or was invalid.");
+            }
+            else
+            {
+                Console.WriteLine(url);
+            }
         }
         catch (RateLimitExceededException ex)
         {

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Additional.cs
@@ -103,6 +103,27 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task GetUploadUrlAsync_ReturnsNullForInvalidUri()
+    {
+        var json = "{\"data\":\"not a uri\"}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        IVirusTotalClient client = new VirusTotalClient(httpClient);
+
+        var uri = await client.GetUploadUrlAsync();
+
+        Assert.Null(uri);
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/files/upload_url", handler.Request!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
     public async Task GetFileDownloadUrlAsync_ReturnsUri()
     {
         var json = "{\"data\":\"https://download.example/file\"}";
@@ -120,6 +141,27 @@ public partial class VirusTotalClientTests
 
         Assert.NotNull(uri);
         Assert.Equal("https://download.example/file", uri!.ToString());
+        Assert.NotNull(handler.Request);
+        Assert.Equal("/api/v3/files/abc/download_url", handler.Request!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task GetFileDownloadUrlAsync_ReturnsNullForInvalidUri()
+    {
+        var json = "{\"data\":\"not a uri\"}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        IVirusTotalClient client = new VirusTotalClient(httpClient);
+
+        var uri = await client.GetFileDownloadUrlAsync("abc");
+
+        Assert.Null(uri);
         Assert.NotNull(handler.Request);
         Assert.Equal("/api/v3/files/abc/download_url", handler.Request!.RequestUri!.AbsolutePath);
     }

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -399,7 +399,8 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
         {
             return null;
         }
-        return new Uri(result.Data);
+
+        return Uri.TryCreate(result.Data, UriKind.Absolute, out var uri) ? uri : null;
     }
 
     public async Task<Stream> DownloadFileAsync(string id, CancellationToken cancellationToken = default)

--- a/VirusTotalAnalyzer/VirusTotalClient.Submissions.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Submissions.cs
@@ -26,7 +26,8 @@ public sealed partial class VirusTotalClient
         {
             return null;
         }
-        return new Uri(result.Data);
+
+        return Uri.TryCreate(result.Data, UriKind.Absolute, out var uri) ? uri : null;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- ensure upload and download URL helpers only return successfully parsed URIs
- cover malformed URI payloads in unit tests and expect null results
- update the file download example to reflect the nullable return behavior

## Testing
- dotnet test *(fails: `dotnet` command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c114570c832e84e693230661db70