### PR TITLE
Add cancellable overload for URL reanalysis

### DIFF
--- a/VirusTotalAnalyzer.Examples/ReanalyzeUrlExample.cs
+++ b/VirusTotalAnalyzer.Examples/ReanalyzeUrlExample.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using VirusTotalAnalyzer.Models;
 
@@ -11,7 +12,8 @@ public static class ReanalyzeUrlExample
         IVirusTotalClient client = VirusTotalClient.Create("YOUR_API_KEY");
         try
         {
-            var report = await client.ReanalyzeUrlAsync("https://www.example.com");
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var report = await client.ReanalyzeUrlAsync("https://www.example.com", cts.Token);
             Console.WriteLine(report?.Id);
         }
         catch (RateLimitExceededException ex)

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientTests.Submissions.Additional.cs
@@ -528,6 +528,29 @@ public partial class VirusTotalClientTests
     }
 
     [Fact]
+    public async Task ReanalyzeUrlAsync_WithCancellationToken_UsesUrlPath()
+    {
+        var json = "{\"id\":\"an\",\"type\":\"analysis\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}";
+        var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://www.virustotal.com/api/v3/")
+        };
+        IVirusTotalClient client = new VirusTotalClient(httpClient);
+
+        const string url = "https://example.com";
+        var id = VirusTotalClientExtensions.GetUrlId(url);
+        var report = await client.ReanalyzeUrlAsync(url, CancellationToken.None);
+
+        Assert.NotNull(report);
+        Assert.NotNull(handler.Request);
+        Assert.Equal($"/api/v3/urls/{id}/analyse", handler.Request!.RequestUri!.AbsolutePath);
+    }
+
+    [Fact]
     public async Task ListRetrohuntJobsAsync_PagesThroughResults()
     {
         var first = "{\"data\":[{\"id\":\"j1\",\"type\":\"retrohunt_job\",\"data\":{\"attributes\":{\"status\":\"queued\"}}}],\"meta\":{\"cursor\":\"abc\"}}";

--- a/VirusTotalAnalyzer/IVirusTotalClient.cs
+++ b/VirusTotalAnalyzer/IVirusTotalClient.cs
@@ -41,6 +41,7 @@ public partial interface IVirusTotalClient : IDisposable
     Task<AnalysisReport?> ReanalyzeFileAsync(string hash, CancellationToken cancellationToken = default);
     Task<AnalysisReport?> ReanalyzeHashAsync(string hash, AnalysisType analysisType = AnalysisType.File, CancellationToken cancellationToken = default);
     Task<AnalysisReport?> ReanalyzeUrlAsync(string id, CancellationToken cancellationToken = default);
+    Task<AnalysisReport?> ReanalyzeUrlAsync(string url, CancellationToken cancellationToken);
     Task<AnalysisReport?> ReanalyzeUrlAsync(string url);
     Task<AnalysisReport?> SubmitFileAsync(Stream stream, string fileName, CancellationToken cancellationToken);
     Task<AnalysisReport?> SubmitFileAsync(Stream stream, string fileName, string? password = null, CancellationToken cancellationToken = default);

--- a/VirusTotalAnalyzer/VirusTotalClient.Submissions.cs
+++ b/VirusTotalAnalyzer/VirusTotalClient.Submissions.cs
@@ -235,7 +235,7 @@ public sealed partial class VirusTotalClient
         return ReanalyzeHashAsync(id, AnalysisType.Url, cancellationToken);
     }
 
-    public Task<AnalysisReport?> ReanalyzeUrlAsync(string url)
+    public Task<AnalysisReport?> ReanalyzeUrlAsync(string url, CancellationToken cancellationToken)
     {
         if (url is null)
         {
@@ -245,8 +245,11 @@ public sealed partial class VirusTotalClient
         {
             throw new ArgumentException("Url must not be empty.", nameof(url));
         }
-        return ReanalyzeUrlAsync(VirusTotalClientExtensions.GetUrlId(url), cancellationToken: default);
+        return ReanalyzeUrlAsync(VirusTotalClientExtensions.GetUrlId(url), cancellationToken);
     }
+
+    public Task<AnalysisReport?> ReanalyzeUrlAsync(string url)
+        => ReanalyzeUrlAsync(url, CancellationToken.None);
 
     public Task<AnalysisReport?> SubmitUrlAsync(string url, CancellationToken cancellationToken = default)
         => SubmitUrlAsync(url, options: null, cancellationToken);


### PR DESCRIPTION
## Summary
- add a CancellationToken-aware ReanalyzeUrlAsync overload and forward the parameterless method to it
- exercise the new overload in unit tests and keep coverage of the existing overload
- refresh the reanalyze URL example to demonstrate cancellation support

## Testing
- `dotnet test VirusTotalAnalyzer.sln` *(fails: dotnet CLI not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c122bb14832eae03d57f185487ef