### PR TITLE
Reject null or whitespace IDs in multi-id operations

### DIFF
--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.MultipleIds.Validation.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.MultipleIds.Validation.cs
@@ -27,6 +27,31 @@ public partial class VirusTotalClientTests
         yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.GetAnalysesAsync(ids)) };
     }
 
+    public static IEnumerable<object[]> InvalidIdsOperations()
+    {
+        var idsWithNull = new[] { "valid", null };
+        var idsWithEmpty = new[] { "valid", string.Empty };
+        var idsWithWhitespace = new[] { "valid", "   " };
+
+        yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.GetFileReportsAsync(idsWithNull)) };
+        yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.GetUrlReportsAsync(idsWithNull)) };
+        yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.GetIpAddressReportsAsync(idsWithNull)) };
+        yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.GetDomainReportsAsync(idsWithNull)) };
+        yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.GetAnalysesAsync(idsWithNull)) };
+
+        yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.GetFileReportsAsync(idsWithEmpty)) };
+        yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.GetUrlReportsAsync(idsWithEmpty)) };
+        yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.GetIpAddressReportsAsync(idsWithEmpty)) };
+        yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.GetDomainReportsAsync(idsWithEmpty)) };
+        yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.GetAnalysesAsync(idsWithEmpty)) };
+
+        yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.GetFileReportsAsync(idsWithWhitespace)) };
+        yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.GetUrlReportsAsync(idsWithWhitespace)) };
+        yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.GetIpAddressReportsAsync(idsWithWhitespace)) };
+        yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.GetDomainReportsAsync(idsWithWhitespace)) };
+        yield return new object[] { new Func<IVirusTotalClient, Task>(c => c.GetAnalysesAsync(idsWithWhitespace)) };
+    }
+
     [Theory]
     [MemberData(nameof(EmptyIdsOperations))]
     public async Task IdsParameter_Empty_Throws(Func<IVirusTotalClient, Task> operation)
@@ -41,5 +66,14 @@ public partial class VirusTotalClientTests
     {
         var client = CreateClient();
         await Assert.ThrowsAsync<ArgumentException>(async () => await operation(client));
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidIdsOperations))]
+    public async Task IdsParameter_InvalidEntries_Throws(Func<IVirusTotalClient, Task> operation)
+    {
+        var client = CreateClient();
+        var exception = await Assert.ThrowsAsync<ArgumentException>(async () => await operation(client));
+        Assert.StartsWith("The collection cannot contain null, empty, or whitespace ids.", exception.Message);
     }
 }

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -934,6 +934,14 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
             throw new ArgumentException("A maximum of 4 ids is allowed.", paramName);
         }
 
+        for (var i = 0; i < array.Length; i++)
+        {
+            if (string.IsNullOrWhiteSpace(array[i]))
+            {
+                throw new ArgumentException("The collection cannot contain null, empty, or whitespace ids.", paramName);
+            }
+        }
+
         return array;
     }
 }


### PR DESCRIPTION
## Summary
- ensure multiple-id operations reject null, empty, or whitespace identifiers with a clear error
- extend validation tests to cover invalid identifier scenarios for each API surface

## Testing
- dotnet test VirusTotalAnalyzer.Tests/VirusTotalAnalyzer.Tests.csproj *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c11b5490832e819096badbb58e8b