### PR TITLE
Ensure download responses are disposed on failure

### DIFF
--- a/VirusTotalAnalyzer.Tests/TrackingResponseHandler.cs
+++ b/VirusTotalAnalyzer.Tests/TrackingResponseHandler.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VirusTotalAnalyzer.Tests;
+
+internal sealed class TrackingResponseHandler : HttpMessageHandler
+{
+    private readonly HttpStatusCode _statusCode;
+    private readonly Func<HttpContent> _contentFactory;
+
+    public TrackingHttpResponseMessage? LastResponse { get; private set; }
+
+    public TrackingResponseHandler(HttpStatusCode statusCode, Func<HttpContent>? contentFactory = null)
+    {
+        _statusCode = statusCode;
+        _contentFactory = contentFactory ?? (() => new ByteArrayContent(Array.Empty<byte>()));
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var response = new TrackingHttpResponseMessage(_statusCode)
+        {
+            Content = _contentFactory()
+        };
+        LastResponse = response;
+        return Task.FromResult<HttpResponseMessage>(response);
+    }
+}
+
+internal sealed class TrackingHttpResponseMessage : HttpResponseMessage
+{
+    public TrackingHttpResponseMessage(HttpStatusCode statusCode)
+        : base(statusCode)
+    {
+    }
+
+    public bool Disposed { get; private set; }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            Disposed = true;
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientDisposeTests.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientDisposeTests.cs
@@ -1,5 +1,9 @@
+using System;
+using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Xunit;
+using VirusTotalAnalyzer.Models;
 
 namespace VirusTotalAnalyzer.Tests;
 
@@ -29,4 +33,32 @@ public class VirusTotalClientDisposeTests
         Assert.False(handler.Disposed);
         httpClient.Dispose();
     }
+
+    [Theory]
+    [MemberData(nameof(DownloadFailureScenarios))]
+    public async Task DownloadMethods_DisposeResponseOnFailure(Func<VirusTotalClient, Task> action)
+    {
+        var handler = new TrackingResponseHandler(HttpStatusCode.InternalServerError);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        using var client = new VirusTotalClient(httpClient);
+
+        await Assert.ThrowsAsync<ApiException>(() => action(client));
+
+        Assert.NotNull(handler.LastResponse);
+        Assert.True(handler.LastResponse!.Disposed);
+        httpClient.Dispose();
+    }
+
+    public static TheoryData<Func<VirusTotalClient, Task>> DownloadFailureScenarios()
+        => new()
+        {
+            { client => client.DownloadFileAsync("id") },
+            { client => client.DownloadYaraRulesetAsync("id") },
+            { client => client.DownloadLivehuntNotificationFileAsync("id") },
+            { client => client.DownloadRetrohuntNotificationFileAsync("id") },
+            { client => client.DownloadPcapAsync("id") }
+        };
 }

--- a/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Analysis.cs
@@ -408,9 +408,21 @@ using var stream = await response.Content.ReadContentStreamAsync(cancellationTok
         var response = await _httpClient
             .GetAsync($"files/{Uri.EscapeDataString(id)}/download", HttpCompletionOption.ResponseHeadersRead, cancellationToken)
             .ConfigureAwait(false);
-        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
-var stream = await response.Content.ReadContentStreamAsync(cancellationToken).ConfigureAwait(false);
-        return new StreamWithResponse(response, stream);
+        var disposeResponse = true;
+        try
+        {
+            await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+            var stream = await response.Content.ReadContentStreamAsync(cancellationToken).ConfigureAwait(false);
+            disposeResponse = false;
+            return new StreamWithResponse(response, stream);
+        }
+        finally
+        {
+            if (disposeResponse)
+            {
+                response.Dispose();
+            }
+        }
     }
 
     /// <summary>

--- a/VirusTotalAnalyzer/VirusTotalClient.Intelligence.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Intelligence.cs
@@ -316,9 +316,21 @@ public sealed partial class VirusTotalClient
         var response = await _httpClient
             .GetAsync($"intelligence/hunting_rulesets/{Uri.EscapeDataString(id)}/download", HttpCompletionOption.ResponseHeadersRead, ct)
             .ConfigureAwait(false);
-        await EnsureSuccessAsync(response, ct).ConfigureAwait(false);
-        var stream = await response.Content.ReadContentStreamAsync(ct).ConfigureAwait(false);
-        return new StreamWithResponse(response, stream);
+        var disposeResponse = true;
+        try
+        {
+            await EnsureSuccessAsync(response, ct).ConfigureAwait(false);
+            var stream = await response.Content.ReadContentStreamAsync(ct).ConfigureAwait(false);
+            disposeResponse = false;
+            return new StreamWithResponse(response, stream);
+        }
+        finally
+        {
+            if (disposeResponse)
+            {
+                response.Dispose();
+            }
+        }
     }
 
     public async Task<Relationship?> GetYaraRulesetOwnerAsync(string id, CancellationToken cancellationToken = default)

--- a/VirusTotalAnalyzer/VirusTotalClient.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.cs
@@ -314,9 +314,21 @@ public sealed partial class VirusTotalClient : IVirusTotalClient
         var response = await _httpClient
             .GetAsync($"intelligence/hunting_notification_files/{Uri.EscapeDataString(id)}", HttpCompletionOption.ResponseHeadersRead, cancellationToken)
             .ConfigureAwait(false);
-        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
-        var stream = await response.Content.ReadContentStreamAsync(cancellationToken).ConfigureAwait(false);
-        return new StreamWithResponse(response, stream);
+        var disposeResponse = true;
+        try
+        {
+            await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+            var stream = await response.Content.ReadContentStreamAsync(cancellationToken).ConfigureAwait(false);
+            disposeResponse = false;
+            return new StreamWithResponse(response, stream);
+        }
+        finally
+        {
+            if (disposeResponse)
+            {
+                response.Dispose();
+            }
+        }
     }
 
     public async Task<Stream> DownloadRetrohuntNotificationFileAsync(string id, CancellationToken cancellationToken = default)
@@ -325,9 +337,21 @@ public sealed partial class VirusTotalClient : IVirusTotalClient
         var response = await _httpClient
             .GetAsync($"intelligence/retrohunt_notification_files/{Uri.EscapeDataString(id)}", HttpCompletionOption.ResponseHeadersRead, cancellationToken)
             .ConfigureAwait(false);
-        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
-        var stream = await response.Content.ReadContentStreamAsync(cancellationToken).ConfigureAwait(false);
-        return new StreamWithResponse(response, stream);
+        var disposeResponse = true;
+        try
+        {
+            await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+            var stream = await response.Content.ReadContentStreamAsync(cancellationToken).ConfigureAwait(false);
+            disposeResponse = false;
+            return new StreamWithResponse(response, stream);
+        }
+        finally
+        {
+            if (disposeResponse)
+            {
+                response.Dispose();
+            }
+        }
     }
 
     public async Task<Stream> DownloadPcapAsync(string analysisId, CancellationToken cancellationToken = default)
@@ -336,9 +360,21 @@ public sealed partial class VirusTotalClient : IVirusTotalClient
         var response = await _httpClient
             .GetAsync($"analyses/{Uri.EscapeDataString(analysisId)}/pcap", HttpCompletionOption.ResponseHeadersRead, cancellationToken)
             .ConfigureAwait(false);
-        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
-        var stream = await response.Content.ReadContentStreamAsync(cancellationToken).ConfigureAwait(false);
-        return new StreamWithResponse(response, stream);
+        var disposeResponse = true;
+        try
+        {
+            await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+            var stream = await response.Content.ReadContentStreamAsync(cancellationToken).ConfigureAwait(false);
+            disposeResponse = false;
+            return new StreamWithResponse(response, stream);
+        }
+        finally
+        {
+            if (disposeResponse)
+            {
+                response.Dispose();
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- wrap download response handling in try/finally blocks to dispose unsuccessful responses safely
- add a tracking response handler and unit tests ensuring failed downloads dispose their responses

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c11f9c38832e920a0436345d3c46