### PR TITLE
Add validation for ScanFileAsync file paths

### DIFF
--- a/VirusTotalAnalyzer.Examples/ScanFileExample.cs
+++ b/VirusTotalAnalyzer.Examples/ScanFileExample.cs
@@ -10,6 +10,11 @@ public static class ScanFileExample
     public static async Task RunAsync()
     {
         var path = "sample.txt";
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            Console.WriteLine("Please provide a valid file path.");
+            return;
+        }
         if (!File.Exists(path))
         {
             Console.WriteLine($"File not found: {path}");

--- a/VirusTotalAnalyzer.Tests/VirusTotalClientExtensionsTests.cs
+++ b/VirusTotalAnalyzer.Tests/VirusTotalClientExtensionsTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using VirusTotalAnalyzer;
+using Xunit;
+
+namespace VirusTotalAnalyzer.Tests;
+
+public class VirusTotalClientExtensionsTests
+{
+    [Fact]
+    public async Task ScanFileAsync_Throws_WhenFilePathNull()
+    {
+        using var client = CreateClient();
+        await Assert.ThrowsAsync<ArgumentNullException>(() => client.ScanFileAsync(null!));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ScanFileAsync_Throws_WhenFilePathWhitespace(string filePath)
+    {
+        using var client = CreateClient();
+        await Assert.ThrowsAsync<ArgumentException>(() => client.ScanFileAsync(filePath));
+    }
+
+    [Fact]
+    public async Task ScanFileAsync_Throws_WhenFileDoesNotExist()
+    {
+        using var client = CreateClient();
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var exception = await Assert.ThrowsAsync<FileNotFoundException>(() => client.ScanFileAsync(path));
+        Assert.Equal(path, exception.FileName);
+    }
+
+    private static IVirusTotalClient CreateClient()
+        => new VirusTotalClient(new HttpClient(new StubHandler("{}")));
+}

--- a/VirusTotalAnalyzer/VirusTotalClientExtensions.cs
+++ b/VirusTotalAnalyzer/VirusTotalClientExtensions.cs
@@ -55,6 +55,9 @@ public static class VirusTotalClientExtensions
     public static Task<AnalysisReport?> ScanFileAsync(this IVirusTotalClient client, string filePath, string? password = null, CancellationToken cancellationToken = default)
     {
         if (client == null) throw new ArgumentNullException(nameof(client));
+        if (filePath == null) throw new ArgumentNullException(nameof(filePath));
+        if (string.IsNullOrWhiteSpace(filePath)) throw new ArgumentException("File path must not be empty.", nameof(filePath));
+        if (!File.Exists(filePath)) throw new FileNotFoundException("File not found.", filePath);
         return ScanFileInternalAsync(client, filePath, password, cancellationToken);
     }
 


### PR DESCRIPTION
## Summary
- validate file paths in ScanFileAsync before submitting files to VirusTotal
- add unit tests covering null, whitespace, and missing file path scenarios
- update the ScanFile example to include a simple file path sanity check

## Testing
- `dotnet test` *(fails: dotnet CLI is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c12c9bf8832e9552e98dab35048f