### PR TITLE
Use the latest PSPublishModule in builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install PSPublishModule
         shell: pwsh
         run: |
-          Install-Module PSPublishModule -MinimumVersion 3.0.106 -Force -Scope CurrentUser -AllowClobber
+          Install-Module PSPublishModule -Force -Scope CurrentUser -AllowClobber
           Install-Module PSSharedGoods -MinimumVersion 0.0.312 -Force -Scope CurrentUser -AllowClobber
 
       - name: Verify generated module help
@@ -52,7 +52,7 @@ jobs:
           RefreshPSD1Only: 'false'
           POWERFORGE_FULL_MODULE_BUILD: '1'
         run: |
-          Import-Module PSPublishModule -MinimumVersion 3.0.106 -Force -ErrorAction Stop
+          Import-Module PSPublishModule -Force -ErrorAction Stop
           ./Build/Build-Module.ps1 -ConfigurationGateMode Documentation -SignModule:$false
 
           git diff --ignore-space-at-eol --exit-code -- Module/Docs Module/en-US

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -11,7 +11,7 @@ param(
     [string] $GitHubApiKeyPath = 'C:\Support\Important\GitHubAPI.txt'
 )
 
-Import-Module PSPublishModule -MinimumVersion 3.0.106 -Force -ErrorAction Stop
+Import-Module PSPublishModule -Force -ErrorAction Stop
 
 Build-Module -ModuleName 'VirusTotalAnalyzer' {
     $Manifest = @{


### PR DESCRIPTION
The build workflow and module wrapper now use the newest available PSPublishModule release instead of carrying a minimum-version constraint.

- CI installs PSPublishModule without a version selector.
- CI and the module build wrapper import the newest installed version.
- The existing coordinated module/NuGet release configuration remains unchanged.

PowerShell 5.1 and PowerShell 7 both resolve the current installed release successfully.